### PR TITLE
Fix dlq{} block parser inside MQ consumer{}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.3] - 2026-05-13
+
+### Fixed
+- **`dlq {}` block inside `consumer {}` was rejected by the parser**, even though the connector schema declares it, `docs/guides/error-handling.md` documents it, and the MQ factory reads it. Operators copying the documented snippet hit `connector parse error: consumer block error: block content error: ...: Unexpected "dlq" block; Blocks are not allowed here.` and either fell back to the `retry_count = N` shorthand (no control over `exchange` / `queue` / `routing_key` / `retry_delay`) or shipped without DLQ. Bug present since v1.18.0 (when `pkg/schema` made `dlq` a child block of `consumer`).
+
+  Two layered causes:
+
+  1. `internal/parser/connector.go` routed `consumer {}` through `parseGenericBlock`, which calls `body.JustAttributes()`. That HCL method rejects every nested block by design — so the schema said "dlq is a child block", the factory expected `consumer["dlq"]` as a map, but the parser refused to even produce that map.
+
+  2. The obvious workaround — `PartialContent({Blocks: [{Type: "dlq"}]})` + `remain.JustAttributes()` — looks correct but **also fails** on hclsyntax v2.24.0. `JustAttributes()` inspects the body's `Blocks` slice directly and does not consult `hiddenBlocks`, so even after `PartialContent` marks `dlq` as extracted, `remain.JustAttributes()` still sees it in the underlying slice and emits the same diagnostic. This is documented in `hclsyntax/structure.go:248-263` ("we will continue processing anyway, and return the attributes we are able to find") — `JustAttributes` continues, but `HasErrors()` is true, so any caller that checks diags bails out.
+
+  Fix: new `parseConsumerBlock` casts the body to `*hclsyntax.Body` (same pattern already used by `extractDynamicAttrs` in `internal/parser/flow.go:1487`) and iterates `Attributes` and `Blocks` directly, routing the `dlq` child to `parseGenericBlock`. Bypasses both `JustAttributes` paths entirely. The factory layer (`internal/connector/mq/factory.go::buildRabbitMQConfig`, extracted from `createRabbitMQ` to make it testable) already handled the map — it was just never reached.
+
+  Workaround for users stuck on v1.21.2 or earlier without redeploying: `consumer { retry_count = N }` still creates `DLQConfig{Enabled: true, MaxRetries: N}` with default `Exchange` / `Queue` / `RoutingKey` / `RetryHeader = "x-retry-count"`. Anything beyond `MaxRetries` requires this fix.
+
+### Tests
+- `internal/parser/parser_test.go::TestParseConnectorRabbitMQConsumerDLQ` — the exact documented snippet (`consumer { ... dlq { enabled, max_retries, retry_delay } }`) now parses and produces `consumer["dlq"]` as `map[string]interface{}` with `enabled=true`, `max_retries=3`, `retry_delay="5s"`. Locks the parser contract.
+- `internal/connector/mq/factory_test.go::TestRabbitMQConsumerDLQEndToEnd` — end-to-end: HCL → parser → `buildRabbitMQConfig` → `rabbitmq.Config.Consumer.DLQ`. Asserts the full struct (`Enabled`, `MaxRetries`, `RetryDelay` as `5*time.Second`, `Exchange`, `Queue`, `RoutingKey`, `RetryHeader`). Guards against silent regressions where the parser would accept the block but the factory would drop it on the way to the broker.
+- `internal/connector/mq/factory_test.go::TestRabbitMQConsumerRetryCountShorthand` — `retry_count = 7` shorthand still creates `DLQConfig{Enabled: true, MaxRetries: 7}`. Pre-fix workaround stays valid.
+
+### Refactor
+- `internal/connector/mq/factory.go`: `createRabbitMQ` split into `createRabbitMQ` (returns `*rabbitmq.Connector`) and `buildRabbitMQConfig` (returns `*rabbitmq.Config`). No semantic change — the only reason to split was to let the factory test inspect the materialized config without an AMQP connection.
+
 ## [1.21.2] - 2026-04-30
 
 ### Fixed

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "1.21.2"
+	version = "1.21.3"
 	commit  = "dev"
 )
 

--- a/internal/connector/mq/factory.go
+++ b/internal/connector/mq/factory.go
@@ -64,6 +64,14 @@ func (f *Factory) Create(ctx context.Context, cfg *connector.Config) (connector.
 
 // createRabbitMQ creates a RabbitMQ connector from configuration.
 func (f *Factory) createRabbitMQ(cfg *connector.Config) (*rabbitmq.Connector, error) {
+	config := buildRabbitMQConfig(cfg)
+	return rabbitmq.NewConnector(cfg.Name, config, f.logger)
+}
+
+// buildRabbitMQConfig translates a parsed connector.Config into a rabbitmq.Config.
+// Extracted from createRabbitMQ so the mapping (including consumer.dlq) is testable
+// without requiring an AMQP connection.
+func buildRabbitMQConfig(cfg *connector.Config) *rabbitmq.Config {
 	config := rabbitmq.DefaultConfig()
 
 	// Connection settings — url overrides host/port/username/password/vhost
@@ -182,7 +190,7 @@ func (f *Factory) createRabbitMQ(cfg *connector.Config) (*rabbitmq.Connector, er
 		}
 	}
 
-	return rabbitmq.NewConnector(cfg.Name, config, f.logger)
+	return config
 }
 
 // Helper functions for extracting configuration values

--- a/internal/connector/mq/factory_test.go
+++ b/internal/connector/mq/factory_test.go
@@ -1,0 +1,132 @@
+package mq
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/matutetandil/mycel/internal/parser"
+)
+
+// TestRabbitMQConsumerDLQEndToEnd verifies the full pipeline: HCL parser →
+// connector.Config → buildRabbitMQConfig → rabbitmq.Config.Consumer.DLQ.
+// Guards against silent regressions where the parser accepts dlq{} but the
+// factory drops it before the connector ever sees it.
+func TestRabbitMQConsumerDLQEndToEnd(t *testing.T) {
+	hcl := `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+  url    = "amqp://guest:guest@localhost:5672/"
+
+  consumer {
+    queue    = "orders"
+    prefetch = 10
+    auto_ack = false
+    workers  = 5
+
+    dlq {
+      enabled      = true
+      max_retries  = 3
+      retry_delay  = "5s"
+      exchange     = "orders.dlx"
+      queue        = "orders.dlq"
+      routing_key  = "orders"
+      retry_header = "x-retry-count"
+    }
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "rabbit.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	p := parser.NewHCLParser()
+	cfg, err := p.ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(cfg.Connectors) != 1 {
+		t.Fatalf("expected 1 connector, got %d", len(cfg.Connectors))
+	}
+
+	rmqCfg := buildRabbitMQConfig(cfg.Connectors[0])
+
+	if rmqCfg.Consumer == nil {
+		t.Fatalf("Consumer config not built")
+	}
+	if rmqCfg.Consumer.Prefetch != 10 {
+		t.Errorf("Consumer.Prefetch=%d, want 10", rmqCfg.Consumer.Prefetch)
+	}
+	if rmqCfg.Consumer.Concurrency != 5 {
+		t.Errorf("Consumer.Concurrency=%d, want 5 (from workers alias)", rmqCfg.Consumer.Concurrency)
+	}
+
+	if rmqCfg.Consumer.DLQ == nil {
+		t.Fatalf("Consumer.DLQ not built — parser may have accepted dlq{} but factory silently dropped it")
+	}
+	dlq := rmqCfg.Consumer.DLQ
+	if !dlq.Enabled {
+		t.Errorf("DLQ.Enabled=false, want true")
+	}
+	if dlq.MaxRetries != 3 {
+		t.Errorf("DLQ.MaxRetries=%d, want 3", dlq.MaxRetries)
+	}
+	if dlq.RetryDelay != 5*time.Second {
+		t.Errorf("DLQ.RetryDelay=%s, want 5s", dlq.RetryDelay)
+	}
+	if dlq.Exchange != "orders.dlx" {
+		t.Errorf("DLQ.Exchange=%q, want %q", dlq.Exchange, "orders.dlx")
+	}
+	if dlq.Queue != "orders.dlq" {
+		t.Errorf("DLQ.Queue=%q, want %q", dlq.Queue, "orders.dlq")
+	}
+	if dlq.RoutingKey != "orders" {
+		t.Errorf("DLQ.RoutingKey=%q, want %q", dlq.RoutingKey, "orders")
+	}
+	if dlq.RetryHeader != "x-retry-count" {
+		t.Errorf("DLQ.RetryHeader=%q, want %q", dlq.RetryHeader, "x-retry-count")
+	}
+}
+
+// TestRabbitMQConsumerRetryCountShorthand verifies the existing retry_count
+// shorthand still works (workaround pre-fix and equivalent post-fix).
+func TestRabbitMQConsumerRetryCountShorthand(t *testing.T) {
+	hcl := `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+
+  consumer {
+    queue       = "orders"
+    retry_count = 7
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "rabbit.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	p := parser.NewHCLParser()
+	cfg, err := p.ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	rmqCfg := buildRabbitMQConfig(cfg.Connectors[0])
+	if rmqCfg.Consumer == nil || rmqCfg.Consumer.DLQ == nil {
+		t.Fatalf("retry_count shorthand did not create DLQ config")
+	}
+	if !rmqCfg.Consumer.DLQ.Enabled {
+		t.Errorf("DLQ.Enabled=false, want true")
+	}
+	if rmqCfg.Consumer.DLQ.MaxRetries != 7 {
+		t.Errorf("DLQ.MaxRetries=%d, want 7", rmqCfg.Consumer.DLQ.MaxRetries)
+	}
+}

--- a/internal/parser/connector.go
+++ b/internal/parser/connector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/matutetandil/mycel/internal/connector"
@@ -349,7 +350,7 @@ func parseConnectorBlock(block *hcl.Block, ctx *hcl.EvalContext) (*connector.Con
 			config.Properties["publisher"] = pub
 
 		case "consumer":
-			consumer, err := parseGenericBlock(nestedBlock, ctx)
+			consumer, err := parseConsumerBlock(nestedBlock, ctx)
 			if err != nil {
 				return nil, fmt.Errorf("consumer block error: %w", err)
 			}
@@ -720,6 +721,40 @@ func parseSubscriptionsBlock(block *hcl.Block, ctx *hcl.EvalContext) (map[string
 	}
 
 	return subscriptions, nil
+}
+
+// parseConsumerBlock parses a consumer block, accepting an optional nested
+// dlq block alongside arbitrary attributes. The MQ connector schema declares
+// dlq as a child of consumer, so plain attribute parsing rejects it.
+func parseConsumerBlock(block *hcl.Block, ctx *hcl.EvalContext) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+
+	syntaxBody, ok := block.Body.(*hclsyntax.Body)
+	if !ok {
+		// Fallback: no nested blocks possible, parse as attribute-only block.
+		return parseGenericBlock(block, ctx)
+	}
+
+	for name, attr := range syntaxBody.Attributes {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("attribute %s error: %s", name, diags.Error())
+		}
+		result[name] = ctyValueToGo(val)
+	}
+
+	for _, nested := range syntaxBody.Blocks {
+		if nested.Type == "dlq" {
+			dlqBlock := nested.AsHCLBlock()
+			dlq, err := parseGenericBlock(dlqBlock, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("dlq block error: %w", err)
+			}
+			result["dlq"] = dlq
+		}
+	}
+
+	return result, nil
 }
 
 // parseGenericBlock parses a block with arbitrary attributes.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2000,3 +2000,66 @@ flow "with_step" {
 		t.Errorf("expected step.Envelope='productData', got %q", got)
 	}
 }
+
+func TestParseConnectorRabbitMQConsumerDLQ(t *testing.T) {
+	hcl := `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+  url    = "amqp://guest:guest@localhost:5672/"
+
+  consumer {
+    queue    = "orders"
+    prefetch = 10
+    auto_ack = false
+    workers  = 5
+
+    dlq {
+      enabled     = true
+      max_retries = 3
+      retry_delay = "5s"
+    }
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "rabbit.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	parser := NewHCLParser()
+	cfg, err := parser.ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if len(cfg.Connectors) != 1 {
+		t.Fatalf("expected 1 connector, got %d", len(cfg.Connectors))
+	}
+
+	consumer, ok := cfg.Connectors[0].Properties["consumer"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("consumer block not parsed as map; got %T", cfg.Connectors[0].Properties["consumer"])
+	}
+	if got := consumer["queue"]; got != "orders" {
+		t.Errorf("expected consumer.queue='orders', got %v", got)
+	}
+	if got := consumer["workers"]; got != 5 {
+		t.Errorf("expected consumer.workers=5, got %v", got)
+	}
+
+	dlq, ok := consumer["dlq"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("dlq nested block not parsed as map; got %T", consumer["dlq"])
+	}
+	if got := dlq["enabled"]; got != true {
+		t.Errorf("expected dlq.enabled=true, got %v", got)
+	}
+	if got := dlq["max_retries"]; got != 3 {
+		t.Errorf("expected dlq.max_retries=3, got %v", got)
+	}
+	if got := dlq["retry_delay"]; got != "5s" {
+		t.Errorf("expected dlq.retry_delay='5s', got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Parser rejected the documented `dlq {}` block inside `consumer {}` since v1.18.0, despite the schema declaring it and the factory expecting the map. Operators hit `Unexpected "dlq" block; Blocks are not allowed here.` and fell back to the `retry_count = N` shorthand (or no DLQ).
- Two layered HCL2 quirks: `parseGenericBlock` calls `JustAttributes()` which rejects nested blocks by design; the obvious `PartialContent` + `remain.JustAttributes()` workaround **also** fails because `JustAttributes` ignores `hiddenBlocks` (verified in `hclsyntax/structure.go:248-263`).
- Fix: new `parseConsumerBlock` casts body to `*hclsyntax.Body` and walks attrs/blocks manually (same pattern as `extractDynamicAttrs` in `flow.go:1487`), routing the `dlq` child through `parseGenericBlock`.
- Refactor: `createRabbitMQ` split into `createRabbitMQ` + `buildRabbitMQConfig` so the parser-to-`rabbitmq.Config` mapping is testable without an AMQP connection.
- Version bump 1.21.2 → 1.21.3, CHANGELOG entry with full narrative.

## Test plan

- [x] `go test ./internal/parser/...` — `TestParseConnectorRabbitMQConsumerDLQ` locks the parser contract for the exact documented snippet
- [x] `go test ./internal/connector/mq/...` — `TestRabbitMQConsumerDLQEndToEnd` asserts the full HCL → parser → `rabbitmq.Config.Consumer.DLQ` pipeline (all 7 fields including `RetryDelay` as `time.Duration`)
- [x] `TestRabbitMQConsumerRetryCountShorthand` — legacy `retry_count = N` shorthand still works (no regression of the pre-fix workaround)
- [x] `go test ./...` — full suite, 70 packages, 0 regressions
- [x] `go build ./...` clean

## Workaround for users stuck on <=v1.21.2

`consumer { retry_count = N }` still creates `DLQConfig{Enabled: true, MaxRetries: N}` with default exchange/queue/routing_key/retry_header. Anything beyond `MaxRetries` requires this fix.