### PR TITLE
BREAKING: RabbitMQ stops auto-creating missing queues and exchanges (v2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-05-18
+
+### ⚠️ BREAKING CHANGE
+- **RabbitMQ connector no longer auto-creates queues or exchanges that do not exist on the broker.** Previously, when a `queue {}` block (or `consumer.queue` shorthand) referenced a queue that did not exist, Mycel silently issued `QueueDeclare` to create it. Same for `exchange {}`. That behaviour made typos invisible — a misspelled `queue = "magento.system.itesm.in.q"` would create a brand new empty queue and the consumer would happily sit on it forever while the real queue's messages went to whoever owned the correct name. It also meant Mycel imposed its idea of topology onto shared brokers where ops or another service genuinely owns the lifecycle.
+
+  From v2.0.0 the default is **fail-fast**: when `QueueDeclarePassive` / `ExchangeDeclarePassive` returns `NotFound`, Mycel returns a clear actionable error at startup instead of declaring. To opt back to the previous behaviour, add `create_if_missing = true` to the relevant block.
+
+  This is the conservative completion of the passive-first refactor shipped in v1.21.4 (which already preserved existing topologies when queues did exist). v1.21.4 closed the "shared queue with different args" failure mode; v2.0.0 closes the "queue does not exist" silent-creation footgun.
+
+  **Migration:**
+  - **Production with externally-managed queues (Terraform, rabbitmqctl, etc.):** no action — this is the new safe default. Queues already exist; passive declare succeeds.
+  - **Dev/local/demo environments where Mycel should create the queue:** add `create_if_missing = true`:
+    ```hcl
+    consumer {
+      queue             = "test-queue"
+      create_if_missing = true
+    }
+    # or in the full block form:
+    queue {
+      name              = "test-queue"
+      durable           = true
+      create_if_missing = true
+    }
+    # same flag on exchange{}:
+    exchange {
+      name              = "events"
+      type              = "topic"
+      create_if_missing = true
+    }
+    ```
+  - **Error message** when missing: `queue "X" does not exist on broker HOST (vhost "Y"). Declare it externally (Terraform, rabbitmqctl, RabbitMQ Management UI) or, for ephemeral environments, set create_if_missing = true on the consumer or queue block`.
+
+### Added
+- `create_if_missing` attribute on the `consumer {}`, `queue {}`, and `exchange {}` blocks of the RabbitMQ connector. Defaults to `false`. On the `consumer {}` block it applies to the shorthand-created queue (so users using `consumer { queue = "x" }` don't have to switch to a full `queue {}` block just to opt in). On `queue {}` and `exchange {}` blocks it applies to that declaration. Wired through `internal/connector/mq/schema.go`, `factory.go`, and `rabbitmq/config.go` (`QueueConfig.CreateIfMissing`, `ExchangeConfig.CreateIfMissing`).
+- New helper `Connector.declareExchange` mirrors `declareConsumerQueue`'s passive-first pattern for exchanges, with the same channel-reopen-after-NotFound dance (passive declare on a missing entity closes the channel server-side).
+
+### Changed
+- `setupTopology` now routes the exchange declare through `declareExchange` (passive-first) instead of unconditional `ExchangeDeclare`.
+
+### Updated config fixtures
+- `tests/integration/config/connectors/mq.mycel`: `create_if_missing = true` added to `test_queue` and `fanout_queue` so the docker-compose integration suite continues to declare them.
+- `examples/mq/service.mycel`, `examples/graphql-federation/connectors.mycel`: pedagogical examples now show `create_if_missing = true` with a comment explaining when to use it.
+
+### Tests
+- `internal/connector/mq/factory_test.go::TestRabbitMQQueueCreateIfMissing` — table-driven coverage of all four entry points: consumer-shorthand default (false), consumer-shorthand explicit (true), `queue {}` block (true), `exchange {}` block (true). Locks the breaking-change default and the opt-in plumbing.
+
 ## [1.22.0] - 2026-05-14
 
 ### Added

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "1.22.0"
+	version = "2.0.0"
 	commit  = "dev"
 )
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -437,6 +437,8 @@ connector "rabbit" {
 3. If retries < max_retries, the message is republished to the same queue with the updated retry header, and the original is acked
 4. If retries >= max_retries, the message is rejected with `Reject(false)` — RabbitMQ then either routes it to the DLX (if the queue carries `x-dead-letter-exchange`) or discards it
 
+**Strict-by-default queue declaration (since v2.0.0):** when the queue named in `consumer.queue` does **not** exist on the broker, Mycel fails at startup with a clear error instead of silently auto-creating an empty queue. To opt back to auto-create (useful for dev/demo environments where Mycel owns the topology), set `create_if_missing = true` on the `consumer {}` or `queue {}` block. The same flag exists on `exchange {}`. See the v2.0.0 entry in the CHANGELOG for migration details.
+
 **Shared queue compatibility (passive-first declare):** When the queue named in `consumer.queue` already exists, Mycel preserves its topology and does not redeclare it. The retry counting in step 3 works unchanged, but step 4 will only route to a DLQ if the queue's `x-dead-letter-exchange` arg was set externally (e.g. via a RabbitMQ `set_policy`). If `dlq.enabled = true` and the queue pre-existed without DLX args, Mycel emits a WARN at startup explaining that retries still work but final rejection discards instead of routing.
 
 When the queue does not exist yet, Mycel declares it with `x-dead-letter-exchange` (and creates the DLX exchange + DLQ queue automatically) — full DLQ-for-inspection behavior is preserved for greenfield deployments.

--- a/examples/graphql-federation/connectors.mycel
+++ b/examples/graphql-federation/connectors.mycel
@@ -49,15 +49,17 @@ connector "events" {
   vhost    = "/"
 
   queue {
-    name    = "product_events"
-    durable = true
+    name              = "product_events"
+    durable           = true
+    create_if_missing = true
   }
 
   exchange {
-    name        = "product_exchange"
-    type        = "topic"
-    durable     = true
-    routing_key = "product.*"
+    name              = "product_exchange"
+    type              = "topic"
+    durable           = true
+    routing_key       = "product.*"
+    create_if_missing = true
   }
 
   consumer {

--- a/examples/mq/service.mycel
+++ b/examples/mq/service.mycel
@@ -29,19 +29,25 @@ connector "order_events" {
   password = env("RABBITMQ_PASS", "guest")
   vhost    = "/"
 
-  // Queue configuration (for consuming)
+  // Queue configuration (for consuming).
+  // create_if_missing = true lets Mycel declare the queue on first run.
+  // Default since v2.0.0 is false: a missing queue fails at startup so
+  // typos and missing infra are caught at deploy time. Set to true for
+  // greenfield/demo environments where Mycel owns the topology.
   queue {
-    name        = "orders"
-    durable     = true
-    auto_delete = false
+    name              = "orders"
+    durable           = true
+    auto_delete       = false
+    create_if_missing = true
   }
 
   // Exchange binding (optional - for topic routing)
   exchange {
-    name        = "orders_exchange"
-    type        = "topic"
-    durable     = true
-    routing_key = "order.*"
+    name              = "orders_exchange"
+    type              = "topic"
+    durable           = true
+    routing_key       = "order.*"
+    create_if_missing = true
   }
 
   // Consumer settings

--- a/internal/connector/mq/factory.go
+++ b/internal/connector/mq/factory.go
@@ -104,12 +104,13 @@ func buildRabbitMQConfig(cfg *connector.Config) *rabbitmq.Config {
 	// Queue configuration
 	if queueCfg := getMap(cfg.Properties, "queue"); queueCfg != nil {
 		config.Queue = &rabbitmq.QueueConfig{
-			Name:       getString(queueCfg, "name", ""),
-			Durable:    getBool(queueCfg, "durable", true),
-			AutoDelete: getBool(queueCfg, "auto_delete", false),
-			Exclusive:  getBool(queueCfg, "exclusive", false),
-			NoWait:     getBool(queueCfg, "no_wait", false),
-			Args:       getMap(queueCfg, "args"),
+			Name:            getString(queueCfg, "name", ""),
+			Durable:         getBool(queueCfg, "durable", true),
+			AutoDelete:      getBool(queueCfg, "auto_delete", false),
+			Exclusive:       getBool(queueCfg, "exclusive", false),
+			NoWait:          getBool(queueCfg, "no_wait", false),
+			Args:            getMap(queueCfg, "args"),
+			CreateIfMissing: getBool(queueCfg, "create_if_missing", false),
 		}
 	}
 
@@ -117,15 +118,16 @@ func buildRabbitMQConfig(cfg *connector.Config) *rabbitmq.Config {
 	if exchangeCfg := getMap(cfg.Properties, "exchange"); exchangeCfg != nil {
 		exchangeType := getString(exchangeCfg, "type", "direct")
 		config.Exchange = &rabbitmq.ExchangeConfig{
-			Name:       getString(exchangeCfg, "name", ""),
-			Type:       rabbitmq.ExchangeType(exchangeType),
-			Durable:    getBool(exchangeCfg, "durable", true),
-			AutoDelete: getBool(exchangeCfg, "auto_delete", false),
-			Internal:   getBool(exchangeCfg, "internal", false),
-			NoWait:     getBool(exchangeCfg, "no_wait", false),
-			RoutingKey: getString(exchangeCfg, "routing_key", ""),
-			Args:       getMap(exchangeCfg, "args"),
-			BindArgs:   getMap(exchangeCfg, "bind_args"),
+			Name:            getString(exchangeCfg, "name", ""),
+			Type:            rabbitmq.ExchangeType(exchangeType),
+			Durable:         getBool(exchangeCfg, "durable", true),
+			AutoDelete:      getBool(exchangeCfg, "auto_delete", false),
+			Internal:        getBool(exchangeCfg, "internal", false),
+			NoWait:          getBool(exchangeCfg, "no_wait", false),
+			RoutingKey:      getString(exchangeCfg, "routing_key", ""),
+			Args:            getMap(exchangeCfg, "args"),
+			BindArgs:        getMap(exchangeCfg, "bind_args"),
+			CreateIfMissing: getBool(exchangeCfg, "create_if_missing", false),
 		}
 	}
 
@@ -147,11 +149,15 @@ func buildRabbitMQConfig(cfg *connector.Config) *rabbitmq.Config {
 			Args:        getMap(consumerCfg, "args"),
 		}
 
-		// Allow queue name as shorthand inside consumer block
+		// Allow queue name as shorthand inside consumer block. The
+		// create_if_missing flag on the consumer block applies to the
+		// shorthand-created queue so users do not have to switch to a full
+		// queue{} block just to opt into auto-creation.
 		if queueName := getString(consumerCfg, "queue", ""); queueName != "" && config.Queue == nil {
 			config.Queue = &rabbitmq.QueueConfig{
-				Name:    queueName,
-				Durable: true,
+				Name:            queueName,
+				Durable:         true,
+				CreateIfMissing: getBool(consumerCfg, "create_if_missing", false),
 			}
 		}
 

--- a/internal/connector/mq/factory_test.go
+++ b/internal/connector/mq/factory_test.go
@@ -130,3 +130,109 @@ connector "rabbit" {
 		t.Errorf("DLQ.MaxRetries=%d, want 7", rmqCfg.Consumer.DLQ.MaxRetries)
 	}
 }
+
+// TestRabbitMQQueueCreateIfMissing covers all four ways to set the
+// create_if_missing flag introduced in v2.0.0, plus the default-false case
+// that is the breaking change.
+func TestRabbitMQQueueCreateIfMissing(t *testing.T) {
+	cases := []struct {
+		name             string
+		hcl              string
+		wantQueueFlag    bool
+		wantExchangeFlag bool
+		hasExchange      bool
+	}{
+		{
+			name: "consumer shorthand defaults to false (v2.0.0 strict default)",
+			hcl: `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+  consumer { queue = "orders" }
+}`,
+			wantQueueFlag: false,
+		},
+		{
+			name: "consumer shorthand with explicit create_if_missing = true",
+			hcl: `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+  consumer {
+    queue             = "orders"
+    create_if_missing = true
+  }
+}`,
+			wantQueueFlag: true,
+		},
+		{
+			name: "queue block with create_if_missing = true",
+			hcl: `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+  queue {
+    name              = "orders"
+    durable           = true
+    create_if_missing = true
+  }
+  consumer { auto_ack = false }
+}`,
+			wantQueueFlag: true,
+		},
+		{
+			name: "exchange block with create_if_missing = true",
+			hcl: `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+  exchange {
+    name              = "events"
+    type              = "topic"
+    create_if_missing = true
+  }
+  queue {
+    name              = "orders"
+    create_if_missing = true
+  }
+  consumer { auto_ack = false }
+}`,
+			wantQueueFlag:    true,
+			wantExchangeFlag: true,
+			hasExchange:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "rabbit.mycel")
+			if err := os.WriteFile(tmpFile, []byte(tc.hcl), 0644); err != nil {
+				t.Fatalf("write temp file: %v", err)
+			}
+
+			cfg, err := parser.NewHCLParser().ParseFile(context.Background(), tmpFile)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+
+			rmqCfg := buildRabbitMQConfig(cfg.Connectors[0])
+
+			if rmqCfg.Queue == nil {
+				t.Fatalf("Queue config not built")
+			}
+			if got := rmqCfg.Queue.CreateIfMissing; got != tc.wantQueueFlag {
+				t.Errorf("Queue.CreateIfMissing=%v, want %v", got, tc.wantQueueFlag)
+			}
+
+			if tc.hasExchange {
+				if rmqCfg.Exchange == nil {
+					t.Fatalf("Exchange config not built")
+				}
+				if got := rmqCfg.Exchange.CreateIfMissing; got != tc.wantExchangeFlag {
+					t.Errorf("Exchange.CreateIfMissing=%v, want %v", got, tc.wantExchangeFlag)
+				}
+			}
+		})
+	}
+}

--- a/internal/connector/mq/rabbitmq/config.go
+++ b/internal/connector/mq/rabbitmq/config.go
@@ -65,6 +65,13 @@ type QueueConfig struct {
 	Exclusive  bool
 	NoWait     bool
 	Args       map[string]interface{}
+
+	// CreateIfMissing controls what happens when the queue does not exist
+	// on the broker. When false (default since v2.0.0), the connector fails
+	// at startup with a clear error so typos and missing infra are caught at
+	// deploy time. When true, the connector falls back to an active declare
+	// and creates the queue with the configured args.
+	CreateIfMissing bool
 }
 
 // ExchangeConfig holds exchange declaration and binding options.
@@ -80,6 +87,12 @@ type ExchangeConfig struct {
 	// Binding configuration
 	RoutingKey string
 	BindArgs   map[string]interface{}
+
+	// CreateIfMissing controls what happens when the exchange does not exist
+	// on the broker. When false (default since v2.0.0), the connector fails
+	// at startup. When true, the connector declares the exchange with the
+	// configured type and args.
+	CreateIfMissing bool
 }
 
 // ConsumerConfig holds consumer options.

--- a/internal/connector/mq/rabbitmq/connector.go
+++ b/internal/connector/mq/rabbitmq/connector.go
@@ -444,33 +444,25 @@ func (c *Connector) handleReconnect() {
 
 // setupTopology declares exchanges and queues.
 //
-// The consumer queue is declared with a passive-first strategy so that shared,
-// pre-existing queues (typically created by another publisher or a historic
-// consumer) do not cause AMQP 406 PRECONDITION_FAILED when this consumer
-// enables dlq{} — which would otherwise add x-dead-letter-exchange args that
-// the existing queue does not carry. When the queue already exists, its
-// topology is preserved as-is; the retry-N-then-drop behaviour still works
-// via the republish path in handleRetry, and Reject(false) at the final
-// attempt discards the message instead of routing to a DLQ.
+// Both exchange and queue use a passive-first strategy so that shared,
+// pre-existing infrastructure (typically owned by ops or another service)
+// is preserved untouched. When the resource does not exist:
+//   - create_if_missing=true → declare it actively
+//   - create_if_missing=false (default since v2.0.0) → fail at startup with
+//     a clear error, so typos and missing infra surface at deploy time
+//     instead of leaving a consumer hanging silently on an empty auto-created
+//     queue
+//
+// When the consumer queue exists, the retry-N-then-drop path still works via
+// republish in handleRetry; Reject(false) at the final attempt discards the
+// message instead of routing to a DLQ unless the queue's existing topology
+// carries x-dead-letter-exchange.
 func (c *Connector) setupTopology() error {
 	// Declare exchange if configured
 	if c.config.Exchange != nil && c.config.Exchange.Name != "" {
-		err := c.channel.ExchangeDeclare(
-			c.config.Exchange.Name,
-			string(c.config.Exchange.Type),
-			c.config.Exchange.Durable,
-			c.config.Exchange.AutoDelete,
-			c.config.Exchange.Internal,
-			c.config.Exchange.NoWait,
-			c.config.Exchange.Args,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to declare exchange: %w", err)
+		if err := c.declareExchange(); err != nil {
+			return err
 		}
-		c.logger.Debug("declared exchange",
-			"name", c.config.Exchange.Name,
-			"type", c.config.Exchange.Type,
-		)
 	}
 
 	dlqConfig := c.getDLQConfig()
@@ -528,8 +520,10 @@ func (c *Connector) setupTopology() error {
 //     args mismatch (e.g. dlq{} adds x-dead-letter-exchange while the existing
 //     queue has none) cannot produce 406 PRECONDITION_FAILED.
 //   - QueueDeclarePassive fails with NotFound (404) → queue does not exist;
-//     RabbitMQ has closed the channel server-side, so we reopen it and run
-//     the active declare with full args (including DLX when dlq is enabled).
+//     RabbitMQ has closed the channel server-side. If CreateIfMissing is true
+//     we reopen the channel and active-declare with full args; if false (the
+//     v2.0.0 default) we return a clear actionable error so the typo or
+//     missing infra surfaces at deploy time.
 //   - Any other passive error is treated as fatal and bubbled up.
 func (c *Connector) declareConsumerQueue(dlqConfig *DLQConfig) (bool, error) {
 	queueCfg := c.config.Queue
@@ -562,6 +556,15 @@ func (c *Connector) declareConsumerQueue(dlqConfig *DLQConfig) (bool, error) {
 	// Distinguish "queue not found" (expected) from real errors.
 	if amqpErr, ok := passiveErr.(*amqp.Error); ok && amqpErr.Code != amqp.NotFound {
 		return false, fmt.Errorf("failed to inspect queue: %w", passiveErr)
+	}
+
+	if !queueCfg.CreateIfMissing {
+		return false, fmt.Errorf(
+			"queue %q does not exist on broker %s (vhost %q). "+
+				"Declare it externally (Terraform, rabbitmqctl, RabbitMQ Management UI) or, "+
+				"for ephemeral environments, set create_if_missing = true on the consumer or queue block",
+			queueCfg.Name, c.config.Host, c.config.Vhost,
+		)
 	}
 
 	// Passive declare on a missing queue closes the channel server-side; reopen.
@@ -600,6 +603,70 @@ func (c *Connector) declareConsumerQueue(dlqConfig *DLQConfig) (bool, error) {
 
 	c.logger.Debug("declared queue", "name", queueCfg.Name)
 	return false, nil
+}
+
+// declareExchange declares the configured exchange using the same
+// passive-first strategy as declareConsumerQueue: respect existing topology
+// when the exchange exists; fail at startup when it does not unless
+// create_if_missing is set.
+func (c *Connector) declareExchange() error {
+	exCfg := c.config.Exchange
+
+	passiveErr := c.channel.ExchangeDeclarePassive(
+		exCfg.Name,
+		string(exCfg.Type),
+		exCfg.Durable,
+		exCfg.AutoDelete,
+		exCfg.Internal,
+		exCfg.NoWait,
+		nil,
+	)
+	if passiveErr == nil {
+		c.logger.Info("exchange exists; preserving existing topology",
+			"name", exCfg.Name,
+			"type", exCfg.Type,
+		)
+		return nil
+	}
+
+	if amqpErr, ok := passiveErr.(*amqp.Error); ok && amqpErr.Code != amqp.NotFound {
+		return fmt.Errorf("failed to inspect exchange: %w", passiveErr)
+	}
+
+	if !exCfg.CreateIfMissing {
+		return fmt.Errorf(
+			"exchange %q does not exist on broker %s (vhost %q). "+
+				"Declare it externally or, for ephemeral environments, set create_if_missing = true on the exchange block",
+			exCfg.Name, c.config.Host, c.config.Vhost,
+		)
+	}
+
+	// Passive declare on a missing exchange closes the channel server-side; reopen.
+	if c.conn == nil || c.conn.IsClosed() {
+		return fmt.Errorf("connection closed during topology setup: %w", passiveErr)
+	}
+	newChannel, chErr := c.conn.Channel()
+	if chErr != nil {
+		return fmt.Errorf("failed to reopen channel after passive declare: %w", chErr)
+	}
+	c.channel = newChannel
+
+	if err := c.channel.ExchangeDeclare(
+		exCfg.Name,
+		string(exCfg.Type),
+		exCfg.Durable,
+		exCfg.AutoDelete,
+		exCfg.Internal,
+		exCfg.NoWait,
+		exCfg.Args,
+	); err != nil {
+		return fmt.Errorf("failed to declare exchange: %w", err)
+	}
+	c.logger.Debug("declared exchange",
+		"name", exCfg.Name,
+		"type", exCfg.Type,
+	)
+	return nil
 }
 
 // getDLQConfig returns the DLQ configuration if available.

--- a/internal/connector/mq/rabbitmq/strict_declare_integration_test.go
+++ b/internal/connector/mq/rabbitmq/strict_declare_integration_test.go
@@ -1,0 +1,231 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// rabbitMQTestURL returns the AMQP URL for integration tests, or "" if no
+// broker is reachable within 2 seconds. Reading the URL from the environment
+// lets the integration suite point this at the docker-compose broker without
+// having to use a build tag.
+func rabbitMQTestURL(t *testing.T) string {
+	t.Helper()
+	target := os.Getenv("MYCEL_TEST_RABBITMQ_URL")
+	if target == "" {
+		target = "amqp://guest:guest@localhost:5672/"
+	}
+
+	u, err := url.Parse(target)
+	if err != nil {
+		t.Skipf("invalid MYCEL_TEST_RABBITMQ_URL %q: %v", target, err)
+	}
+	host := u.Host
+	if host == "" || !strings.Contains(host, ":") {
+		host = host + ":5672"
+	}
+	conn, err := net.DialTimeout("tcp", host, 2*time.Second)
+	if err != nil {
+		t.Skipf("no RabbitMQ broker reachable at %s (set MYCEL_TEST_RABBITMQ_URL to enable): %v", host, err)
+	}
+	_ = conn.Close()
+	return target
+}
+
+// newTestConnector builds a Connector wired to the test broker and connected.
+// The caller is responsible for c.Close() when done.
+func newTestConnector(t *testing.T, target string, queueCfg *QueueConfig, exCfg *ExchangeConfig) *Connector {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.URL = target
+	cfg.Queue = queueCfg
+	cfg.Exchange = exCfg
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	c, err := NewConnector(t.Name(), cfg, logger)
+	if err != nil {
+		t.Fatalf("NewConnector: %v", err)
+	}
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	return c
+}
+
+// uniqueName returns a queue/exchange name unique to the test invocation so
+// parallel and repeat runs do not collide.
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}
+
+// purgeOrDelete removes a queue best-effort. Used as a deferred cleanup so a
+// failing test does not leave broker state behind.
+func purgeOrDelete(target, name string) {
+	conn, err := amqp.Dial(target)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	ch, err := conn.Channel()
+	if err != nil {
+		return
+	}
+	defer ch.Close()
+	_, _ = ch.QueueDelete(name, false, false, true)
+}
+
+// deleteExchange removes an exchange best-effort.
+func deleteExchange(target, name string) {
+	conn, err := amqp.Dial(target)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	ch, err := conn.Channel()
+	if err != nil {
+		return
+	}
+	defer ch.Close()
+	_ = ch.ExchangeDelete(name, false, true)
+}
+
+// TestSetupTopologyStrictDeclare_Integration is the v2.0.0 contract test: it
+// covers the three scenarios that motivated the breaking change.
+//
+// Requires a reachable RabbitMQ broker. Skips fast (~2s connect timeout) when
+// no broker is available so that running the unit-test suite (`go test ./...`)
+// on a developer machine without docker stays cheap.
+//
+// The integration suite sets MYCEL_TEST_RABBITMQ_URL to point this at the
+// docker-compose broker.
+func TestSetupTopologyStrictDeclare_Integration(t *testing.T) {
+	target := rabbitMQTestURL(t)
+
+	t.Run("missing queue with default create_if_missing=false fails fast", func(t *testing.T) {
+		name := uniqueName("strict_missing_default")
+		defer purgeOrDelete(target, name)
+
+		c := newTestConnector(t, target, &QueueConfig{
+			Name:    name,
+			Durable: true,
+			// CreateIfMissing intentionally left false: this is the new default
+		}, nil)
+		defer c.Close(context.Background())
+
+		err := c.setupTopology()
+		if err == nil {
+			t.Fatalf("expected setupTopology to fail for missing queue with create_if_missing=false; got nil")
+		}
+		if !strings.Contains(err.Error(), "does not exist on broker") {
+			t.Errorf("error message should reference broker; got %v", err)
+		}
+		if !strings.Contains(err.Error(), "create_if_missing") {
+			t.Errorf("error message should point operators at the opt-in flag; got %v", err)
+		}
+
+		// And confirm Mycel did NOT silently create the queue.
+		probeConn, err := amqp.Dial(target)
+		if err != nil {
+			t.Fatalf("probe dial: %v", err)
+		}
+		defer probeConn.Close()
+		probeCh, err := probeConn.Channel()
+		if err != nil {
+			t.Fatalf("probe channel: %v", err)
+		}
+		defer probeCh.Close()
+		if _, err := probeCh.QueueDeclarePassive(name, true, false, false, false, nil); err == nil {
+			t.Errorf("queue %q was created despite create_if_missing=false; v2.0.0 contract broken", name)
+		}
+	})
+
+	t.Run("missing queue with create_if_missing=true is declared", func(t *testing.T) {
+		name := uniqueName("strict_missing_optin")
+		defer purgeOrDelete(target, name)
+
+		c := newTestConnector(t, target, &QueueConfig{
+			Name:            name,
+			Durable:         true,
+			CreateIfMissing: true,
+		}, nil)
+		defer c.Close(context.Background())
+
+		if err := c.setupTopology(); err != nil {
+			t.Fatalf("setupTopology with create_if_missing=true: %v", err)
+		}
+
+		// Confirm the queue was actually declared on the broker.
+		probeConn, _ := amqp.Dial(target)
+		defer probeConn.Close()
+		probeCh, _ := probeConn.Channel()
+		defer probeCh.Close()
+		if _, err := probeCh.QueueDeclarePassive(name, true, false, false, false, nil); err != nil {
+			t.Errorf("queue %q was not created despite create_if_missing=true: %v", name, err)
+		}
+	})
+
+	t.Run("existing queue with default create_if_missing=false boots cleanly", func(t *testing.T) {
+		name := uniqueName("strict_existing")
+		defer purgeOrDelete(target, name)
+
+		// Pre-create the queue out-of-band, simulating Terraform/ops-managed infra.
+		setupConn, err := amqp.Dial(target)
+		if err != nil {
+			t.Fatalf("setup dial: %v", err)
+		}
+		setupCh, err := setupConn.Channel()
+		if err != nil {
+			setupConn.Close()
+			t.Fatalf("setup channel: %v", err)
+		}
+		if _, err := setupCh.QueueDeclare(name, true, false, false, false, nil); err != nil {
+			setupCh.Close()
+			setupConn.Close()
+			t.Fatalf("pre-create queue: %v", err)
+		}
+		setupCh.Close()
+		setupConn.Close()
+
+		c := newTestConnector(t, target, &QueueConfig{
+			Name:    name,
+			Durable: true,
+			// CreateIfMissing left false: we want to verify the strict-default
+			// path STILL works when the queue already exists.
+		}, nil)
+		defer c.Close(context.Background())
+
+		if err := c.setupTopology(); err != nil {
+			t.Fatalf("setupTopology against existing queue with create_if_missing=false: %v", err)
+		}
+	})
+
+	t.Run("missing exchange with default create_if_missing=false fails fast", func(t *testing.T) {
+		exName := uniqueName("strict_ex_missing")
+		defer deleteExchange(target, exName)
+
+		c := newTestConnector(t, target, nil, &ExchangeConfig{
+			Name:    exName,
+			Type:    ExchangeTopic,
+			Durable: true,
+			// CreateIfMissing intentionally left false
+		})
+		defer c.Close(context.Background())
+
+		err := c.setupTopology()
+		if err == nil {
+			t.Fatalf("expected setupTopology to fail for missing exchange with create_if_missing=false")
+		}
+		if !strings.Contains(err.Error(), "exchange") || !strings.Contains(err.Error(), "does not exist") {
+			t.Errorf("error message should be exchange-specific; got %v", err)
+		}
+	})
+}

--- a/internal/connector/mq/schema.go
+++ b/internal/connector/mq/schema.go
@@ -41,6 +41,7 @@ func (RabbitMQSchema) ConnectorSchema() schema.Block {
 				{Name: "auto_delete", Doc: "Delete when last consumer disconnects", Type: schema.TypeBool},
 				{Name: "exclusive", Doc: "Only this connection can access", Type: schema.TypeBool},
 				{Name: "no_wait", Doc: "Do not wait for server confirmation", Type: schema.TypeBool},
+				{Name: "create_if_missing", Doc: "Declare the queue when it does not exist on the broker. Default false since v2.0.0: a missing queue fails at startup so typos and missing infra are caught at deploy time", Type: schema.TypeBool},
 			}},
 			{Type: "exchange", Doc: "Exchange declaration", Attrs: []schema.Attr{
 				{Name: "name", Doc: "Exchange name", Type: schema.TypeString},
@@ -48,6 +49,7 @@ func (RabbitMQSchema) ConnectorSchema() schema.Block {
 				{Name: "durable", Doc: "Survives broker restart", Type: schema.TypeBool},
 				{Name: "auto_delete", Doc: "Delete when no queues bound", Type: schema.TypeBool},
 				{Name: "routing_key", Doc: "Routing key for bindings", Type: schema.TypeString},
+				{Name: "create_if_missing", Doc: "Declare the exchange when it does not exist on the broker. Default false since v2.0.0", Type: schema.TypeBool},
 			}},
 			{Type: "consumer", Doc: "Consumer settings", Attrs: []schema.Attr{
 				{Name: "queue", Doc: "Queue name (shorthand)", Type: schema.TypeString},
@@ -59,6 +61,7 @@ func (RabbitMQSchema) ConnectorSchema() schema.Block {
 				{Name: "concurrency", Doc: "Number of concurrent consumers", Type: schema.TypeNumber},
 				{Name: "workers", Doc: "Alias for concurrency", Type: schema.TypeNumber},
 				{Name: "prefetch", Doc: "Prefetch count", Type: schema.TypeNumber},
+				{Name: "create_if_missing", Doc: "When using the queue shorthand, declare the queue if missing. Default false since v2.0.0", Type: schema.TypeBool},
 			}, Children: []schema.Block{
 				{Type: "dlq", Doc: "Dead letter queue", Attrs: []schema.Attr{
 					{Name: "enabled", Doc: "Enable DLQ processing", Type: schema.TypeBool},

--- a/tests/integration/config/connectors/mq.mycel
+++ b/tests/integration/config/connectors/mq.mycel
@@ -29,9 +29,10 @@ connector "rabbit_sub" {
   vhost    = "/"
 
   queue {
-    name        = "test_queue"
-    durable     = true
-    auto_delete = false
+    name              = "test_queue"
+    durable           = true
+    auto_delete       = false
+    create_if_missing = true
   }
 
   consumer {
@@ -72,9 +73,10 @@ connector "rabbit_fanout_sub" {
   vhost    = "/"
 
   queue {
-    name        = "fanout_queue"
-    durable     = true
-    auto_delete = false
+    name              = "fanout_queue"
+    durable           = true
+    auto_delete       = false
+    create_if_missing = true
   }
 
   consumer {

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -154,6 +154,10 @@ services:
   # ==========================================================================
   rabbitmq:
     image: rabbitmq:3-management-alpine
+    ports:
+      # Exposed so the strict-declare integration test (go test against a
+      # real broker) can reach the broker from the host.
+      - "${PORT_RABBIT:-5672}:5672"
     environment:
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -75,6 +75,7 @@ PORT_DEFS=(
   PORT_ADMIN:9090
   PORT_COSMO:5000
   PORT_MOCK:8888
+  PORT_RABBIT:5672
 )
 
 echo "Checking ports..."
@@ -129,6 +130,7 @@ else
     scripts/test-soap.sh
     scripts/test-cache.sh
     scripts/test-rabbitmq.sh
+    scripts/test-rabbitmq-strict-declare.sh
     scripts/test-kafka.sh
     scripts/test-elasticsearch.sh
     scripts/test-s3.sh

--- a/tests/integration/scripts/test-rabbitmq-strict-declare.sh
+++ b/tests/integration/scripts/test-rabbitmq-strict-declare.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Test: RabbitMQ strict declare (v2.0.0 contract)
+# Drives `go test` against the docker-compose RabbitMQ broker to validate
+# that setupTopology fails fast on a missing queue/exchange when
+# create_if_missing is false (the new v2.0.0 default), and succeeds when
+# the resource exists or when create_if_missing is true.
+source "$(dirname "$0")/lib.sh"
+
+echo "=== RabbitMQ Strict Declare (v2.0.0) ==="
+
+# Require Go on the host — the test runs against the broker via TCP from
+# outside the docker network.
+if ! command -v go >/dev/null 2>&1; then
+  echo "  ✗ Go toolchain not found on PATH; cannot run strict-declare integration tests"
+  FAIL=$((FAIL + 1))
+  report
+  return $FAIL 2>/dev/null || exit $FAIL
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+RABBIT_URL="amqp://guest:guest@localhost:${PORT_RABBIT:-5672}/"
+
+output=$(cd "$REPO_ROOT" && \
+  MYCEL_TEST_RABBITMQ_URL="$RABBIT_URL" \
+  go test -count=1 -v \
+    -run '^TestSetupTopologyStrictDeclare_Integration$' \
+    ./internal/connector/mq/rabbitmq/... 2>&1)
+exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+  # Confirm the test actually ran — not just skipped because the broker
+  # wasn't reachable. A skipped run still exits 0.
+  if echo "$output" | grep -q "^--- SKIP:"; then
+    echo "  ✗ Test was SKIPPED (broker unreachable at $RABBIT_URL)"
+    echo "$output" | grep -A1 "^=== RUN" | head -6
+    FAIL=$((FAIL + 1))
+  else
+    # Count sub-tests that passed.
+    passed=$(echo "$output" | grep -c "^    --- PASS:")
+    if [[ $passed -ge 4 ]]; then
+      echo "  ✓ Missing queue with default fails fast"
+      echo "  ✓ Missing queue with create_if_missing=true is declared"
+      echo "  ✓ Existing queue with default boots cleanly"
+      echo "  ✓ Missing exchange with default fails fast"
+      PASS=$((PASS + 4))
+    else
+      echo "  ✗ Only $passed of 4 sub-tests passed"
+      echo "$output" | tail -30
+      FAIL=$((FAIL + 1))
+    fi
+  fi
+else
+  echo "  ✗ go test exited with code $exit_code"
+  echo "$output" | tail -40
+  FAIL=$((FAIL + 1))
+fi
+
+report


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE — major version bump to v2.0.0

`setupTopology` no longer silently auto-creates a RabbitMQ queue or exchange when it does not exist on the broker. Surfaced by a user-reported bug: a typo in `consumer.queue` produced a brand new empty queue, the consumer happily sat on it, and the real queue's messages went somewhere else — invisible failure that wastes hours to diagnose.

The default is now **fail-fast**: passive declare first; on `NotFound`, return a clear actionable error at startup. To opt back to auto-create (greenfield, dev, demo), set `create_if_missing = true`.

This is the inverse of the v1.21.4 fix: that one preserved existing topologies when queues *did* exist (closing the 406 PRECONDITION_FAILED footgun on shared brokers); this one closes the *silent creation* footgun when queues *don't* exist.

## Behavior

| Scenario | Before (v1.x) | After (v2.0.0, default) | After (with `create_if_missing = true`) |
|---|---|---|---|
| Queue exists | Active redeclare (or 406 pre v1.21.4) | Passive succeeds, topology preserved | Same (passive succeeds) |
| Queue does not exist | Silently creates empty queue | **Startup error** | Reopens channel, active-declare with full args |
| Exchange exists | Idempotent redeclare | Passive succeeds | Same |
| Exchange does not exist | Silently creates | **Startup error** | Active declare |

Error message when missing:
```
queue "magento.system.items.in.q" does not exist on broker HOST (vhost "Y").
Declare it externally (Terraform, rabbitmqctl, RabbitMQ Management UI) or,
for ephemeral environments, set create_if_missing = true on the consumer or queue block
```

## Migration

- **Production with externally-managed queues:** no action — this is the new safe default.
- **Dev/local/demo where Mycel should create:** add `create_if_missing = true`:
  ```hcl
  consumer {
    queue             = "test-queue"
    create_if_missing = true   # opt back to v1.x behaviour
  }
  ```

The flag lives on `consumer {}` (covers the shorthand path), `queue {}`, and `exchange {}` blocks.

## Implementation

- `internal/connector/mq/rabbitmq/config.go`: `QueueConfig.CreateIfMissing` + `ExchangeConfig.CreateIfMissing`
- `internal/connector/mq/rabbitmq/connector.go`: new `declareExchange` helper symmetric to `declareConsumerQueue`; both gate on `CreateIfMissing` before falling back from passive → active. `setupTopology` simplified to route through both helpers.
- `internal/connector/mq/schema.go` + `factory.go`: HCL → config wiring on all three blocks.
- Fixtures updated: `tests/integration/config/connectors/mq.mycel`, `examples/mq/service.mycel`, `examples/graphql-federation/connectors.mycel`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — 70 packages, 0 regressions
- [x] `TestRabbitMQQueueCreateIfMissing` — table-driven: consumer-shorthand default false, consumer-shorthand explicit true, queue-block true, exchange-block true
- [x] Existing `TestRabbitMQConsumerDLQEndToEnd` still passes (locks the DLQ wiring across the refactor)
- [ ] Integration: run `tests/integration/run.sh` to validate against real RabbitMQ in docker-compose
- [ ] Mercury smoke: after deploy, confirm the 4 consumers boot against the existing queues (passive succeeds) and a typo'd `consumer.queue = "wrong-name"` fails loud at startup