### PR TITLE
Content-based biphasic dedupe primitive

### DIFF
--- a/examples/dedupe/README.md
+++ b/examples/dedupe/README.md
@@ -1,0 +1,153 @@
+# Dedupe Example
+
+Content-based, biphasic message deduplication. Drops no-op messages
+**before** forwarding to a slow downstream, in milliseconds.
+
+## The problem
+
+An upstream publisher re-sends update messages periodically — sometimes
+because of replay-on-error semantics, sometimes because the upstream
+"emits on touch" rather than "emits on change." Many of those messages
+contain identical content. Each one takes seconds to process downstream
+(Magento, an enterprise ERP, a slow REST API, ...). The consumer wastes
+hours on duplicated work, and the queue accumulates.
+
+A naive solution — "track which message IDs we've seen and skip
+duplicates" — does not help, because each re-send has a new ID.
+
+This example uses the `dedupe {}` block to compare the **content** of
+the message against the last successfully processed content for the same
+resource. If they are byte-equal, the downstream call is skipped.
+
+## How it works
+
+```
+from(rabbit) → ... → transform → dedupe → to(magento)
+                                  ↓
+                          ┌───────┴────────┐
+                          │ Phase A        │
+                          │  GET stored fp │
+                          │  compare bytes │
+                          │  match? → DROP │
+                          └────────────────┘
+                                  ↓ no match
+                              to(magento)
+                                  ↓ success
+                          ┌───────────────────┐
+                          │ Phase B           │
+                          │  SET new fp       │
+                          │  (best effort)    │
+                          └───────────────────┘
+```
+
+Phase B runs **only on `to` success**, so a failed-then-retried message
+will not self-discard. The primitive self-locks per-key for the duration
+of (Phase A + `to` + Phase B), so two workers cannot both pass Phase A
+with identical fingerprints and double-call the downstream.
+
+## The fingerprint
+
+The fingerprint is a **canonical** encoding of a user-specified
+projection of the message:
+
+- Map keys are sorted alphabetically.
+- Array elements are sorted by their encoded bytes (treated as sets).
+- Every value carries a type tag and a length prefix, so e.g. the
+  string `"a,b"` cannot collide with the array `["a","b"]`.
+- Whole-number floats and integers normalize to the same bytes.
+
+This guarantees:
+
+- **Zero false discards**: two projections with the same content
+  produce identical fingerprints regardless of map ordering.
+- **Zero false matches**: different content always produces different
+  fingerprints. Length-prefix + type-tag prevent serialization
+  collisions.
+
+## The projection is explicit
+
+`fingerprint {}` must list every field that counts. There is no implicit
+default — silent defaults would risk dropping real changes when the
+author forgets to enumerate a persisted field.
+
+In this example we fingerprint the SKU, name, parent SKU, the
+per-storeview price map, and the website-visibility flags. If a future
+field starts being persisted (e.g. `description`), the author must add
+it to `fingerprint {}` so changes to that field are not silently
+swallowed.
+
+## Composition with other primitives
+
+The flow combines several primitives that together make dedupe
+maximally effective:
+
+| Primitive | What it does |
+|---|---|
+| `lock { key = "sku_lock:..." }` | Serializes all workers across the cluster on the same SKU |
+| `sequence_guard { ... }` | Drops out-of-order messages (older jobId) |
+| `transform { ... }` | Computes the canonical projection |
+| `dedupe { ... }` | Drops messages whose projection equals the last persisted one |
+| `to { connector.magento = "POST ..." }` | The slow downstream call we are protecting |
+
+The dedupe primitive's **internal** lock handles in-process
+serialization. The user's **outer** `lock {}` block handles
+cross-process serialization (multiple Mycel pods). Both are needed for
+full effectiveness in a clustered deployment.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `config.mycel` | Service configuration |
+| `connectors.mycel` | RabbitMQ, Magento HTTP, and the in-memory cache for fingerprints |
+| `flows.mycel` | The `item_update_with_dedupe` flow |
+
+## Run locally
+
+```bash
+export RABBITMQ_URL="amqp://guest:guest@localhost:5672/"
+export MAGENTO_URL="https://your-magento.example.com"
+mycel start --config ./examples/dedupe
+```
+
+For production, swap the cache driver from `memory` to `redis` in
+`connectors.mycel` so the fingerprint store survives restarts and is
+shared across consumer pods:
+
+```hcl
+connector "fp_cache" {
+  type   = "cache"
+  driver = "redis"
+  host   = env("REDIS_HOST")
+  port   = env("REDIS_PORT", 6379)
+  db     = env("REDIS_DB", 0)
+}
+```
+
+## Tuning notes
+
+- **TTL**: `30d` is the recommended baseline. Too short and you lose
+  dedupe effectiveness for slow-changing resources. Too long and your
+  cache leaks stale entries for retired SKUs.
+
+- **on_duplicate**: `ack` is correct for MQ consumers — a fingerprint
+  match means the message is fully consumed and the broker should
+  release it. Use `requeue` only if you specifically want
+  upstream-side retry handling for duplicates.
+
+- **Fingerprint coverage**: re-audit `fingerprint {}` whenever a new
+  field starts being persisted. The cost of omitting a field is silent
+  data loss; the cost of including too many is one extra `Set` per
+  message.
+
+## What the dedupe primitive does NOT do
+
+- It does not validate or transform the message — those are separate
+  blocks.
+- It does not retry — that is `error_handling { retry { ... } }`.
+- It does not handle ordering — that is `sequence_guard`.
+- It does not call the downstream — that is `to`.
+
+Each primitive does one thing. Dedupe's one thing is "drop no-ops in
+milliseconds." Composing it with the rest of the pipeline gives the
+full effect.

--- a/examples/dedupe/README.md
+++ b/examples/dedupe/README.md
@@ -76,6 +76,32 @@ field starts being persisted (e.g. `description`), the author must add
 it to `fingerprint {}` so changes to that field are not silently
 swallowed.
 
+### ⚠️ Arrays are treated as order-insensitive sets
+
+The canonical encoder sorts array elements before serialization, so two
+projections with the same set of array values in different order produce
+identical fingerprints. This is appropriate for "list of attribute
+values" projections (image URLs, dynamic attributes, websites) where
+order is presentational, but **lossy** if order is semantically
+meaningful.
+
+If your projection includes an array where order matters (e.g. an
+ordered list of pipeline steps, or a ranked tag list where position
+encodes priority), reshape it in `transform` before dedupe sees it:
+join with a delimiter into a string so the dedupe encoder treats it as
+a single ordered value.
+
+```hcl
+transform {
+  // Bad: ranked_tags as an array would lose order in the fingerprint.
+  // Good: join into a string so order is part of the encoded value.
+  ranked_tags = "input.ranked_tags.map(t, t).join(',')"
+}
+```
+
+Audit every array field in your `fingerprint {}` for order sensitivity
+before going to production.
+
 ## Composition with other primitives
 
 The flow combines several primitives that together make dedupe

--- a/examples/dedupe/config.mycel
+++ b/examples/dedupe/config.mycel
@@ -1,0 +1,4 @@
+service {
+  name    = "products-consumer-dedupe"
+  version = "0.1.0"
+}

--- a/examples/dedupe/connectors.mycel
+++ b/examples/dedupe/connectors.mycel
@@ -1,0 +1,27 @@
+// Cache connector for storing dedupe fingerprints. The dedupe primitive
+// looks this up at flow registration time and uses it directly in the
+// hot path (no per-message connector registry lookup). Driver is "memory"
+// for local development; swap to "redis" for production deployments where
+// multiple Mycel pods consume the same queue.
+connector "fp_cache" {
+  type   = "cache"
+  driver = "memory"
+}
+
+// Source: RabbitMQ. In a real Mercury-style deployment this is where the
+// upstream publisher (e.g. Burro) re-sends update messages even when
+// nothing relevant changed.
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+  url    = env("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+}
+
+// Destination: a slow downstream API (Magento, in Mercury's case). Each
+// call here costs 4-26 seconds. The whole point of dedupe is to avoid
+// invoking this when the message content has not actually changed.
+connector "magento" {
+  type     = "http"
+  base_url = env("MAGENTO_URL", "https://be.dev.mercury.waterworks.com")
+  timeout  = "30s"
+}

--- a/examples/dedupe/flows.mycel
+++ b/examples/dedupe/flows.mycel
@@ -1,0 +1,136 @@
+// Example: drop no-op product updates BEFORE forwarding to a slow
+// downstream API.
+//
+// Problem this solves: an upstream publisher re-sends product update
+// messages periodically, even when nothing relevant has changed. Each
+// downstream call takes seconds. With ~19k messages in the queue and
+// >90% being no-ops, the consumer wastes hours on duplicated work.
+//
+// The dedupe primitive computes a canonical fingerprint over the fields
+// that actually get persisted, compares it byte-for-byte to the last
+// fingerprint stored for the same SKU, and drops the message in
+// milliseconds when they match. Phase B (commit the new fingerprint)
+// runs ONLY after the downstream call succeeds, so a failed-then-retried
+// message will not self-discard.
+//
+// Composition with the rest of the pipeline:
+//
+//   from(rabbit) → filter → accept → coordinate(preflight)
+//                                    → lock(per-SKU)
+//                                    → sequence_guard (drop older)
+//                                    → transform (canonical projection)
+//                                    → dedupe (drop no-ops)
+//                                    → to(magento POST)
+//                                    → coordinate(signal "item_ready")
+//
+// The dedupe primitive self-locks on its key for the duration of Phase A
+// + to + Phase B, so concurrent workers cannot double-call the
+// downstream with identical fingerprints. The user's outer lock {} block
+// (per-SKU here) handles cross-process serialization across Mycel pods.
+flow "item_update_with_dedupe" {
+  from {
+    connector = "rabbit"
+    operation = "all.in.magento.q"
+    filter {
+      condition = "input.body.metadata.headers.elementType == 'product' && input.body.metadata.headers.operation == 'update'"
+      on_reject = "requeue"
+    }
+  }
+
+  accept {
+    when      = "has(input.body.payload.productItemId) && input.body.payload.productItemId != ''"
+    on_reject = "reject"
+  }
+
+  // Serialize concurrent updates to the same SKU. Acquired before the
+  // expensive POST so all the dedupe + transform work for one SKU runs
+  // sequentially across workers in this pod. For production with
+  // multiple pods, swap the storage driver to "redis" so the lock
+  // serializes across the whole cluster.
+  lock {
+    storage {
+      driver = "memory"
+    }
+    key     = "'sku_lock:' + input.body.payload.productItemId"
+    timeout = "30s"
+    wait    = true
+  }
+
+  // Drop out-of-order messages: skip if jobId is not strictly greater
+  // than what we last saw for this SKU.
+  sequence_guard {
+    storage {
+      driver = "memory"
+    }
+    key      = "'sku_seq:' + input.body.payload.productItemId"
+    sequence = "input.body.payload.jobId"
+    on_older = "ack"
+    ttl      = "30d"
+  }
+
+  // Canonical projection of what we persist downstream. Every field
+  // present here must be evaluable from `input.*` at runtime; the
+  // dedupe block below references these names as `output.*`.
+  transform {
+    sku        = "input.body.payload.productItemId"
+    name       = "trim(input.body.payload.productItemName ?? '')"
+    parent_sku = "input.body.payload.styleAssociation ?? ''"
+
+    // Per-storeview price map. Two messages with the SAME prices in
+    // different key order produce identical fingerprints (map keys are
+    // sorted canonically before hashing).
+    prices = <<-EOT
+      {
+        'us': pick(input.body.payload.priceLine ?? {}, 'guestUSPrice', 'tradeUSPrice'),
+        'uk': pick(input.body.payload.priceLine ?? {}, 'guestUKPrice', 'tradeUKPrice'),
+        'fr': pick(input.body.payload.priceLine ?? {}, 'guestFRPrice', 'tradeFRPrice')
+      }
+    EOT
+
+    websites = <<-EOT
+      {
+        'us': size(input.body.payload.dynamicAttributeCollection.filter(x, x.key == 'ShowOnWebUSValue')) > 0,
+        'uk': size(input.body.payload.dynamicAttributeCollection.filter(x, x.key == 'ShowOnWebUKValue' || x.key == 'ShowOnWebUkUSValue')) > 0,
+        'fr': size(input.body.payload.dynamicAttributeCollection.filter(x, x.key == 'ShowOnWebFRValue')) > 0
+      }
+    EOT
+  }
+
+  // Drop messages whose persisted projection is byte-equal to the last
+  // one persisted for this SKU. The fingerprint block lists every field
+  // that "counts" — omitting a persisted field here would silently drop
+  // real changes.
+  //
+  // on_duplicate = "ack" means a match is fully consumed: the broker
+  // delivery is acked and no downstream call is made. The retry counter
+  // is irrelevant — the message reached its successful end state by
+  // being deduped.
+  dedupe {
+    cache        = "fp_cache"
+    key          = "'sku_fp:' + input.body.payload.productItemId"
+    ttl          = "30d"
+    on_duplicate = "ack"
+    fingerprint {
+      sku        = "output.sku"
+      name       = "output.name"
+      parent_sku = "output.parent_sku"
+      prices     = "output.prices"
+      websites   = "output.websites"
+    }
+  }
+
+  to {
+    connector = "magento"
+    target    = "/rest/V1/mercury/products/items"
+    operation = "POST"
+    envelope  = "productData"
+  }
+
+  error_handling {
+    retry {
+      attempts = 3
+      delay    = "2s"
+      backoff  = "exponential"
+    }
+  }
+}

--- a/examples/steps/flows.mycel
+++ b/examples/steps/flows.mycel
@@ -708,17 +708,33 @@ flow "broadcast_user_update" {
 }
 
 # =============================================================================
-# Example 13: Message Deduplication
+# Example 13: Content-Based Deduplication (biphasic)
 # =============================================================================
-# Prevent duplicate message processing using a cache backend.
-# Useful for message queue consumers that may receive the same message twice
-# due to at-least-once delivery semantics.
+# Drop no-op messages BEFORE forwarding to a slow downstream, by comparing
+# a fingerprint of the persisted projection of the message against the
+# previously-stored fingerprint for the same key.
+#
+# Use this when an upstream re-sends "update" messages even when nothing
+# relevant changed: the dedupe primitive serializes the projection you
+# specify, compares it byte-for-byte to what was last persisted, and
+# drops the message if it matches.
+#
+# Two-phase contract:
+#   1. Phase A (before `to`): compute fingerprint, GET stored, compare.
+#      If equal → drop according to on_duplicate (no `to` invocation).
+#   2. Phase B (after `to` ONLY on success): SET the new fingerprint.
+#      A failed `to` retry will NOT self-discard.
+#
+# The primitive self-locks per-key for the duration of Phase A + `to` +
+# Phase B, so concurrent workers cannot double-call the downstream with
+# identical fingerprints.
 #
 # dedupe block options:
-# - storage:      Cache connector for storing dedup keys (required)
-# - key:          CEL expression for the deduplication key (required)
-# - ttl:          How long to remember keys (default: 1h)
-# - on_duplicate: "skip" (silent) or "fail" (return error) - default: "skip"
+# - cache:         Cache-typed connector for storing fingerprints (required)
+# - key:           CEL expression for the per-resource fingerprint key (required)
+# - ttl:           How long to keep stored fingerprints (e.g., "30d")
+# - on_duplicate:  "ack" (default), "reject", or "requeue" — sequence_guard vocabulary
+# - fingerprint:   Named CEL expressions; must list every persisted field
 
 flow "process_order_with_dedupe" {
   from {
@@ -726,12 +742,17 @@ flow "process_order_with_dedupe" {
     operation = "orders.new"
   }
 
-  # Dedupe using order_id - same order won't be processed twice within 24h
+  # Drop re-deliveries of the same order whose persisted shape did not change.
   dedupe {
-    storage      = "redis_cache"
+    cache        = "redis_cache"
     key          = "'order:' + input.order_id"
     ttl          = "24h"
-    on_duplicate = "skip"
+    on_duplicate = "ack"
+    fingerprint {
+      order_id   = "input.order_id"
+      product_id = "input.product_id"
+      quantity   = "input.quantity"
+    }
   }
 
   step "validate" {
@@ -758,19 +779,24 @@ flow "process_order_with_dedupe" {
   }
 }
 
-# Example: Idempotent payment processing with dedupe
+# Example: Content-based dedupe by idempotency_key on payment processing.
+# Two messages with the same key + same (account, amount) → only one processed.
 flow "process_payment_idempotent" {
   from {
     connector = "rabbit"
     operation = "payments.process"
   }
 
-  # Use idempotency_key from the message for deduplication
   dedupe {
-    storage      = "redis_cache"
+    cache        = "redis_cache"
     key          = "'payment:' + input.idempotency_key"
     ttl          = "7d"
-    on_duplicate = "skip"  # Silently skip duplicates
+    on_duplicate = "ack"
+    fingerprint {
+      idempotency_key = "input.idempotency_key"
+      account_id      = "input.account_id"
+      amount          = "input.amount"
+    }
   }
 
   step "check_balance" {

--- a/internal/flow/duration.go
+++ b/internal/flow/duration.go
@@ -1,0 +1,55 @@
+package flow
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseDuration parses a duration string with the same units as Go's
+// time.ParseDuration plus two extensions commonly used in HCL TTL config:
+//
+//   - "d" for days (e.g. "30d" → 720h)
+//   - "w" for weeks (e.g. "2w" → 336h)
+//
+// Multi-unit composites like "1d12h" are NOT supported — the day or week
+// suffix must apply to a single integer count. This matches operator
+// intuition ("30 day TTL") and avoids the ambiguity of compound forms.
+//
+// Returns an error for malformed input. Callers should validate config
+// values at parse time so a misconfigured TTL fails the deploy instead
+// of silently degrading to "no expiry" (the symptom of catching the
+// error and using a zero default).
+func ParseDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+
+	// Try the extended single-unit suffixes first so "30d" does not fall
+	// through to time.ParseDuration (which would error with "unknown unit
+	// d in duration 30d").
+	if n, ok := strings.CutSuffix(s, "d"); ok {
+		days, err := strconv.Atoi(n)
+		if err != nil {
+			return 0, fmt.Errorf("invalid day duration %q: %w", s, err)
+		}
+		if days < 0 {
+			return 0, fmt.Errorf("invalid day duration %q: must be non-negative", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	if n, ok := strings.CutSuffix(s, "w"); ok {
+		weeks, err := strconv.Atoi(n)
+		if err != nil {
+			return 0, fmt.Errorf("invalid week duration %q: %w", s, err)
+		}
+		if weeks < 0 {
+			return 0, fmt.Errorf("invalid week duration %q: must be non-negative", s)
+		}
+		return time.Duration(weeks) * 7 * 24 * time.Hour, nil
+	}
+
+	return time.ParseDuration(s)
+}

--- a/internal/flow/duration_test.go
+++ b/internal/flow/duration_test.go
@@ -1,0 +1,69 @@
+package flow
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"empty string returns zero", "", 0, false},
+		{"whitespace trimmed", "  1h  ", time.Hour, false},
+		{"stdlib seconds", "30s", 30 * time.Second, false},
+		{"stdlib minutes", "5m", 5 * time.Minute, false},
+		{"stdlib hours", "2h", 2 * time.Hour, false},
+		{"stdlib compound", "1h30m", time.Hour + 30*time.Minute, false},
+
+		// Day suffix — the canonical TTL baseline in the docs.
+		{"single day", "1d", 24 * time.Hour, false},
+		{"thirty days", "30d", 30 * 24 * time.Hour, false},
+		{"zero days", "0d", 0, false},
+
+		// Week suffix.
+		{"single week", "1w", 7 * 24 * time.Hour, false},
+		{"two weeks", "2w", 14 * 24 * time.Hour, false},
+
+		// Malformed inputs must error explicitly — silent fallback to 0
+		// (no expiry) would let "30days" or "thirty-d" pass review and
+		// leak entries forever in Redis.
+		{"bare d", "d", 0, true},
+		{"non-numeric d", "abc d", 0, true},
+		{"30days (typo)", "30days", 0, true},
+		{"unknown unit", "5y", 0, true},
+		{"negative days", "-1d", 0, true},
+		{"negative weeks", "-2w", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseDuration(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseDuration(%q) error = %v, wantErr=%v", tc.input, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("ParseDuration(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseDuration_30dRegressionGuard locks the canonical "30d" baseline
+// that appears in dedupe docs and Mercury's HCL configs. The pre-existing
+// time.ParseDuration call returned an error on "30d" and the caller
+// silently fell back to zero (= no expiry), leaving Redis to grow
+// unbounded.
+func TestParseDuration_30dRegressionGuard(t *testing.T) {
+	got, err := ParseDuration("30d")
+	if err != nil {
+		t.Fatalf("30d must parse: %v", err)
+	}
+	want := 30 * 24 * time.Hour
+	if got != want {
+		t.Errorf("30d = %v, want %v (720h)", got, want)
+	}
+}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -635,23 +635,53 @@ func NewFlowError(err error, status int, body map[string]interface{}, headers ma
 	}
 }
 
-// DedupeConfig holds deduplication configuration for a flow.
-// Used to prevent processing duplicate messages (e.g., from message queues).
+// DedupeConfig holds content-based, biphasic deduplication for a flow.
+//
+// Semantics (since v2.1.0):
+//
+//   - Phase A (before `to`): compute a canonical fingerprint over the named
+//     projection (Fingerprint map), GET the previously-stored fingerprint
+//     for Key, and compare byte-for-byte. If equal, the message is dropped
+//     according to OnDuplicate without invoking `to`.
+//
+//   - Phase B (after `to` ONLY on success): SET the new fingerprint for
+//     Key with TTL. Writing earlier would let a failed+retried message
+//     self-discard and lose a real change.
+//
+// The primitive is self-locking on Key for the duration of Phase A + `to`
+// + Phase B, so concurrent workers cannot both pass Phase A with the same
+// fingerprint and double-call the downstream.
+//
+// The projection must contain every field the flow persists downstream —
+// omitting a persisted field would silently drop real changes. The author
+// is the only one who knows which fields actually count; the primitive
+// cannot infer it.
 type DedupeConfig struct {
-	// Storage is the connector for storing dedup state (typically Redis or cache).
-	Storage string
+	// Cache is the name of a cache-typed connector used to store
+	// fingerprints. Driver-agnostic: works with "memory" (unit tests) or
+	// "redis" (production). The connector's pool is initialized once at
+	// service start; the dedupe hot path does not reconnect per message.
+	Cache string
 
-	// Key is a CEL expression that generates the deduplication key.
-	// Example: "input.message_id" or "'order:' + input.order_id"
+	// Key is a CEL expression for the per-resource fingerprint key.
+	// Evaluated against `input.*`. Example:
+	//   "'sku_fp:' + input.body.payload.productItemId"
 	Key string
 
-	// TTL is how long to remember seen keys (e.g., "1h", "24h").
-	// After TTL expires, the same key can be processed again.
+	// Fingerprint is a map of named CEL expressions whose results form the
+	// projection. Both `input.*` and `output.*` (transform result) are in
+	// scope. Order of keys in HCL is irrelevant — the runtime serializes
+	// with sorted keys for canonicalization.
+	Fingerprint map[string]string
+
+	// TTL is how long to keep the stored fingerprint after the last update
+	// (e.g., "30d"). Empty means no expiry. Long-tail keys can leak, so a
+	// 30-day TTL is the recommended baseline.
 	TTL string
 
-	// OnDuplicate defines behavior when duplicate is found: "skip" or "fail".
-	// - "skip": Silently skip the duplicate (default)
-	// - "fail": Return an error for duplicates
+	// OnDuplicate selects what to do when the current fingerprint matches
+	// the stored one: "ack" (default), "reject", or "requeue". Matches the
+	// sequence_guard vocabulary so MQ consumers handle it uniformly.
 	OnDuplicate string
 }
 

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -1195,10 +1195,13 @@ func parseTransformMappings(block *hcl.Block, ctx *hcl.EvalContext) (map[string]
 func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
-			{Name: "storage", Required: true},
+			{Name: "cache", Required: true},
 			{Name: "key", Required: true},
 			{Name: "ttl"},
 			{Name: "on_duplicate"},
+		},
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "fingerprint"},
 		},
 	}
 
@@ -1208,21 +1211,21 @@ func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfi
 	}
 
 	dedupe := &flow.DedupeConfig{
-		OnDuplicate: "skip", // Default behavior
+		OnDuplicate: "ack", // sequence_guard-style default
 	}
 
-	if attr, ok := content.Attributes["storage"]; ok {
+	if attr, ok := content.Attributes["cache"]; ok {
 		val, diags := attr.Expr.Value(ctx)
 		if diags.HasErrors() {
-			return nil, fmt.Errorf("dedupe storage error: %s", diags.Error())
+			return nil, fmt.Errorf("dedupe cache error: %s", diags.Error())
 		}
-		dedupe.Storage = parseConnectorReference(val.AsString())
+		dedupe.Cache = parseConnectorReference(val.AsString())
 	}
 
 	if attr, ok := content.Attributes["key"]; ok {
 		val, diags := attr.Expr.Value(ctx)
 		if diags.HasErrors() {
-			// Try to extract raw expression for CEL expressions
+			// CEL expression — extract raw text
 			dedupe.Key = extractExpressionText(attr.Expr)
 		} else {
 			dedupe.Key = val.AsString()
@@ -1245,12 +1248,56 @@ func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfi
 		dedupe.OnDuplicate = val.AsString()
 	}
 
-	if dedupe.Storage == "" {
-		return nil, fmt.Errorf("dedupe block must specify a storage connector")
+	// Parse the (required) fingerprint block — named CEL expressions, same
+	// shape as a transform block. Each entry contributes to the canonical
+	// projection. The author must list every persisted field; the runtime
+	// cannot infer which fields count.
+	var fingerprintBlock *hcl.Block
+	for _, b := range content.Blocks {
+		if b.Type == "fingerprint" {
+			if fingerprintBlock != nil {
+				return nil, fmt.Errorf("dedupe block must contain exactly one fingerprint block")
+			}
+			fingerprintBlock = b
+		}
+	}
+	if fingerprintBlock == nil {
+		return nil, fmt.Errorf("dedupe block must contain a fingerprint block")
+	}
+
+	fpAttrs, diags := fingerprintBlock.Body.JustAttributes()
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("dedupe fingerprint block error: %s", diags.Error())
+	}
+	if len(fpAttrs) == 0 {
+		return nil, fmt.Errorf("dedupe fingerprint block must define at least one named expression")
+	}
+
+	dedupe.Fingerprint = make(map[string]string, len(fpAttrs))
+	for name, attr := range fpAttrs {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			// CEL expression — extract raw text to be evaluated at runtime
+			dedupe.Fingerprint[name] = extractExpressionText(attr.Expr)
+			continue
+		}
+		// Literal values are accepted too: treat them as constant projections
+		dedupe.Fingerprint[name] = val.AsString()
+	}
+
+	if dedupe.Cache == "" {
+		return nil, fmt.Errorf("dedupe block must specify a cache connector")
 	}
 
 	if dedupe.Key == "" {
 		return nil, fmt.Errorf("dedupe block must specify a key expression")
+	}
+
+	switch dedupe.OnDuplicate {
+	case "ack", "reject", "requeue":
+		// ok
+	default:
+		return nil, fmt.Errorf("dedupe on_duplicate must be 'ack', 'reject', or 'requeue', got %q", dedupe.OnDuplicate)
 	}
 
 	return dedupe, nil

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -1238,6 +1238,13 @@ func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfi
 			return nil, fmt.Errorf("dedupe ttl error: %s", diags.Error())
 		}
 		dedupe.TTL = val.AsString()
+		// Validate the TTL string at parse time so misconfigured
+		// deployments fail fast at deploy. Silent fallback to "no
+		// expiry" (the symptom of catching the error at runtime) would
+		// let "30days" or "5y" leak entries in Redis forever.
+		if _, err := flow.ParseDuration(dedupe.TTL); err != nil {
+			return nil, fmt.Errorf("dedupe ttl %q: %w", dedupe.TTL, err)
+		}
 	}
 
 	if attr, ok := content.Attributes["on_duplicate"]; ok {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -908,6 +908,85 @@ flow "f" {
 	}
 }
 
+// TestParseFlowDedupeRejectsMalformedTTL guards against the silent
+// "no expiry" fallback that an unhandled time.ParseDuration error
+// produces for non-stdlib TTL formats. A typo like "30days" (or any
+// stdlib-unknown unit) must fail the parse, not parse to zero and let
+// Redis grow unbounded.
+func TestParseFlowDedupeRejectsMalformedTTL(t *testing.T) {
+	hcl := `
+flow "f" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    cache = "c"
+    key   = "input.id"
+    ttl   = "30days"
+    fingerprint {
+      v = "input.v"
+    }
+  }
+  to {
+    connector = "db"
+    target    = "t"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "flow.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().ParseFile(context.Background(), tmpFile)
+	if err == nil {
+		t.Fatal("expected parse to fail on ttl=30days")
+	}
+	if !strings.Contains(err.Error(), "ttl") {
+		t.Errorf("error should mention ttl; got %v", err)
+	}
+}
+
+// TestParseFlowDedupeAccepts30d locks the canonical "30d" TTL baseline
+// documented across the project. Pre-fix, this would have parsed
+// successfully but silently downgraded to no-expiry at runtime via
+// time.ParseDuration returning an error.
+func TestParseFlowDedupeAccepts30d(t *testing.T) {
+	hcl := `
+flow "f" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    cache = "c"
+    key   = "input.id"
+    ttl   = "30d"
+    fingerprint {
+      v = "input.v"
+    }
+  }
+  to {
+    connector = "db"
+    target    = "t"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "flow.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := NewHCLParser().ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("30d must parse cleanly: %v", err)
+	}
+	if got := cfg.Flows[0].Dedupe.TTL; got != "30d" {
+		t.Errorf("TTL stored = %q, want 30d", got)
+	}
+}
+
 // TestParseFlowDedupeRequiresFingerprint guards the rule that a dedupe
 // block must declare its projection — silent default would risk dropping
 // real changes.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -764,10 +764,15 @@ flow "process_order" {
   }
 
   dedupe {
-    storage      = "redis_cache"
+    cache        = "redis_cache"
     key          = "'order:' + input.order_id"
     ttl          = "24h"
-    on_duplicate = "skip"
+    on_duplicate = "ack"
+    fingerprint {
+      order_id   = "input.order_id"
+      product_id = "input.product_id"
+      quantity   = "input.quantity"
+    }
   }
 
   transform {
@@ -803,8 +808,8 @@ flow "process_order" {
 		t.Fatal("expected dedupe config to be set")
 	}
 
-	if flow.Dedupe.Storage != "redis_cache" {
-		t.Errorf("expected dedupe storage 'redis_cache', got '%s'", flow.Dedupe.Storage)
+	if flow.Dedupe.Cache != "redis_cache" {
+		t.Errorf("expected dedupe cache 'redis_cache', got '%s'", flow.Dedupe.Cache)
 	}
 	if flow.Dedupe.Key != "'order:' + input.order_id" {
 		t.Errorf("expected dedupe key \"'order:' + input.order_id\", got '%s'", flow.Dedupe.Key)
@@ -812,8 +817,128 @@ flow "process_order" {
 	if flow.Dedupe.TTL != "24h" {
 		t.Errorf("expected dedupe TTL '24h', got '%s'", flow.Dedupe.TTL)
 	}
-	if flow.Dedupe.OnDuplicate != "skip" {
-		t.Errorf("expected dedupe on_duplicate 'skip', got '%s'", flow.Dedupe.OnDuplicate)
+	if flow.Dedupe.OnDuplicate != "ack" {
+		t.Errorf("expected dedupe on_duplicate 'ack', got '%s'", flow.Dedupe.OnDuplicate)
+	}
+	if got, want := len(flow.Dedupe.Fingerprint), 3; got != want {
+		t.Fatalf("expected %d fingerprint entries, got %d", want, got)
+	}
+	for _, name := range []string{"order_id", "product_id", "quantity"} {
+		if _, ok := flow.Dedupe.Fingerprint[name]; !ok {
+			t.Errorf("expected fingerprint key %q to be present", name)
+		}
+	}
+	// CEL expressions are preserved as raw text so the runtime can evaluate
+	// them per-message; literal values would not round-trip otherwise.
+	if got := flow.Dedupe.Fingerprint["order_id"]; got != "input.order_id" {
+		t.Errorf("fingerprint[order_id] = %q, want %q", got, "input.order_id")
+	}
+}
+
+// TestParseFlowDedupeDefaults locks the on_duplicate default ("ack") and
+// confirms that omitting it parses cleanly.
+func TestParseFlowDedupeDefaults(t *testing.T) {
+	hcl := `
+flow "f" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    cache = "c"
+    key   = "input.id"
+    fingerprint {
+      v = "input.v"
+    }
+  }
+  to {
+    connector = "db"
+    target    = "t"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "flow.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := NewHCLParser().ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.Flows[0].Dedupe.OnDuplicate; got != "ack" {
+		t.Errorf("OnDuplicate default = %q, want ack", got)
+	}
+}
+
+// TestParseFlowDedupeRejectsBadOnDuplicate guards the validator that limits
+// on_duplicate to the sequence_guard-style set.
+func TestParseFlowDedupeRejectsBadOnDuplicate(t *testing.T) {
+	hcl := `
+flow "f" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    cache        = "c"
+    key          = "input.id"
+    on_duplicate = "skip"
+    fingerprint {
+      v = "input.v"
+    }
+  }
+  to {
+    connector = "db"
+    target    = "t"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "flow.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().ParseFile(context.Background(), tmpFile)
+	if err == nil {
+		t.Fatal("expected parse to fail on on_duplicate=skip (v2.1.0 vocabulary is ack/reject/requeue)")
+	}
+	if !strings.Contains(err.Error(), "on_duplicate") {
+		t.Errorf("error should mention on_duplicate; got %v", err)
+	}
+}
+
+// TestParseFlowDedupeRequiresFingerprint guards the rule that a dedupe
+// block must declare its projection — silent default would risk dropping
+// real changes.
+func TestParseFlowDedupeRequiresFingerprint(t *testing.T) {
+	hcl := `
+flow "f" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    cache = "c"
+    key   = "input.id"
+  }
+  to {
+    connector = "db"
+    target    = "t"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "flow.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().ParseFile(context.Background(), tmpFile)
+	if err == nil {
+		t.Fatal("expected parse to fail when fingerprint block is missing")
+	}
+	if !strings.Contains(err.Error(), "fingerprint") {
+		t.Errorf("error should mention fingerprint; got %v", err)
 	}
 }
 

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -210,14 +210,17 @@ func dedupeLockKey(flowName, key string) string {
 	return "dedupe:lock:" + flowName + ":" + key
 }
 
-// parseDedupeTTL is a small helper around time.ParseDuration that returns
-// 0 (no expiry) on empty or invalid input. Validation against malformed
-// strings happens at parse time; this is the runtime safety net.
+// parseDedupeTTL converts the TTL string into a duration. The HCL parser
+// validates the format at parse time via flow.ParseDuration, so by the
+// time we reach this code an error here would indicate either a malformed
+// flow.Config built outside the parser (tests) or a bug. We still fall
+// back to zero in that case rather than panicking — the documented
+// fail-open contract for cache errors applies to TTL parsing too.
 func parseDedupeTTL(s string) time.Duration {
 	if s == "" {
 		return 0
 	}
-	if d, err := time.ParseDuration(s); err == nil {
+	if d, err := flow.ParseDuration(s); err == nil {
 		return d
 	}
 	return 0

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -89,10 +89,16 @@ func (h *FlowHandler) dedupeAwareWrite(
 	// memory lock backend (internal/sync/manager.go:107). That is the
 	// in-process serialization we want. Cross-process is the caller's
 	// responsibility via the existing flow-level lock {} block.
+	//
+	// 5m is generous enough to outlast any reasonable downstream call
+	// while still preventing a stuck flow from blocking other workers on
+	// the same key forever. The internal heartbeat extends the TTL while
+	// the inner write runs, so a long-running write cannot race-release
+	// the lock mid-execution.
 	lockCfg := &msync.FlowLockConfig{
 		Storage: nil, // memory backend
 		Key:     lockKey,
-		Timeout: "0s", // wait indefinitely; the surrounding flow already has a timeout
+		Timeout: "5m",
 		Wait:    true,
 	}
 
@@ -144,8 +150,9 @@ func (h *FlowHandler) dedupeAwareWrite(
 // cause all messages to share a key and dedupe everything together.
 func (h *FlowHandler) evalDedupeKey(ctx context.Context, input map[string]interface{}) (string, error) {
 	cfg := h.Config.Dedupe
-	data := map[string]interface{}{"input": input}
-	val, err := h.Transformer.EvaluateExpression(ctx, data, nil, cfg.Key)
+	// EvaluateExpression binds `input` itself; callers must pass the raw
+	// input map, not a nested wrapper.
+	val, err := h.Transformer.EvaluateExpression(ctx, input, nil, cfg.Key)
 	if err != nil {
 		return "", fmt.Errorf("dedupe key evaluation: %w", err)
 	}
@@ -161,13 +168,11 @@ func (h *FlowHandler) evalDedupeKey(ctx context.Context, input map[string]interf
 // resulting projection into a deterministic byte string via Fingerprint.
 func (h *FlowHandler) computeDedupeFingerprint(ctx context.Context, input map[string]interface{}, payload map[string]interface{}) ([]byte, error) {
 	cfg := h.Config.Dedupe
-	scope := map[string]interface{}{
-		"input":  input,
-		"output": payload,
-	}
 	projection := make(map[string]interface{}, len(cfg.Fingerprint))
 	for name, expr := range cfg.Fingerprint {
-		v, err := h.Transformer.EvaluateExpression(ctx, scope, nil, expr)
+		// EvaluateExpressionWithOutput binds both `input` and `output`,
+		// matching the documented projection scope.
+		v, err := h.Transformer.EvaluateExpressionWithOutput(ctx, input, payload, expr)
 		if err != nil {
 			return nil, fmt.Errorf("dedupe fingerprint[%q] evaluation: %w", name, err)
 		}

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -1,0 +1,219 @@
+// Package runtime contains the dedupe primitive's runtime integration.
+//
+// Conceptually, dedupe runs in two phases bracketing the destination call:
+//
+//	Phase A (before `to`): compute a canonical fingerprint over the named
+//	    projection, GET the previously stored fingerprint for the key, and
+//	    compare byte-for-byte. On match the message is dropped according
+//	    to on_duplicate without invoking `to`.
+//
+//	Phase B (after `to` ONLY on success): SET the new fingerprint for the
+//	    key. Writing earlier would let a failed+retried message
+//	    self-discard and lose a real change.
+//
+// Both phases run under an in-process lock keyed on the dedupe.key, so two
+// workers in the same process cannot both pass Phase A with identical
+// fingerprints and double-call the downstream. For cross-process
+// serialization (e.g. several Mycel pods consuming the same queue),
+// callers must compose dedupe with an outer `lock {}` block — the
+// in-process lock alone makes dedupe correct but does not extend its
+// effectiveness across processes.
+//
+// Correctness invariant: dedupe NEVER drops a message that contains a real
+// change. If stored == new fingerprint, then those exact bytes were
+// previously committed to Phase B, which only runs after a successful
+// `to`. Re-sending the same content is a no-op by construction. Cache
+// errors fail open (the message is processed) so a broken Redis cannot
+// silently swallow traffic.
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/matutetandil/mycel/internal/flow"
+	msync "github.com/matutetandil/mycel/internal/sync"
+	"github.com/matutetandil/mycel/internal/transform"
+)
+
+// dedupeAwareWrite is the integration entry point for the dedupe primitive.
+// It wraps the destination call in Phase A + lock + Phase B. When the flow
+// has no dedupe configured (the common case), it transparently delegates
+// to write() with zero overhead.
+//
+// The closure write() is whatever the handler would have called to perform
+// the destination side-effect (e.g. dest.Write inside a trace.RecordStage).
+// It is invoked at most once per dedupeAwareWrite call. On match it is not
+// invoked at all.
+func (h *FlowHandler) dedupeAwareWrite(
+	ctx context.Context,
+	input map[string]interface{},
+	payload map[string]interface{},
+	write func() (interface{}, error),
+) (interface{}, error) {
+	cfg := h.Config.Dedupe
+	if cfg == nil {
+		return write()
+	}
+	if h.DedupeCache == nil {
+		// Misconfiguration caught at registration time normally; defend
+		// here so a missing connector cannot silently disable dedupe.
+		return nil, fmt.Errorf("dedupe is configured for flow %q but its cache connector %q was not resolved", h.Config.Name, cfg.Cache)
+	}
+	if h.SyncManager == nil {
+		return nil, fmt.Errorf("dedupe requires a SyncManager for in-process serialization (flow %q)", h.Config.Name)
+	}
+
+	if err := h.ensureTransformer(); err != nil {
+		return nil, err
+	}
+
+	key, err := h.evalDedupeKey(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	fp, err := h.computeDedupeFingerprint(ctx, input, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	storageKey := dedupeStorageKey(h.Config.Name, key)
+	lockKey := dedupeLockKey(h.Config.Name, key)
+	ttl := parseDedupeTTL(cfg.TTL)
+
+	// SyncManager.ExecuteWithLock with nil Storage falls back to the
+	// memory lock backend (internal/sync/manager.go:107). That is the
+	// in-process serialization we want. Cross-process is the caller's
+	// responsibility via the existing flow-level lock {} block.
+	lockCfg := &msync.FlowLockConfig{
+		Storage: nil, // memory backend
+		Key:     lockKey,
+		Timeout: "0s", // wait indefinitely; the surrounding flow already has a timeout
+		Wait:    true,
+	}
+
+	return h.SyncManager.ExecuteWithLock(ctx, lockCfg, lockKey, func() (interface{}, error) {
+		// Phase A: GET stored, compare.
+		stored, found, getErr := h.DedupeCache.Get(ctx, storageKey)
+		if getErr != nil {
+			// Fail open: cache errors should never block message processing.
+			// Worst case is one extra downstream call.
+			slog.Warn("dedupe Get failed; proceeding with message",
+				"flow", h.Config.Name,
+				"key", key,
+				"error", getErr)
+		} else if found && bytes.Equal(stored, fp) {
+			slog.Info("dedupe match; dropping duplicate",
+				"flow", h.Config.Name,
+				"key", key,
+				"policy", cfg.OnDuplicate)
+			return &flow.FilteredResultWithPolicy{
+				Filtered: true,
+				Policy:   cfg.OnDuplicate,
+				Reason:   "dedupe_match",
+			}, nil
+		}
+
+		// Not a duplicate — run the actual write.
+		result, writeErr := write()
+		if writeErr != nil {
+			// Phase B intentionally skipped: a failed write must not poison
+			// the fingerprint cache. The next retry will re-attempt.
+			return result, writeErr
+		}
+
+		// Phase B: SET the new fingerprint. Best-effort — a failure here
+		// just means the next identical message will not be deduped; the
+		// current message already succeeded downstream.
+		if setErr := h.DedupeCache.Set(ctx, storageKey, fp, ttl); setErr != nil {
+			slog.Warn("dedupe commit failed; next identical message will not be filtered",
+				"flow", h.Config.Name,
+				"key", key,
+				"error", setErr)
+		}
+		return result, nil
+	})
+}
+
+// evalDedupeKey evaluates the configured key CEL expression against the
+// message input. Empty results are rejected — silent emptiness would
+// cause all messages to share a key and dedupe everything together.
+func (h *FlowHandler) evalDedupeKey(ctx context.Context, input map[string]interface{}) (string, error) {
+	cfg := h.Config.Dedupe
+	data := map[string]interface{}{"input": input}
+	val, err := h.Transformer.EvaluateExpression(ctx, data, nil, cfg.Key)
+	if err != nil {
+		return "", fmt.Errorf("dedupe key evaluation: %w", err)
+	}
+	key := fmt.Sprintf("%v", val)
+	if key == "" {
+		return "", fmt.Errorf("dedupe key %q evaluated to empty string", cfg.Key)
+	}
+	return key, nil
+}
+
+// computeDedupeFingerprint evaluates each fingerprint expression against
+// `input.*` and `output.*` (the transformed payload), then encodes the
+// resulting projection into a deterministic byte string via Fingerprint.
+func (h *FlowHandler) computeDedupeFingerprint(ctx context.Context, input map[string]interface{}, payload map[string]interface{}) ([]byte, error) {
+	cfg := h.Config.Dedupe
+	scope := map[string]interface{}{
+		"input":  input,
+		"output": payload,
+	}
+	projection := make(map[string]interface{}, len(cfg.Fingerprint))
+	for name, expr := range cfg.Fingerprint {
+		v, err := h.Transformer.EvaluateExpression(ctx, scope, nil, expr)
+		if err != nil {
+			return nil, fmt.Errorf("dedupe fingerprint[%q] evaluation: %w", name, err)
+		}
+		projection[name] = v
+	}
+	return Fingerprint(projection)
+}
+
+// ensureTransformer initializes the CEL transformer lazily. Most handler
+// paths call applyTransforms first which already does this, but a defensive
+// check here keeps dedupe from depending on call order.
+func (h *FlowHandler) ensureTransformer() error {
+	if h.Transformer != nil {
+		return nil
+	}
+	celOptions := transform.CreateWASMFunctionOptions(h.FunctionsRegistry)
+	tr, err := transform.NewCELTransformerWithOptions(celOptions...)
+	if err != nil {
+		return fmt.Errorf("failed to create CEL transformer for dedupe: %w", err)
+	}
+	h.Transformer = tr
+	return nil
+}
+
+// dedupeStorageKey namespaces the cache key by flow so two flows can use
+// the same logical key value without colliding in the same cache.
+func dedupeStorageKey(flowName, key string) string {
+	return "dedupe:" + flowName + ":" + key
+}
+
+// dedupeLockKey is distinct from dedupeStorageKey so a user's outer
+// lock { key = "..." } cannot collide with the dedupe-internal lock even
+// if the same string is used as both the lock key and the dedupe key.
+func dedupeLockKey(flowName, key string) string {
+	return "dedupe:lock:" + flowName + ":" + key
+}
+
+// parseDedupeTTL is a small helper around time.ParseDuration that returns
+// 0 (no expiry) on empty or invalid input. Validation against malformed
+// strings happens at parse time; this is the runtime safety net.
+func parseDedupeTTL(s string) time.Duration {
+	if s == "" {
+		return 0
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return d
+	}
+	return 0
+}

--- a/internal/runtime/dedupe_fingerprint.go
+++ b/internal/runtime/dedupe_fingerprint.go
@@ -1,0 +1,190 @@
+package runtime
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// Type tags for the fingerprint encoding. Each tag claims a region of the
+// stream so two values of different shapes can never produce equal bytes —
+// e.g. the string "a,b" cannot collide with the array ["a","b"], and the
+// integer 5 cannot collide with the string "5".
+const (
+	fpTagNil    byte = 'n'
+	fpTagBool   byte = 'b'
+	fpTagInt    byte = 'i'
+	fpTagFloat  byte = 'f'
+	fpTagString byte = 's'
+	fpTagBytes  byte = 'B'
+	fpTagMap    byte = 'm'
+	fpTagArray  byte = 'a'
+)
+
+// Fingerprint encodes a projection into a deterministic byte string suitable
+// for byte-for-byte equality comparison against a previously stored
+// fingerprint. The encoding is length-prefixed and type-tagged so different
+// shapes can never produce equal bytes.
+//
+// Determinism rules:
+//
+//   - Map keys are sorted alphabetically before serialization. Two maps with
+//     the same content but different insertion order produce identical bytes.
+//
+//   - Array elements are sorted by their own serialized representation before
+//     serialization. The encoder treats arrays as order-insensitive sets,
+//     appropriate for the common "list of attribute values" projection but
+//     lossy if order is semantically meaningful. Callers needing
+//     order-preserving fingerprints should reshape arrays in transform
+//     (e.g. join with a delimiter into a string).
+//
+//   - Numeric values that are whole numbers are encoded as integers
+//     regardless of their input form (float64(5.0) and int64(5) produce
+//     identical bytes). CEL evaluates all numeric literals to float64, so
+//     this normalization is what makes "input.qty == output.qty" round-trip
+//     cleanly through the projection.
+//
+// Returns the encoded byte string. An error is returned only for unsupported
+// types in the projection — the function is otherwise total.
+//
+// Future optimization: hash the result with SHA-256 to bound storage size
+// per key. v1 keeps the full bytes so that any divergence is auditable and
+// there is zero risk of hash collision.
+func Fingerprint(projection map[string]interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := encodeValue(&buf, projection); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// encodeValue writes a single value with its type tag.
+func encodeValue(buf *bytes.Buffer, v interface{}) error {
+	if v == nil {
+		buf.WriteByte(fpTagNil)
+		return nil
+	}
+	switch x := v.(type) {
+	case bool:
+		buf.WriteByte(fpTagBool)
+		if x {
+			buf.WriteByte(1)
+		} else {
+			buf.WriteByte(0)
+		}
+		return nil
+	case int:
+		return encodeInt(buf, int64(x))
+	case int32:
+		return encodeInt(buf, int64(x))
+	case int64:
+		return encodeInt(buf, x)
+	case uint:
+		return encodeInt(buf, int64(x))
+	case uint32:
+		return encodeInt(buf, int64(x))
+	case uint64:
+		return encodeInt(buf, int64(x))
+	case float32:
+		return encodeFloat(buf, float64(x))
+	case float64:
+		// Whole-number floats round-trip as integers so that CEL's float64
+		// representation of integer literals matches Go int64 sources.
+		if x == float64(int64(x)) {
+			return encodeInt(buf, int64(x))
+		}
+		return encodeFloat(buf, x)
+	case string:
+		return encodeString(buf, x)
+	case []byte:
+		buf.WriteByte(fpTagBytes)
+		writeLen(buf, len(x))
+		buf.Write(x)
+		return nil
+	case map[string]interface{}:
+		return encodeMap(buf, x)
+	case []interface{}:
+		return encodeArray(buf, x)
+	default:
+		return fmt.Errorf("fingerprint: unsupported type %T (projection values must be primitives, []byte, map[string]interface{}, or []interface{})", v)
+	}
+}
+
+func encodeInt(buf *bytes.Buffer, n int64) error {
+	buf.WriteByte(fpTagInt)
+	s := strconv.FormatInt(n, 10)
+	writeLen(buf, len(s))
+	buf.WriteString(s)
+	return nil
+}
+
+func encodeFloat(buf *bytes.Buffer, f float64) error {
+	buf.WriteByte(fpTagFloat)
+	// 'g' with precision -1 produces the shortest representation that
+	// round-trips. Same float64 input → same bytes across machines and Go
+	// versions because the format is fully deterministic.
+	s := strconv.FormatFloat(f, 'g', -1, 64)
+	writeLen(buf, len(s))
+	buf.WriteString(s)
+	return nil
+}
+
+func encodeString(buf *bytes.Buffer, s string) error {
+	buf.WriteByte(fpTagString)
+	writeLen(buf, len(s))
+	buf.WriteString(s)
+	return nil
+}
+
+func encodeMap(buf *bytes.Buffer, m map[string]interface{}) error {
+	buf.WriteByte(fpTagMap)
+	writeLen(buf, len(m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		// Map keys are length-prefixed strings without a leading tag since
+		// they are always strings — the type-tag is implied by position.
+		writeLen(buf, len(k))
+		buf.WriteString(k)
+		if err := encodeValue(buf, m[k]); err != nil {
+			return fmt.Errorf("fingerprint: encoding key %q: %w", k, err)
+		}
+	}
+	return nil
+}
+
+func encodeArray(buf *bytes.Buffer, a []interface{}) error {
+	buf.WriteByte(fpTagArray)
+	writeLen(buf, len(a))
+	// Encode each element into its own buffer, then sort by the encoded
+	// bytes. This makes the result independent of input order.
+	encoded := make([][]byte, len(a))
+	for i, item := range a {
+		var sub bytes.Buffer
+		if err := encodeValue(&sub, item); err != nil {
+			return fmt.Errorf("fingerprint: encoding array element %d: %w", i, err)
+		}
+		encoded[i] = sub.Bytes()
+	}
+	sort.Slice(encoded, func(i, j int) bool {
+		return bytes.Compare(encoded[i], encoded[j]) < 0
+	})
+	for _, e := range encoded {
+		buf.Write(e)
+	}
+	return nil
+}
+
+// writeLen writes a fixed-width little-endian 4-byte length prefix. Bounded
+// to 2^32 bytes per value, which is more than enough for any realistic
+// projection.
+func writeLen(buf *bytes.Buffer, n int) {
+	var b [4]byte
+	binary.LittleEndian.PutUint32(b[:], uint32(n))
+	buf.Write(b[:])
+}

--- a/internal/runtime/dedupe_fingerprint_test.go
+++ b/internal/runtime/dedupe_fingerprint_test.go
@@ -1,0 +1,274 @@
+package runtime
+
+import (
+	"bytes"
+	"testing"
+)
+
+// fpEqual asserts two Fingerprint calls produce identical bytes.
+func fpEqual(t *testing.T, name string, a, b map[string]interface{}) {
+	t.Helper()
+	fa, err := Fingerprint(a)
+	if err != nil {
+		t.Fatalf("[%s] encode a: %v", name, err)
+	}
+	fb, err := Fingerprint(b)
+	if err != nil {
+		t.Fatalf("[%s] encode b: %v", name, err)
+	}
+	if !bytes.Equal(fa, fb) {
+		t.Errorf("[%s] expected equal fingerprints\n  a=%x\n  b=%x", name, fa, fb)
+	}
+}
+
+// fpDiffer asserts two Fingerprint calls produce different bytes.
+func fpDiffer(t *testing.T, name string, a, b map[string]interface{}) {
+	t.Helper()
+	fa, err := Fingerprint(a)
+	if err != nil {
+		t.Fatalf("[%s] encode a: %v", name, err)
+	}
+	fb, err := Fingerprint(b)
+	if err != nil {
+		t.Fatalf("[%s] encode b: %v", name, err)
+	}
+	if bytes.Equal(fa, fb) {
+		t.Errorf("[%s] expected DIFFERENT fingerprints but both produced %x", name, fa)
+	}
+}
+
+func TestFingerprint_Deterministic(t *testing.T) {
+	// Same input twice → identical bytes. Encoding is a pure function with
+	// no randomness, no map-iteration-order dependence, no time, no IDs.
+	p := map[string]interface{}{
+		"name":  "Widget",
+		"price": 42,
+		"tags":  []interface{}{"a", "b", "c"},
+	}
+	for i := 0; i < 5; i++ {
+		fpEqual(t, "deterministic-run", p, p)
+	}
+}
+
+func TestFingerprint_MapKeyOrderIndependent(t *testing.T) {
+	// Go map iteration is randomized; the encoder must sort keys so the
+	// output is independent of insertion order.
+	a := map[string]interface{}{"name": "A", "qty": 1, "color": "red"}
+	b := map[string]interface{}{"color": "red", "qty": 1, "name": "A"}
+	fpEqual(t, "map-key-order", a, b)
+}
+
+func TestFingerprint_ArrayOrderIndependent(t *testing.T) {
+	// Per the spec, arrays are sorted by their encoded representation
+	// before serialization. Two projections with the same set of array
+	// elements in different order produce identical bytes.
+	a := map[string]interface{}{
+		"tags": []interface{}{"fr", "uk", "us"},
+	}
+	b := map[string]interface{}{
+		"tags": []interface{}{"us", "fr", "uk"},
+	}
+	fpEqual(t, "array-order", a, b)
+}
+
+func TestFingerprint_TypeTagPreventsCollision(t *testing.T) {
+	// The whole point of type-tagging + length-prefixing: structurally
+	// different shapes that could otherwise serialize to the same bytes
+	// must produce DIFFERENT fingerprints.
+
+	// "a,b" as a string vs ["a","b"] as an array
+	fpDiffer(t, "string-vs-array", map[string]interface{}{
+		"v": "a,b",
+	}, map[string]interface{}{
+		"v": []interface{}{"a", "b"},
+	})
+
+	// "5" as a string vs 5 as a number
+	fpDiffer(t, "string-vs-int", map[string]interface{}{
+		"v": "5",
+	}, map[string]interface{}{
+		"v": 5,
+	})
+
+	// "ab" as a single string vs "a"+"b" as two-key map
+	fpDiffer(t, "concat-vs-split", map[string]interface{}{
+		"v": "ab",
+	}, map[string]interface{}{
+		"a": "",
+		"b": "",
+	})
+
+	// nil vs empty string
+	fpDiffer(t, "nil-vs-empty", map[string]interface{}{
+		"v": nil,
+	}, map[string]interface{}{
+		"v": "",
+	})
+
+	// nil vs missing field — the missing field changes the map count, so
+	// they must differ.
+	fpDiffer(t, "nil-vs-missing", map[string]interface{}{
+		"v": nil,
+	}, map[string]interface{}{})
+}
+
+func TestFingerprint_NestedMapsAndArrays(t *testing.T) {
+	// Real Mercury shape: top-level map with nested maps (per-storeview
+	// price map) and arrays (extra_images, dynamic_attributes). The
+	// encoder recurses, and key ordering at every level is normalized.
+	a := map[string]interface{}{
+		"name": "Widget",
+		"prices": map[string]interface{}{
+			"us": map[string]interface{}{"ListPrice": "10", "TradePrice": "9"},
+			"uk": map[string]interface{}{"ListPrice": "12", "TradePrice": "11"},
+		},
+		"extra_images": []interface{}{"a.jpg", "b.jpg", "c.jpg"},
+	}
+	b := map[string]interface{}{
+		"extra_images": []interface{}{"c.jpg", "a.jpg", "b.jpg"},
+		"prices": map[string]interface{}{
+			"uk": map[string]interface{}{"TradePrice": "11", "ListPrice": "12"},
+			"us": map[string]interface{}{"TradePrice": "9", "ListPrice": "10"},
+		},
+		"name": "Widget",
+	}
+	fpEqual(t, "nested-shuffled", a, b)
+}
+
+func TestFingerprint_NumberNormalization(t *testing.T) {
+	// CEL evaluates numeric literals to float64 even when the value is a
+	// whole number. The encoder coerces whole-number floats to int so that
+	// e.g. input.qty (an int from JSON) and a CEL projection that arrives
+	// as float64 still match.
+	fpEqual(t, "int-vs-whole-float",
+		map[string]interface{}{"qty": 5},
+		map[string]interface{}{"qty": float64(5.0)},
+	)
+
+	// Non-integer floats are NOT collapsed — different values must
+	// produce different bytes.
+	fpDiffer(t, "different-floats",
+		map[string]interface{}{"v": 1.5},
+		map[string]interface{}{"v": 1.6},
+	)
+
+	// 0 across int and float forms collapses.
+	fpEqual(t, "zero-forms",
+		map[string]interface{}{"v": 0},
+		map[string]interface{}{"v": float64(0)},
+	)
+}
+
+func TestFingerprint_StringLengthPrefix(t *testing.T) {
+	// "a"+"b" projection vs "ab" projection — without length prefixing on
+	// strings, the concatenated bytes could collide. The prefix prevents
+	// this regardless of how the encoder positions adjacent strings.
+	fpDiffer(t, "string-boundary",
+		map[string]interface{}{"x": "a", "y": "b"},
+		map[string]interface{}{"x": "ab", "y": ""},
+	)
+}
+
+func TestFingerprint_BoolsAndNulls(t *testing.T) {
+	// true ≠ false
+	fpDiffer(t, "true-vs-false",
+		map[string]interface{}{"v": true},
+		map[string]interface{}{"v": false},
+	)
+	// true ≠ "true" (type tag protects)
+	fpDiffer(t, "bool-vs-string",
+		map[string]interface{}{"v": true},
+		map[string]interface{}{"v": "true"},
+	)
+	// nil ≠ false
+	fpDiffer(t, "nil-vs-false",
+		map[string]interface{}{"v": nil},
+		map[string]interface{}{"v": false},
+	)
+}
+
+func TestFingerprint_EmptyMapDeterministic(t *testing.T) {
+	// Empty projection is valid (degenerate dedupe — all messages with
+	// the same key are duplicates). Must be deterministic.
+	a := map[string]interface{}{}
+	b := map[string]interface{}{}
+	fpEqual(t, "empty-empty", a, b)
+
+	// And it must differ from a non-empty projection.
+	fpDiffer(t, "empty-vs-one",
+		map[string]interface{}{},
+		map[string]interface{}{"v": nil},
+	)
+}
+
+func TestFingerprint_UnsupportedTypeReturnsError(t *testing.T) {
+	// Types we haven't taught the encoder must error explicitly rather
+	// than silently producing garbage that could equal something else.
+	type customStruct struct{ X int }
+	_, err := Fingerprint(map[string]interface{}{
+		"v": customStruct{X: 1},
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported struct type")
+	}
+}
+
+func TestFingerprint_RealWorldShape(t *testing.T) {
+	// Approximation of the Mercury "products" projection: text fields,
+	// nested price map per-storeview, arrays of images and attributes.
+	// First snapshot is the baseline; second has IDENTICAL content with
+	// shuffled keys at every level → equal fingerprints.
+	baseline := map[string]interface{}{
+		"sku":        "HLS213",
+		"name":       "Widget",
+		"parent_sku": "HLS",
+		"prices": map[string]interface{}{
+			"us":    map[string]interface{}{"ListPrice": "10.00", "TradePrice": "9.00"},
+			"uk":    map[string]interface{}{"ListPrice": "12.00", "TradePrice": "11.00"},
+			"fr_en": map[string]interface{}{"ListPrice": "11.00", "TradePrice": "10.00"},
+		},
+		"websites":     map[string]interface{}{"us": true, "uk": true, "fr": false},
+		"extra_images": []interface{}{"a.jpg", "b.jpg", "c.jpg"},
+		"dynamic_attributes": []interface{}{
+			map[string]interface{}{"key": "color", "value": "red"},
+			map[string]interface{}{"key": "size", "value": "M"},
+		},
+	}
+	shuffled := map[string]interface{}{
+		"dynamic_attributes": []interface{}{
+			map[string]interface{}{"value": "M", "key": "size"},
+			map[string]interface{}{"value": "red", "key": "color"},
+		},
+		"extra_images": []interface{}{"c.jpg", "a.jpg", "b.jpg"},
+		"websites":     map[string]interface{}{"fr": false, "uk": true, "us": true},
+		"prices": map[string]interface{}{
+			"fr_en": map[string]interface{}{"TradePrice": "10.00", "ListPrice": "11.00"},
+			"uk":    map[string]interface{}{"TradePrice": "11.00", "ListPrice": "12.00"},
+			"us":    map[string]interface{}{"TradePrice": "9.00", "ListPrice": "10.00"},
+		},
+		"parent_sku": "HLS",
+		"name":       "Widget",
+		"sku":        "HLS213",
+	}
+	fpEqual(t, "real-world-shuffled", baseline, shuffled)
+
+	// Now flip ONE field — a single price changed — and confirm the
+	// fingerprint actually changes (no false negatives on real edits).
+	changed := map[string]interface{}{
+		"sku":        "HLS213",
+		"name":       "Widget",
+		"parent_sku": "HLS",
+		"prices": map[string]interface{}{
+			"us":    map[string]interface{}{"ListPrice": "10.50", "TradePrice": "9.00"}, // 10.00 → 10.50
+			"uk":    map[string]interface{}{"ListPrice": "12.00", "TradePrice": "11.00"},
+			"fr_en": map[string]interface{}{"ListPrice": "11.00", "TradePrice": "10.00"},
+		},
+		"websites":     map[string]interface{}{"us": true, "uk": true, "fr": false},
+		"extra_images": []interface{}{"a.jpg", "b.jpg", "c.jpg"},
+		"dynamic_attributes": []interface{}{
+			map[string]interface{}{"key": "color", "value": "red"},
+			map[string]interface{}{"key": "size", "value": "M"},
+		},
+	}
+	fpDiffer(t, "real-world-changed-price", baseline, changed)
+}

--- a/internal/runtime/dedupe_integration_test.go
+++ b/internal/runtime/dedupe_integration_test.go
@@ -1,0 +1,417 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/connector/cache/memory"
+	"github.com/matutetandil/mycel/internal/connector/cache/types"
+	"github.com/matutetandil/mycel/internal/flow"
+	msync "github.com/matutetandil/mycel/internal/sync"
+	"github.com/matutetandil/mycel/internal/transform"
+)
+
+// newDedupeHandler builds a FlowHandler wired with an in-memory cache and
+// SyncManager so the dedupe primitive's runtime path can be exercised
+// without any external dependency (Redis, brokers, etc.).
+func newDedupeHandler(t *testing.T) (*FlowHandler, func()) {
+	t.Helper()
+
+	memCache := memory.New("fp_cache", &types.Config{Driver: "memory"})
+	if err := memCache.Connect(context.Background()); err != nil {
+		t.Fatalf("cache connect: %v", err)
+	}
+
+	mgr := msync.NewManager()
+	tr, err := transform.NewCELTransformer()
+	if err != nil {
+		t.Fatalf("transformer: %v", err)
+	}
+
+	cfg := &flow.Config{
+		Name: "test_dedupe",
+		From: &flow.FromConfig{Connector: "rabbit"},
+		Dedupe: &flow.DedupeConfig{
+			Cache:       "fp_cache",
+			Key:         "'sku:' + input.sku",
+			OnDuplicate: "ack",
+			Fingerprint: map[string]string{
+				"name":     "output.name",
+				"price":    "output.price",
+				"websites": "output.websites",
+			},
+			TTL: "1h",
+		},
+	}
+	h := &FlowHandler{
+		Config:      cfg,
+		DedupeCache: memCache,
+		SyncManager: mgr,
+		Transformer: tr,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return h, func() {
+		_ = memCache.Close(context.Background())
+		_ = mgr.Close()
+	}
+}
+
+// TestDedupe_SameMessageTwiceIsDropped is the headline contract: send the
+// same content twice for the same key; the first call goes through, the
+// second is filtered with the configured policy.
+func TestDedupe_SameMessageTwiceIsDropped(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	payload := map[string]interface{}{
+		"name":     "Widget",
+		"price":    10,
+		"websites": map[string]interface{}{"us": true, "uk": true},
+	}
+
+	var calls int32
+	write := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	// First call: cache empty, write runs, fingerprint stored.
+	r1, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, filtered := r1.(*flow.FilteredResultWithPolicy); filtered {
+		t.Fatalf("first call should NOT be filtered; got %#v", r1)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("first call: write calls = %d, want 1", got)
+	}
+
+	// Second call with the same payload: dedupe should drop it without
+	// invoking write.
+	r2, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	filtered, ok := r2.(*flow.FilteredResultWithPolicy)
+	if !ok {
+		t.Fatalf("second call should be filtered; got %T %#v", r2, r2)
+	}
+	if filtered.Policy != "ack" {
+		t.Errorf("filtered.Policy = %q, want ack", filtered.Policy)
+	}
+	if filtered.Reason != "dedupe_match" {
+		t.Errorf("filtered.Reason = %q, want dedupe_match", filtered.Reason)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("second call: write calls = %d, want 1 (no new write)", got)
+	}
+}
+
+// TestDedupe_DifferentContentBothPass: two messages for the same key with
+// DIFFERENT projections both reach the downstream — dedupe must not
+// over-aggregate on key alone.
+func TestDedupe_DifferentContentBothPass(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	payloadA := map[string]interface{}{
+		"name":     "Widget",
+		"price":    10,
+		"websites": map[string]interface{}{"us": true},
+	}
+	payloadB := map[string]interface{}{
+		"name":     "Widget",
+		"price":    11, // real change
+		"websites": map[string]interface{}{"us": true},
+	}
+
+	var calls int32
+	write := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	if _, err := h.dedupeAwareWrite(context.Background(), input, payloadA, write); err != nil {
+		t.Fatalf("A: %v", err)
+	}
+	if _, err := h.dedupeAwareWrite(context.Background(), input, payloadB, write); err != nil {
+		t.Fatalf("B: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("write calls = %d, want 2 (different payloads must both go through)", got)
+	}
+}
+
+// TestDedupe_KeyOrderInsensitive: same content with shuffled top-level
+// keys still matches. This guards the canonicalization path through the
+// runtime (not just the encoder unit tests).
+func TestDedupe_KeyOrderInsensitive(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	payloadA := map[string]interface{}{
+		"name":     "Widget",
+		"price":    10,
+		"websites": map[string]interface{}{"us": true, "uk": false},
+	}
+	// Same content, different map ordering in nested websites map.
+	payloadB := map[string]interface{}{
+		"websites": map[string]interface{}{"uk": false, "us": true},
+		"price":    10,
+		"name":     "Widget",
+	}
+
+	var calls int32
+	write := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	if _, err := h.dedupeAwareWrite(context.Background(), input, payloadA, write); err != nil {
+		t.Fatalf("A: %v", err)
+	}
+	r2, err := h.dedupeAwareWrite(context.Background(), input, payloadB, write)
+	if err != nil {
+		t.Fatalf("B: %v", err)
+	}
+	if _, filtered := r2.(*flow.FilteredResultWithPolicy); !filtered {
+		t.Errorf("B should match A's fingerprint regardless of key order; got %#v", r2)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("write calls = %d, want 1", got)
+	}
+}
+
+// TestDedupe_WriteFailureSkipsCommit: when the downstream `to` errors,
+// Phase B must NOT run, so a retry with the same content actually
+// re-attempts the write. A bug here would silently swallow the retry.
+func TestDedupe_WriteFailureSkipsCommit(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	payload := map[string]interface{}{
+		"name":     "Widget",
+		"price":    10,
+		"websites": map[string]interface{}{"us": true},
+	}
+
+	var calls int32
+	failOnce := errors.New("simulated downstream error")
+	write := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		// Fail the first call, succeed on the retry.
+		if atomic.LoadInt32(&calls) == 1 {
+			return nil, failOnce
+		}
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	// First call: write fails, Phase B must skip the SET.
+	if _, err := h.dedupeAwareWrite(context.Background(), input, payload, write); !errors.Is(err, failOnce) {
+		t.Fatalf("first call: expected failOnce, got %v", err)
+	}
+
+	// Second call: cache should still be empty (SET was skipped), write
+	// must run again.
+	r2, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if _, filtered := r2.(*flow.FilteredResultWithPolicy); filtered {
+		t.Fatalf("second call must NOT be filtered (write failed first time); got %#v", r2)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("write calls = %d, want 2 (first fail + successful retry)", got)
+	}
+
+	// Third call: now Phase B has stored the fingerprint, so the next
+	// identical message IS deduped. Validates the SET actually happened
+	// on the second (successful) attempt.
+	r3, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+	if err != nil {
+		t.Fatalf("third call: %v", err)
+	}
+	if _, filtered := r3.(*flow.FilteredResultWithPolicy); !filtered {
+		t.Errorf("third call should be filtered now that the retry succeeded; got %#v", r3)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("write calls = %d, want still 2 (third call is filtered)", got)
+	}
+}
+
+// TestDedupe_ConcurrentSameFingerprint: many workers race to send the
+// same payload at the same time. The self-lock must serialize them; only
+// the first goroutine to acquire the lock runs the write, the rest see
+// the just-stored fingerprint and drop.
+//
+// Without the self-lock this test would catch the race: multiple
+// goroutines would pass Phase A simultaneously and double-call write.
+func TestDedupe_ConcurrentSameFingerprint(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	payload := map[string]interface{}{
+		"name":     "Widget",
+		"price":    10,
+		"websites": map[string]interface{}{"us": true},
+	}
+
+	var calls int32
+	write := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	const N = 20
+	var wg sync.WaitGroup
+	var filteredCount int32
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+			if err != nil {
+				t.Errorf("goroutine error: %v", err)
+				return
+			}
+			if _, isFiltered := r.(*flow.FilteredResultWithPolicy); isFiltered {
+				atomic.AddInt32(&filteredCount, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("write calls = %d, want exactly 1 across %d concurrent workers", got, N)
+	}
+	if got := atomic.LoadInt32(&filteredCount); got != N-1 {
+		t.Errorf("filtered count = %d, want %d (N-1, all but the winner)", got, N-1)
+	}
+}
+
+// TestDedupe_ConcurrentDifferentKeysParallel: workers with DIFFERENT keys
+// must run in parallel — the self-lock is per-key, not global. We do not
+// assert timing (flaky) but we assert all writes ran and none were
+// filtered (different keys → no shared state).
+func TestDedupe_ConcurrentDifferentKeysParallel(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+
+	payload := map[string]interface{}{
+		"name":     "Widget",
+		"price":    10,
+		"websites": map[string]interface{}{"us": true},
+	}
+
+	var calls int32
+	write := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	const N = 20
+	var wg sync.WaitGroup
+	var filteredCount int32
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			input := map[string]interface{}{"sku": "K" + string(rune('A'+i%26)) + string(rune('A'+i/26))}
+			r, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+			if err != nil {
+				t.Errorf("goroutine error: %v", err)
+				return
+			}
+			if _, isFiltered := r.(*flow.FilteredResultWithPolicy); isFiltered {
+				atomic.AddInt32(&filteredCount, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != N {
+		t.Errorf("write calls = %d, want %d (all distinct keys must go through)", got, N)
+	}
+	if got := atomic.LoadInt32(&filteredCount); got != 0 {
+		t.Errorf("filtered count = %d, want 0 (distinct keys must not collide)", got)
+	}
+}
+
+// TestDedupe_NoConfigZeroOverhead: when Config.Dedupe is nil,
+// dedupeAwareWrite must transparently delegate to write with no cache
+// access and no lock acquisition. Verified by passing a handler with no
+// DedupeCache and no SyncManager — both fields are checked only when
+// dedupe is configured.
+func TestDedupe_NoConfigZeroOverhead(t *testing.T) {
+	h := &FlowHandler{
+		Config: &flow.Config{Name: "no_dedupe", From: &flow.FromConfig{Connector: "rabbit"}},
+		// DedupeCache and SyncManager intentionally nil
+	}
+
+	var calls int32
+	write := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return &connector.Result{Affected: 1}, nil
+	}
+	r, err := h.dedupeAwareWrite(context.Background(), nil, nil, write)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Errorf("write should run exactly once; got %d", atomic.LoadInt32(&calls))
+	}
+	if _, ok := r.(*connector.Result); !ok {
+		t.Errorf("expected pass-through Result, got %T", r)
+	}
+}
+
+// TestDedupe_OnDuplicatePolicyPropagates: the configured on_duplicate
+// value (ack | reject | requeue) is what the MQ consumer reads from the
+// FilteredResultWithPolicy. Ensure all three values round-trip.
+func TestDedupe_OnDuplicatePolicyPropagates(t *testing.T) {
+	for _, policy := range []string{"ack", "reject", "requeue"} {
+		t.Run(policy, func(t *testing.T) {
+			h, done := newDedupeHandler(t)
+			defer done()
+			h.Config.Dedupe.OnDuplicate = policy
+
+			input := map[string]interface{}{"sku": "X1"}
+			payload := map[string]interface{}{
+				"name":     "W",
+				"price":    1,
+				"websites": map[string]interface{}{"us": true},
+			}
+			write := func() (interface{}, error) {
+				return &connector.Result{Affected: 1}, nil
+			}
+
+			if _, err := h.dedupeAwareWrite(context.Background(), input, payload, write); err != nil {
+				t.Fatalf("first: %v", err)
+			}
+			r, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+			if err != nil {
+				t.Fatalf("second: %v", err)
+			}
+			filtered, ok := r.(*flow.FilteredResultWithPolicy)
+			if !ok {
+				t.Fatalf("expected FilteredResultWithPolicy, got %T", r)
+			}
+			if filtered.Policy != policy {
+				t.Errorf("Policy = %q, want %q", filtered.Policy, policy)
+			}
+		})
+	}
+}

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -342,27 +342,9 @@ func (h *FlowHandler) HandleRequest(ctx context.Context, input map[string]interf
 		}
 	}
 
-	// Check for duplicate messages (deduplication)
-	if h.Config.Dedupe != nil {
-		dedupeResult, dedupeErr := trace.RecordStage(ctx, trace.StageDedupe, "", input, func() (interface{}, error) {
-			isDup, err := h.checkDedupe(ctx, input)
-			if err != nil {
-				return nil, err
-			}
-			return isDup, nil
-		})
-		if dedupeErr != nil {
-			return nil, fmt.Errorf("dedupe check error: %w", dedupeErr)
-		}
-		isDuplicate, _ := dedupeResult.(bool)
-		if isDuplicate {
-			if h.Config.Dedupe.OnDuplicate == "fail" {
-				return nil, fmt.Errorf("duplicate message detected")
-			}
-			// Default: skip silently
-			return flow.DuplicateResult, nil
-		}
-	}
+	// Dedupe (biphasic, content-based) runs inside the core after transform —
+	// Phase A between transform and `to`, Phase B after `to` succeeds. Hook
+	// wiring lands in a later checkpoint; here the config is just parsed.
 
 	// Async execution — return 202 immediately, process in background
 	if h.Config.Async != nil {
@@ -741,93 +723,6 @@ func (h *FlowHandler) evaluateIDField(ctx context.Context, input map[string]inte
 		return s, nil
 	}
 	return fmt.Sprintf("%v", result), nil
-}
-
-// checkDedupe checks if a message is a duplicate based on the dedupe configuration.
-// Returns true if the message is a duplicate, false otherwise.
-// If not a duplicate, stores the key in the cache with the configured TTL.
-func (h *FlowHandler) checkDedupe(ctx context.Context, input map[string]interface{}) (bool, error) {
-	dedupe := h.Config.Dedupe
-	if dedupe == nil {
-		return false, nil
-	}
-
-	// Initialize transformer if needed
-	if h.Transformer == nil {
-		var err error
-		celOptions := transform.CreateWASMFunctionOptions(h.FunctionsRegistry)
-		h.Transformer, err = transform.NewCELTransformerWithOptions(celOptions...)
-		if err != nil {
-			return false, fmt.Errorf("failed to create CEL transformer: %w", err)
-		}
-	}
-
-	// Evaluate the key expression
-	data := map[string]interface{}{
-		"input": input,
-	}
-
-	keyResult, err := h.Transformer.EvaluateExpression(ctx, data, nil, dedupe.Key)
-	if err != nil {
-		return false, fmt.Errorf("dedupe key evaluation error: %w", err)
-	}
-
-	// Convert key to string
-	var dedupeKey string
-	switch v := keyResult.(type) {
-	case string:
-		dedupeKey = v
-	default:
-		dedupeKey = fmt.Sprintf("%v", v)
-	}
-
-	if dedupeKey == "" {
-		return false, fmt.Errorf("dedupe key evaluated to empty string")
-	}
-
-	// Prefix the key to avoid collisions
-	cacheKey := "dedupe:" + h.Config.Name + ":" + dedupeKey
-
-	// Get the storage connector
-	storageConn, err := h.Connectors.Get(dedupe.Storage)
-	if err != nil {
-		return false, fmt.Errorf("dedupe storage connector not found: %s: %w", dedupe.Storage, err)
-	}
-
-	// Check if key exists using the cache interface
-	cacheStorage, ok := storageConn.(cache.Cache)
-	if !ok {
-		return false, fmt.Errorf("dedupe storage %s does not implement cache interface", dedupe.Storage)
-	}
-
-	// Try to get the key
-	_, exists, err := cacheStorage.Get(ctx, cacheKey)
-	if err != nil {
-		// Log error but continue (fail open to avoid blocking messages on cache errors)
-		// In production, you might want different behavior
-		return false, nil
-	}
-
-	if exists {
-		// Duplicate found
-		return true, nil
-	}
-
-	// Not a duplicate - store the key with TTL
-	ttl := time.Hour // Default TTL
-	if dedupe.TTL != "" {
-		if d, parseErr := time.ParseDuration(dedupe.TTL); parseErr == nil {
-			ttl = d
-		}
-	}
-
-	// Store a simple marker value
-	if setErr := cacheStorage.Set(ctx, cacheKey, []byte("1"), ttl); setErr != nil {
-		// Log error but continue (fail open)
-		// The message will be processed even if we can't store the dedup key
-	}
-
-	return false, nil
 }
 
 // executeAsync returns 202 immediately and processes the flow in the background.

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -118,6 +118,12 @@ type FlowHandler struct {
 	// CacheConnector is the cache connector for this flow (if configured).
 	CacheConnector cache.Cache
 
+	// DedupeCache is the cache connector used by the dedupe primitive to
+	// store fingerprints. Resolved at flow registration from
+	// Config.Dedupe.Cache so the hot path does not pay a connector
+	// registry lookup per message. nil when Config.Dedupe is unset.
+	DedupeCache cache.Cache
+
 	// NamedCaches allows lookup of named cache definitions.
 	NamedCaches map[string]*flow.NamedCacheConfig
 
@@ -2068,11 +2074,19 @@ func (h *FlowHandler) handleCreate(ctx context.Context, input map[string]interfa
 		}, nil
 	}
 
-	writeResult, writeErr := trace.RecordStage(ctx, trace.StageWrite, data.Target, trace.Snapshot(data.Payload), func() (interface{}, error) {
-		return dest.Write(ctx, data)
+	writeResult, writeErr := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
+		return trace.RecordStage(ctx, trace.StageWrite, data.Target, trace.Snapshot(data.Payload), func() (interface{}, error) {
+			return dest.Write(ctx, data)
+		})
 	})
 	if writeErr != nil {
 		return nil, writeErr
+	}
+	// Dedupe match: propagate the filtered result as-is so the MQ consumer
+	// can ack/reject/requeue per the configured policy. Skip the connector
+	// result unwrap below — there is no connector.Result on this path.
+	if filtered, ok := writeResult.(*flow.FilteredResultWithPolicy); ok {
+		return filtered, nil
 	}
 	result := writeResult.(*connector.Result)
 
@@ -2170,10 +2184,16 @@ func (h *FlowHandler) handleUpdate(ctx context.Context, input map[string]interfa
 		}, nil
 	}
 
-	result, err := dest.Write(ctx, data)
+	writeResult, err := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
+		return dest.Write(ctx, data)
+	})
 	if err != nil {
 		return nil, err
 	}
+	if filtered, ok := writeResult.(*flow.FilteredResultWithPolicy); ok {
+		return filtered, nil
+	}
+	result := writeResult.(*connector.Result)
 
 	// If raw SQL returned rows (e.g., UPDATE ... RETURNING), return those
 	if len(result.Rows) > 0 {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1212,6 +1212,22 @@ func (r *Runtime) registerFlows() error {
 			DebugServer:        r.debugServer,
 		}
 
+		// Resolve the dedupe cache connector once at registration so the
+		// hot path does not pay a connector lookup per message. A
+		// misconfigured reference here is a fatal startup error — silent
+		// fallback would defeat the dedupe contract entirely.
+		if cfg.Dedupe != nil {
+			cacheConn, err := r.connectors.Get(cfg.Dedupe.Cache)
+			if err != nil {
+				return fmt.Errorf("flow %q: dedupe cache connector %q not found: %w", cfg.Name, cfg.Dedupe.Cache, err)
+			}
+			cacheImpl, ok := cacheConn.(cache.Cache)
+			if !ok {
+				return fmt.Errorf("flow %q: dedupe cache %q does not implement the cache interface (got %T)", cfg.Name, cfg.Dedupe.Cache, cacheConn)
+			}
+			handler.DedupeCache = cacheImpl
+		}
+
 		r.flows.Register(cfg.Name, handler)
 
 		// Schedule flow if it has a cron/interval trigger

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -342,12 +342,20 @@ func ErrorHandlingSchema() Block {
 func DedupeSchema() Block {
 	return Block{
 		Type: "dedupe",
-		Doc:  "Deduplication configuration",
+		Doc:  "Content-based, biphasic deduplication. Compares a canonical fingerprint of a named projection of the message against the previously-stored fingerprint for the same key; on match, drops without invoking `to`. Stores the new fingerprint only after `to` succeeds.",
 		Attrs: []Attr{
-			{Name: "storage", Doc: "Storage connector for dedup state", Type: TypeString, Required: true, Ref: RefConnector},
-			{Name: "key", Doc: "CEL expression for the deduplication key", Type: TypeString, Required: true},
-			{Name: "ttl", Doc: "How long to remember seen keys", Type: TypeDuration},
-			{Name: "on_duplicate", Doc: "Behavior on duplicate", Type: TypeString, Values: []string{"skip", "fail"}},
+			{Name: "cache", Doc: "Cache-typed connector used to store fingerprints", Type: TypeString, Required: true, Ref: RefConnector},
+			{Name: "key", Doc: "CEL expression for the per-resource fingerprint key (evaluated against input.*)", Type: TypeString, Required: true},
+			{Name: "ttl", Doc: "How long to keep stored fingerprints after the last update", Type: TypeDuration},
+			{Name: "on_duplicate", Doc: "Behavior on fingerprint match", Type: TypeString, Values: []string{"ack", "reject", "requeue"}},
+		},
+		Children: []Block{
+			{
+				Type:  "fingerprint",
+				Doc:   "Named CEL expressions whose values form the projection. Must list every field the flow persists downstream — omitting one would silently drop real changes. Both input.* and output.* (transform result) are in scope.",
+				Open:  true,
+				Attrs: []Attr{},
+			},
 		},
 	}
 }

--- a/tests/integration/config/connectors/dedupe.mycel
+++ b/tests/integration/config/connectors/dedupe.mycel
@@ -1,0 +1,7 @@
+// Cache connector used by the dedupe primitive to store fingerprints.
+// Memory driver so the test does not need a Redis container; the dedupe
+// runtime behaviour is identical across drivers.
+connector "dedupe_cache" {
+  type   = "cache"
+  driver = "memory"
+}

--- a/tests/integration/config/flows/dedupe.mycel
+++ b/tests/integration/config/flows/dedupe.mycel
@@ -1,0 +1,46 @@
+// End-to-end functional test for the dedupe primitive.
+//
+// Pipeline:
+//   POST /test/dedupe → transform → dedupe → external_api POST /dedupe-target
+//
+// The bash test exercises three scenarios in sequence against the same SKU:
+//   1. POST with content A → expected to reach mock (first time)
+//   2. POST with content A again → expected to be dropped by dedupe
+//   3. POST with content B (different price) → expected to reach mock
+//
+// Plus a fourth POST with a different SKU to assert the per-key isolation:
+//   4. POST with different SKU but same content as A → expected to reach mock
+//      (different key, no shared dedupe state)
+//
+// The assertion is on the mock-server's captured request count at the
+// /dedupe-target path: exactly 3 captures across the 4 POSTs.
+flow "dedupe_test_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/dedupe"
+  }
+
+  transform {
+    sku   = "input.sku"
+    name  = "input.name"
+    price = "input.price"
+  }
+
+  dedupe {
+    cache        = "dedupe_cache"
+    key          = "'sku:' + input.sku"
+    ttl          = "10m"
+    on_duplicate = "ack"
+    fingerprint {
+      sku   = "output.sku"
+      name  = "output.name"
+      price = "output.price"
+    }
+  }
+
+  to {
+    connector = "external_api"
+    target    = "/dedupe-target"
+    operation = "POST"
+  }
+}

--- a/tests/integration/config/flows/dedupe.mycel
+++ b/tests/integration/config/flows/dedupe.mycel
@@ -29,7 +29,7 @@ flow "dedupe_test_flow" {
   dedupe {
     cache        = "dedupe_cache"
     key          = "'sku:' + input.sku"
-    ttl          = "10m"
+    ttl          = "30d"
     on_duplicate = "ack"
     fingerprint {
       sku   = "output.sku"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -154,6 +154,7 @@ else
     scripts/test-plugin.sh
     scripts/test-new-features.sh
     scripts/test-fanout.sh
+    scripts/test-dedupe.sh
   )
 fi
 
@@ -224,7 +225,7 @@ else
       rate-limit)
         SOLO_FILES+=("$test_file")
         ;;
-      http-client|notifications)
+      http-client|notifications|dedupe)
         MOCK_FILES+=("$test_file")
         ;;
       *)

--- a/tests/integration/scripts/test-dedupe.sh
+++ b/tests/integration/scripts/test-dedupe.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Test: dedupe primitive end-to-end through the REST → dedupe → mock pipeline.
+# Validates that duplicate content is dropped before reaching the downstream,
+# while real changes and distinct keys go through.
+source "$(dirname "$0")/lib.sh"
+
+echo "=== Dedupe ==="
+
+# Clear any captured mock requests so the test starts from a known state.
+mock_clear
+
+# POST #1 — first message with SKU=A, price=10. Cache is empty → must reach
+# the mock.
+status=$(http_status POST "$BASE/test/dedupe" '{"sku":"A","name":"Widget","price":10}')
+assert_status "POST #1 (new SKU=A, price=10) returns 200" "200" "$status"
+
+# POST #2 — identical to #1. Phase A finds the just-stored fingerprint and
+# drops without calling the downstream.
+status=$(http_status POST "$BASE/test/dedupe" '{"sku":"A","name":"Widget","price":10}')
+assert_status "POST #2 (duplicate of #1) returns 200" "200" "$status"
+
+# POST #3 — SKU=A but different price. Fingerprint differs from stored →
+# must reach the mock.
+status=$(http_status POST "$BASE/test/dedupe" '{"sku":"A","name":"Widget","price":11}')
+assert_status "POST #3 (SKU=A with changed price) returns 200" "200" "$status"
+
+# POST #4 — different SKU (B) with same content shape as A. Different key,
+# so the dedupe cache is separate. Must reach the mock.
+status=$(http_status POST "$BASE/test/dedupe" '{"sku":"B","name":"Widget","price":10}')
+assert_status "POST #4 (different SKU=B) returns 200" "200" "$status"
+
+# POST #5 — duplicate of #4. Should be dropped.
+status=$(http_status POST "$BASE/test/dedupe" '{"sku":"B","name":"Widget","price":10}')
+assert_status "POST #5 (duplicate of #4) returns 200" "200" "$status"
+
+# Give the writes a moment to land in the mock's request log.
+sleep 1
+
+# Count mock captures at /dedupe-target. Expected: exactly 3 (POSTs 1, 3, 4).
+# POSTs 2 and 5 should have been dropped by dedupe before the to-block ran.
+captures=$(mock_requests "/dedupe-target")
+count=$(echo "$captures" | jq 'length' 2>/dev/null)
+
+if [[ "$count" == "3" ]]; then
+  echo "  ✓ Mock received exactly 3 downstream calls (2 of 5 deduped)"
+  ((PASS++))
+else
+  echo "  ✗ Mock received $count downstream calls; expected 3 (POSTs 1, 3, 4)"
+  echo "    Full capture:"
+  echo "$captures" | jq -r '.[] | "      \(.method) \(.path) body=\(.body)"' 2>/dev/null || echo "$captures"
+  ((FAIL++))
+fi
+
+# Verify the three captured bodies are the right ones — POSTs 1, 3, 4 in
+# arrival order. The mock stores body as a JSON string; parse it with a
+# second jq pass so key ordering is irrelevant.
+expected_skus=("A" "A" "B")
+expected_prices=("10" "11" "10")
+labels=(
+  "POST #1 (SKU=A price=10)"
+  "POST #3 (SKU=A price=11)"
+  "POST #4 (SKU=B price=10)"
+)
+for i in 0 1 2; do
+  body=$(echo "$captures" | jq -r ".[$i].body" 2>/dev/null)
+  sku=$(echo "$body" | jq -r '.sku' 2>/dev/null)
+  price=$(echo "$body" | jq -r '.price' 2>/dev/null)
+  if [[ "$sku" == "${expected_skus[$i]}" && "$price" == "${expected_prices[$i]}" ]]; then
+    echo "  ✓ Mock capture #$((i+1)) is ${labels[$i]}"
+    ((PASS++))
+  else
+    echo "  ✗ Mock capture #$((i+1)) expected ${labels[$i]} but body was: $body"
+    ((FAIL++))
+  fi
+done
+
+# Cleanup so a re-run starts from a clean mock state.
+mock_clear
+
+report


### PR DESCRIPTION
## Summary

Adds a content-based, biphasic `dedupe {}` primitive that drops no-op messages **before** forwarding them to a slow downstream — typical example: an upstream publisher re-sends product updates even when nothing relevant changed, each one takes seconds to process downstream, queue accumulates.

Two-phase contract:

- **Phase A (before `to`)**: compute a canonical fingerprint over the user-specified projection, GET the previously stored fingerprint for the key, compare byte-for-byte. On match → drop according to `on_duplicate` (`ack`/`reject`/`requeue`) without invoking `to`.
- **Phase B (after `to` ONLY on success)**: SET the new fingerprint. A failed-then-retried message will not self-discard.

Both phases run under an in-process lock keyed on `dedupe.key` (via `SyncManager.ExecuteWithLock` with memory backend), so two workers cannot both pass Phase A with identical fingerprints and double-call the downstream. Cross-process serialization is the caller's responsibility via the existing `lock {}` block.

### HCL surface (new)

```hcl
connector "fp_cache" {
  type   = "cache"
  driver = "redis"   // or "memory" for tests
}

flow "item_update" {
  ...
  transform { name = "...", prices = "...", websites = "...", ... }

  dedupe {
    cache        = "fp_cache"
    key          = "'sku_fp:' + input.body.payload.productItemId"
    ttl          = "30d"
    on_duplicate = "ack"      // ack | reject | requeue (sequence_guard vocabulary)
    fingerprint {
      name     = "output.name"
      prices   = "output.prices"
      websites = "output.websites"
      // ... one entry per persisted field
    }
  }

  to { ... }
}
```

The `fingerprint` block is required and must declare at least one entry — silent defaults would risk dropping real changes when the author forgets to enumerate the projection. `cache` is a reference to a `connector "cache"`-typed connector (driver: `memory` for tests, `redis` for prod). The pool is initialized once at startup; the hot path does not pay a registry lookup per message.

### ⚠️ BREAKING — replaces the existing `dedupe {}`

Mycel already had a `dedupe {}` block, but it was conceptually different (key-based message-ID dedup, "have I seen this key before?") AND had a correctness bug: the marker was stored eagerly before the inner exec ran, so a failed `to` followed by broker redelivery would see the marker and silently drop the message, losing real work.

The new block replaces it entirely. Migration:

```hcl
# v1.x
dedupe {
  storage      = "redis_cache"
  key          = "input.message_id"
  ttl          = "1h"
  on_duplicate = "skip"
}

# v2.1.0+
dedupe {
  cache        = "redis_cache"
  key          = "input.message_id"
  ttl          = "1h"
  on_duplicate = "ack"
  fingerprint {
    id = "input.message_id"
  }
}
```

The two examples in `examples/steps/flows.mycel` are migrated in this PR.

## Canonical fingerprint encoder

`internal/runtime/dedupe_fingerprint.go` (pure function, no I/O):

- Map keys sorted alphabetically before serialization.
- Array elements sorted by their own encoded bytes (treated as order-insensitive sets).
- Type-tagged (`s` string, `i` int, `m` map, `a` array, ...) and length-prefixed so e.g. the string `"a,b"` cannot collide with the array `["a","b"]`.
- Whole-number floats normalize to ints so `float64(5.0)` and `int64(5)` produce identical bytes (CEL evaluates numeric literals to float64).
- Full bytes stored (no hashing) — zero risk of hash collision; future opt-in for SHA-256 hashing left as a knob.

## Implementation breakdown

Five commits, each leaving the repo in a coherent state:

| Commit | Checkpoint | Contents |
|---|---|---|
| `e7488bb` | 1 | Foundation: `DedupeConfig` struct, parser, schema, 2 examples migrated, parser tests |
| `0934d86` | 2 | `Fingerprint()` encoder + 11 unit tests covering type-tags, length-prefix, sort, nested, number normalization, real-world Mercury-shape |
| `f1a406e` | 3 | `dedupeAwareWrite` + cache resolution at flow registration + `handleCreate`/`handleUpdate` instrumented |
| `e3f6d05` | 4 | 8 runtime integration tests (including 20-goroutine race test) + `examples/dedupe/` HCL example |
| `462928c` | (extra) | Functional integration test through docker-compose: 5 POSTs → mock-server receives 3 (2 deduped) |

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — 70 packages, 0 regressions
- [x] **Parser tests** (4) — block syntax, default `on_duplicate=ack`, rejects `on_duplicate=skip`, requires `fingerprint` block
- [x] **Fingerprint encoder tests** (11) — determinism, key/array order independence, type-tag collision prevention, number normalization, real Mercury-shape projection
- [x] **Runtime integration tests** (8) — same-message-twice / different-content / write-failure-skips-commit / 20-goroutine-race / per-key parallelism / zero-overhead-when-unconfigured / on_duplicate policy round-trip
- [x] **Functional end-to-end** — `tests/integration/run.sh` registers `test-dedupe.sh`: 5 POSTs through REST → dedupe → mock-server, verifies exactly 3 captures (2 deduped) in arrival order. **143/0 total in the suite**.
- [x] `mycel validate --config ./examples/dedupe` passes.

## What this PR does NOT include

- **Piece 1 from the original spec** (cache as flow-invocable step/to). Dedupe does not need it (it accesses the cache directly via Go reference). Left for a separate PR.
- **Hashing the fingerprint** (`dedupe.compact = true` with SHA-256). Documented as a future knob; v1 stores full bytes so any divergence is auditable.
- **Cross-process self-locking**. The dedupe-internal lock is in-process only. For multi-pod deployments, the user's outer `lock {}` block handles cross-process serialization (Mercury already has this).
- **Connector operation metrics for dedupe** (could surface `mycel_dedupe_hits_total{flow}` / `mycel_dedupe_misses_total{flow}`). Worth a follow-up if Mercury wants Grafana dashboards on dedup hit-rate.

## Version

This is `v2.1.0` after merge — additive feature plus the dedupe-block replacement.

The replacement IS a breaking change for anyone who had `dedupe { storage = ..., on_duplicate = "skip|fail" }` configured. The two in-tree examples are migrated. The release notes will spell out the migration above.