### PR TITLE
docs: align all references with v2.1.0 dedupe primitive

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -243,7 +243,7 @@ All core features are implemented and production-ready. The roadmap below reflec
 - ✅ **on_error with retry + DLQ**: exponential backoff, dead letter queues
 - ✅ **merge / omit / pick**: object manipulation helpers in transforms
 - ✅ **multi-to**: fan-out to multiple targets
-- ✅ **dedupe**: deduplication with storage backend, TTL, and `on_duplicate` policy
+- ✅ **dedupe**: content-based biphasic deduplication (since v2.1.0). Compares a canonical fingerprint of the persisted projection against the last stored fingerprint for the same key; drops no-ops before reaching the downstream. `cache` connector, `fingerprint {}` projection, `on_duplicate` policy (`ack`/`reject`/`requeue`), self-locking per key
 
 ### Phase 8 - GraphQL Query Optimization (Complete)
 - ✅ **Field Analyzer**: parses incoming queries to determine requested fields

--- a/docs/STUDIO-DEBUG-PROTOCOL.md
+++ b/docs/STUDIO-DEBUG-PROTOCOL.md
@@ -1179,7 +1179,7 @@ These are the `trace.Stage` constants that can be used in breakpoints:
 | `sanitize` | `StageSanitize` | Input sanitization (XSS, injection prevention) |
 | `filter` | `StageFilter` | `from.filter` CEL condition evaluation |
 | `accept` | `StageAccept` | `accept` gate — business-level condition |
-| `dedupe` | `StageDedupe` | Deduplication check |
+| `dedupe` | `StageDedupe` | Content-based deduplication check (since v2.1.0: runs after transform, compares canonical fingerprint of the projection against the last stored value for the key) |
 | `validate_input` | `StageValidateIn` | Input type validation |
 | `enrich` | `StageEnrich` | Data enrichment from external sources |
 | `transform` | `StageTransform` | CEL transformation rules |
@@ -1195,10 +1195,12 @@ These are the `trace.Stage` constants that can be used in breakpoints:
 A typical flow executes stages in this order:
 
 ```
-input → sanitize → filter → accept → dedupe → validate_input → enrich → transform → step(s) → validate_output → write/read → response
+input → sanitize → filter → accept → validate_input → enrich → step(s) → transform → dedupe → validate_output → write/read → response
 ```
 
 Not all stages are present in every flow. Stages are skipped if not configured (e.g., no `validate` block → skip `validate_input`).
+
+**Note:** since v2.1.0 the `dedupe` stage runs **after** `transform` — the content-based primitive needs the transformed payload (`output.*`) to compute the fingerprint. Earlier versions ran the (key-based) dedupe before transform.
 
 ---
 

--- a/docs/core-concepts/flows.md
+++ b/docs/core-concepts/flows.md
@@ -145,8 +145,10 @@ flow "handle_type_b2" {
 ### Pipeline position
 
 ```
-from → filter → accept → dedupe → validate → enrich/steps → transform → to
+from → filter → accept → validate → enrich/steps → transform → dedupe → to
 ```
+
+Since v2.1.0 the `dedupe` block runs **after** `transform` — the content-based primitive needs the transformed payload (`output.*`) to compute its fingerprint. Earlier versions ran the (key-based) dedupe before transform.
 
 ## The `to` Block
 
@@ -613,20 +615,38 @@ flow "update_product" {
 
 ## Dedupe Block
 
-Prevent processing duplicate events (useful for message queues):
+Drop **no-op** messages before reaching the downstream by comparing a canonical fingerprint of the persisted projection against the last stored fingerprint for the same key. Phase A runs after `transform` and before `to`; Phase B stores the new fingerprint only if `to` succeeds, so a failed-then-retried message does not self-discard. The primitive self-locks per key so two workers cannot double-call the downstream with identical content.
+
+Useful for MQ consumers where the upstream re-sends update messages even when nothing relevant changed.
 
 ```hcl
+connector "fp_cache" {
+  type   = "cache"
+  driver = "redis"   # or "memory" for tests
+}
+
 flow "process_payment" {
   from {
     connector = "rabbit"
     operation = "payments"
   }
 
+  transform {
+    payment_id = "input.payment_id"
+    account_id = "input.account_id"
+    amount     = "input.amount"
+  }
+
   dedupe {
-    storage      = "redis_cache"
-    key          = "input.payment_id"
+    cache        = "fp_cache"
+    key          = "'payment:' + input.payment_id"
     ttl          = "24h"
-    on_duplicate = "skip"  # "skip" or "error"
+    on_duplicate = "ack"      # ack | reject | requeue (sequence_guard vocabulary)
+    fingerprint {
+      payment_id = "output.payment_id"
+      account_id = "output.account_id"
+      amount     = "output.amount"
+    }
   }
 
   to {
@@ -635,6 +655,18 @@ flow "process_payment" {
   }
 }
 ```
+
+| Attribute | Required | Description |
+|---|---|---|
+| `cache` | yes | Name of a `connector { type = "cache" }` used to store fingerprints. Pool is initialized once at startup; the hot path does not pay a registry lookup per message |
+| `key` | yes | CEL expression for the per-resource fingerprint key (evaluated against `input.*`) |
+| `fingerprint {}` | yes | Block of named CEL expressions whose values form the projection; must list every persisted field — omitting one would silently drop real changes |
+| `ttl` | no | How long to keep stored fingerprints. Supports `"30d"` and `"2w"` plus stdlib units; malformed values fail the parse |
+| `on_duplicate` | no | Behavior on match: `"ack"` (default), `"reject"`, `"requeue"` |
+
+**Pipeline order:** `dedupe` runs **after** `transform` because the fingerprint references `output.*` (the transformed payload). Earlier versions ran the (key-based) dedupe before transform — see CHANGELOG v2.1.0 for migration.
+
+**Array order-insensitivity:** the canonical encoder sorts array elements before serialization, treating them as order-insensitive sets. Reshape order-sensitive arrays into delimited strings in `transform` before dedupe sees them.
 
 ## Error Handling Block
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -101,10 +101,15 @@ flow "process_payment" {
   }
 
   dedupe {
-    storage      = "connector.redis"
-    key          = "input.payment_id"
+    cache        = "redis"
+    key          = "'payment:' + input.payment_id"
     ttl          = "24h"
-    on_duplicate = "skip"
+    on_duplicate = "ack"
+    fingerprint {
+      payment_id = "input.payment_id"
+      amount     = "input.amount"
+      account_id = "input.account_id"
+    }
   }
 
   error_handling {

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -1,6 +1,6 @@
 # Caching
 
-Mycel provides two flow-level caching mechanisms: **cache** for avoiding repeated calls by storing results, and **dedupe** for preventing duplicate processing of the same message or request.
+Mycel provides two flow-level caching mechanisms: **cache** for avoiding repeated reads by storing results, and **dedupe** (since v2.1.0) for dropping **no-op** writes whose persisted projection is byte-identical to the last one processed for the same key.
 
 ## Cache Setup
 
@@ -171,20 +171,40 @@ flow "update_product" {
 
 ## Deduplication
 
-The `dedupe` block prevents processing the same message or request more than once. Essential for message queue consumers where messages can be delivered more than once.
+Since v2.1.0 the `dedupe` block is **content-based** and runs in two phases. Phase A (after `transform`, before `to`) computes a canonical fingerprint over the projection the operator declares and compares it byte-for-byte to the stored fingerprint for the same key; on match the message is dropped according to `on_duplicate` without invoking `to`. Phase B (after `to` succeeds) stores the new fingerprint, so a failed-then-retried message will not self-discard.
+
+The primitive self-locks per key (in-process via the memory-backed `SyncManager`) so two workers cannot both pass Phase A with identical fingerprints and double-call the downstream. For cross-process serialization across multiple Mycel pods, compose with an outer `lock {}` block on the same resource key.
+
+The typical use case is an MQ consumer where the upstream re-sends "update" messages even when nothing relevant changed: every redelivery hits a slow downstream and the queue accumulates. With dedupe, only messages whose persisted projection actually differs reach the downstream.
 
 ```hcl
+connector "fp_cache" {
+  type   = "cache"
+  driver = "redis"   # or "memory" for tests / single-pod
+}
+
 flow "process_payment" {
   from {
     connector = "rabbit"
     operation = "payments"
   }
 
+  transform {
+    payment_id = "input.payment_id"
+    account_id = "input.account_id"
+    amount     = "input.amount"
+  }
+
   dedupe {
-    storage      = "redis_cache"
-    key          = "input.payment_id"
+    cache        = "fp_cache"
+    key          = "'payment:' + input.payment_id"
     ttl          = "24h"
-    on_duplicate = "skip"
+    on_duplicate = "ack"
+    fingerprint {
+      payment_id = "output.payment_id"
+      account_id = "output.account_id"
+      amount     = "output.amount"
+    }
   }
 
   to {
@@ -198,19 +218,27 @@ flow "process_payment" {
 
 | Attribute | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `storage` | string | yes | — | Cache connector name |
-| `key` | string | yes | — | CEL expression to compute the unique message key |
-| `ttl` | string | no | — | How long to remember processed message IDs |
-| `on_duplicate` | string | no | `"skip"` | What to do with duplicates: `"skip"` or `"error"` |
+| `cache` | string | yes | — | Name of a `connector { type = "cache" }`. The connector pool is initialized once at startup; the hot path does not pay a registry lookup per message |
+| `key` | string | yes | — | CEL expression for the per-resource fingerprint key (evaluated against `input.*`) |
+| `fingerprint {}` | block | yes | — | Named CEL expressions whose values form the projection. Both `input.*` and `output.*` (transform result) are in scope. Must list every persisted field — omitting one would silently drop real changes |
+| `ttl` | string | no | — | How long to keep stored fingerprints. Supports `"30d"` and `"2w"` plus stdlib units (`s`/`m`/`h`); malformed values fail the parse |
+| `on_duplicate` | string | no | `"ack"` | Behavior on fingerprint match: `"ack"`, `"reject"`, `"requeue"`. Matches the `sequence_guard` vocabulary so MQ consumers handle it uniformly |
 
-### Dedupe with Complex Keys
+### Pipeline order
+
+The `dedupe` block runs **after** `transform`. The fingerprint expressions reference `output.*` (the transformed payload), so transform must run first. Earlier versions (≤ 2.0.0) had a key-based dedupe block that ran before transform; see CHANGELOG v2.1.0 for migration.
+
+### Array order-insensitivity
+
+The canonical encoder sorts array elements before serialization, treating them as **order-insensitive sets**. This is appropriate for projections like "list of attribute values" or "set of website flags," but **lossy** for fields where order is semantically meaningful (e.g. a ranked list where position encodes priority).
+
+For order-sensitive arrays, reshape them in `transform` before dedupe sees them — join with a delimiter into a single string:
 
 ```hcl
-dedupe {
-  storage      = "redis_cache"
-  key          = "'order:' + input.order_id + ':' + input.event_type"
-  ttl          = "1h"
-  on_duplicate = "skip"
+transform {
+  # Bad: ranked_tags as an array would lose order in the fingerprint.
+  # Good: join into a string so order is part of the encoded value.
+  ranked_tags = "input.ranked_tags.map(t, t).join(',')"
 }
 ```
 
@@ -218,11 +246,12 @@ dedupe {
 
 | | Cache | Dedupe |
 |--|-------|--------|
-| Purpose | Avoid redundant reads | Prevent duplicate processing |
+| Purpose | Avoid redundant downstream reads | Drop no-op writes |
 | Applies to | Read flows | Write flows (especially MQ consumers) |
-| Cache miss | Execute `to` block, cache result | Process normally |
-| Cache hit | Return cached value immediately | Skip the flow execution |
-| Key source | Request parameters | Message content |
+| Cache miss | Execute `to`, cache result | Process normally; store fingerprint after `to` success |
+| Cache hit | Return cached value immediately | Drop without invoking `to` |
+| Compares | Key only | Canonical content fingerprint |
+| Pipeline position | Before `to` (read path) | After `transform`, before `to` |
 
 ## Production Considerations
 
@@ -280,18 +309,29 @@ flow "update_product" {
   }
 }
 
-# Deduplicate webhook events
+# Deduplicate no-op inventory updates by content
 flow "handle_inventory_update" {
   from {
     connector = "rabbit"
     operation = "inventory.updated"
   }
 
+  transform {
+    product_id  = "input.product_id"
+    stock_qty   = "input.stock_qty"
+    reorder_at  = "input.reorder_at"
+  }
+
   dedupe {
-    storage      = "redis_cache"
-    key          = "input.event_id"
+    cache        = "redis_cache"
+    key          = "'inv_fp:' + input.product_id"
     ttl          = "1h"
-    on_duplicate = "skip"
+    on_duplicate = "ack"
+    fingerprint {
+      product_id = "output.product_id"
+      stock_qty  = "output.stock_qty"
+      reorder_at = "output.reorder_at"
+    }
   }
 
   to {

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -227,11 +227,11 @@ $ mycel trace create_user --input '{"email":"TEST@X.COM","name":"Test"}' --break
 | `input` | Raw input data as received |
 | `sanitize` | After input sanitization (XSS, injection protection) |
 | `filter` | Filter expression evaluation (accept/reject) |
-| `dedupe` | Deduplication check |
 | `validate` | Input validation against type schema |
 | `enrich` | Data enrichment from other connectors |
-| `transform` | CEL transformation (the most common breakpoint) |
 | `step` | Individual step execution in multi-step flows |
+| `transform` | CEL transformation (the most common breakpoint) |
+| `dedupe` | Content-based deduplication check (since v2.1.0: runs **after** transform, compares the fingerprint of the projection) |
 | `read` | Database/API read operation |
 | `write` | Database/API write operation |
 
@@ -706,8 +706,8 @@ Flags:
   --dry-run           Simulate write operations without executing them
   --breakpoints       Pause at every pipeline stage for interactive debugging (dev only)
   --break-at string   Pause at specific stages (dev only, comma-separated)
-                      Valid stages: input, sanitize, filter, accept, dedupe, validate,
-                      transform, step, read, write
+                      Valid stages: input, sanitize, filter, accept, validate,
+                      enrich, step, transform, dedupe, read, write
   --dap int           Start DAP server on this port for IDE debugging (dev only)
   --list              List all available flows
 

--- a/docs/guides/synchronization.md
+++ b/docs/guides/synchronization.md
@@ -373,15 +373,7 @@ flow "critical_payment" {
     operation = "payments"
   }
 
-  # Deduplicate first
-  dedupe {
-    storage      = "connector.redis"
-    key          = "input.payment_id"
-    ttl          = "24h"
-    on_duplicate = "skip"
-  }
-
-  # Then lock the account
+  # Lock the account
   lock {
     storage {
       driver = "redis"
@@ -400,6 +392,29 @@ flow "critical_payment" {
     key     = "'payment_gateway'"
     limit   = 10
     timeout = "10s"
+  }
+
+  # Canonical projection of what the downstream sees. Required for dedupe
+  # below since the fingerprint is computed over `output.*`.
+  transform {
+    payment_id = "input.payment_id"
+    account_id = "input.account_id"
+    amount     = "input.amount"
+  }
+
+  # Drop re-deliveries whose persisted projection equals the last one
+  # processed for this payment. Self-locks per key, so even without the
+  # outer `lock {}` two workers cannot double-charge.
+  dedupe {
+    cache        = "redis_cache"
+    key          = "'payment:' + input.payment_id"
+    ttl          = "24h"
+    on_duplicate = "ack"
+    fingerprint {
+      payment_id = "output.payment_id"
+      account_id = "output.account_id"
+      amount     = "output.amount"
+    }
   }
 
   to {
@@ -446,7 +461,7 @@ Both forms (`url` and `host`/`port`) work for `lock`, `semaphore`, `coordinate`,
 
 ## Sequence Guard (Monotonic Dedup)
 
-A `sequence_guard` block rejects messages whose monotonic sequence number is not strictly greater than the last one observed for the same key. The classic use case: an MQ source that may redeliver — under retry, fan-out, requeue policies, or just multi-worker shuffling — and would otherwise let an older update overwrite a newer one already applied. This is **comparative** dedup, not the boolean "have I seen this exact key" of `dedupe` and `idempotency`.
+A `sequence_guard` block rejects messages whose monotonic sequence number is not strictly greater than the last one observed for the same key. The classic use case: an MQ source that may redeliver — under retry, fan-out, requeue policies, or just multi-worker shuffling — and would otherwise let an older update overwrite a newer one already applied. This is **comparative** dedup by ordering: a message is rejected because something *newer* was already processed, regardless of content. Contrast with `dedupe` (since v2.1.0), which is **content-based**: a message is rejected because its persisted projection is byte-identical to the last one processed, regardless of order. The two compose cleanly — `sequence_guard` drops out-of-order replays, `dedupe` then drops content-identical no-ops.
 
 ```hcl
 flow "style_update" {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -734,14 +734,26 @@ after {
 
 ### dedupe block
 
+Content-based, biphasic deduplication (since v2.1.0). Compares a canonical fingerprint of the projection against the last stored fingerprint for the same key and drops byte-for-byte matches before reaching `to`. Phase B stores the new fingerprint **only on `to` success**, so a failed-then-retried message does not self-discard. The primitive self-locks per key (in-process via memory-backed `SyncManager`) so concurrent workers cannot double-call the downstream with identical content.
+
 ```hcl
 dedupe {
-  storage      = "redis_cache"         # Required
-  key          = "input.payment_id"    # Required: CEL expression
-  ttl          = "24h"
-  on_duplicate = "skip"                # "skip" or "error"
+  cache        = "redis_cache"                                   # Required: name of a connector { type = "cache" }
+  key          = "'sku_fp:' + input.body.payload.productItemId"  # Required: CEL expression for the per-resource key
+  ttl          = "30d"                                           # Optional: supports "d" / "w" plus stdlib units; malformed values fail the parse
+  on_duplicate = "ack"                                           # Optional: "ack" (default), "reject", "requeue"
+
+  fingerprint {                                                   # Required: at least one named CEL expression
+    name   = "output.name"                                        # Both input.* and output.* (transform result) are in scope
+    prices = "output.prices"
+    # ... one entry per persisted field — omitting one would silently drop real changes
+  }
 }
 ```
+
+**Pipeline order:** `dedupe` runs **after** `transform` because the fingerprint expressions reference `output.*`. Earlier versions (≤ 2.0.0) ran a key-based dedupe before transform; see CHANGELOG v2.1.0 for migration.
+
+**Canonical encoding rules:** map keys sorted alphabetically; array elements sorted by their encoded bytes (treated as order-insensitive sets); each value type-tagged and length-prefixed so `"a,b"` cannot collide with `["a","b"]`; whole-number floats normalize to ints.
 
 ### idempotency block
 

--- a/examples/steps/README.md
+++ b/examples/steps/README.md
@@ -323,9 +323,11 @@ flow "process_order" {
 | `target` | Destination (table, topic, exchange, etc.) (required) |
 | `include_error` | Include error details in fallback message |
 
-## Message Deduplication
+## Content-Based Deduplication (v2.1.0+)
 
-Prevent duplicate message processing using cache-based deduplication. This is essential for message queue consumers that may receive the same message twice due to at-least-once delivery semantics.
+Drop **no-op** messages whose persisted projection is byte-identical to the last one processed for the same key. Useful for MQ consumers where the upstream re-sends update messages even when nothing relevant changed: every redelivery hits a slow downstream and burns capacity for no gain.
+
+The primitive runs in two phases. Phase A (after `transform`, before `to`) computes a canonical fingerprint over the projection the operator declares and compares it to the stored fingerprint for the same key. On match the message is dropped without invoking `to`. Phase B (after `to` succeeds) stores the new fingerprint — a failed-then-retried message does NOT self-discard. The primitive self-locks per key so two workers cannot both pass Phase A with identical fingerprints and double-call the downstream.
 
 ```hcl
 flow "process_order_with_dedupe" {
@@ -334,14 +336,23 @@ flow "process_order_with_dedupe" {
     operation = "orders.new"
   }
 
-  dedupe {
-    storage      = "redis_cache"           # Cache connector for dedup keys
-    key          = "'order:' + input.order_id"  # CEL expression for unique key
-    ttl          = "24h"                   # How long to remember keys
-    on_duplicate = "skip"                  # "skip" (silent) or "fail" (error)
+  transform {
+    order_id   = "input.order_id"
+    product_id = "input.product_id"
+    quantity   = "input.quantity"
   }
 
-  # ... steps and transform ...
+  dedupe {
+    cache        = "redis_cache"
+    key          = "'order:' + input.order_id"
+    ttl          = "24h"
+    on_duplicate = "ack"
+    fingerprint {
+      order_id   = "output.order_id"
+      product_id = "output.product_id"
+      quantity   = "output.quantity"
+    }
+  }
 
   to {
     connector = "orders_db"
@@ -354,26 +365,34 @@ flow "process_order_with_dedupe" {
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `storage` | Cache connector name (required) | - |
-| `key` | CEL expression for the dedup key (required) | - |
-| `ttl` | How long to remember keys | `1h` |
-| `on_duplicate` | What to do on duplicate: `skip` or `fail` | `skip` |
+| `cache` | Cache-typed connector name for storing fingerprints (required) | — |
+| `key` | CEL expression for the per-resource key (required) | — |
+| `fingerprint {}` | Named CEL expressions whose values form the projection (required, ≥1 entry). Lists every field that counts toward "did anything change" | — |
+| `ttl` | How long to keep stored fingerprints. Supports `"30d"` and `"2w"` plus stdlib units | no expiry |
+| `on_duplicate` | Behavior on fingerprint match: `"ack"`, `"reject"`, `"requeue"` | `"ack"` |
 
 ### Use Cases
 
-- **Idempotent API Endpoints**: Use request ID or idempotency key as dedup key
-- **Message Queue Processing**: Prevent reprocessing on redelivery
-- **Event Sourcing**: Ensure events are processed exactly once
-- **Payment Processing**: Prevent double-charging with idempotency keys
+- **MQ consumers with chatty upstreams**: drop product update re-sends that contain no actual changes
+- **Event sourcing**: skip events whose persisted shape was already applied
+- **Idempotent API endpoints**: combine with `idempotency {}` (key-based) for layered protection
+- **Payment processing**: ensure the same (account, amount, idempotency_key) is not double-charged
 
 ### How It Works
 
-1. When a message arrives, the `key` expression is evaluated
-2. If the key exists in cache → duplicate detected
-   - `on_duplicate = "skip"`: Return silently (no error)
-   - `on_duplicate = "fail"`: Return error to caller
-3. If key doesn't exist → store key with TTL and process message
-4. On cache errors, flow continues (fail-open for availability)
+1. Message arrives; `transform` produces the canonical projection (`output.*`)
+2. Phase A acquires the in-process lock for the `key` value
+3. Phase A evaluates each `fingerprint.{name}` CEL expression against `input.*` and `output.*`, encodes the result canonically (sorted map keys, sorted array elements, type-tagged, length-prefixed), and `GET`s the stored fingerprint for `key`
+4. **Match** (`stored == new`): release the lock, return `FilteredResultWithPolicy{Policy: on_duplicate, Reason: "dedupe_match"}`. The MQ consumer handles it per the policy. `to` is NOT invoked.
+5. **No match**: invoke `to` (still holding the lock)
+6. **Phase B (only if `to` succeeded)**: `SET` the new fingerprint with the configured TTL, release the lock
+7. **`to` failed**: skip Phase B, release the lock. A retry will re-attempt the write — no self-discard.
+
+Cache errors fail open: a broken Redis processes the message anyway rather than silently swallowing traffic. Phase B failures log a WARN but do not fail the flow.
+
+### Pipeline order vs the old (≤ 2.0.0) dedupe
+
+The block name is the same but the semantics changed in v2.1.0. The old key-based dedupe ran before `transform`; the new content-based dedupe runs **after** `transform` because the fingerprint references `output.*`. The old `storage =` / `on_duplicate = "skip"` syntax is rejected at parse time; see CHANGELOG v2.1.0 for migration.
 
 ## Examples in This Directory
 


### PR DESCRIPTION
## Summary

Docs-only PR. Brings every documentation file that references the `dedupe {}` block in line with the content-based biphasic primitive shipped in v2.1.0. Without this, operators reading the docs would copy the old API (`storage = ...`, `on_duplicate = "skip"`) and the parser would reject it at deploy time.

Two distinct cleanups in this PR:

### 1. API surface — old syntax → new

Every `dedupe {}` block in the docs was using the pre-v2.1.0 attributes (`storage`, `on_duplicate = "skip"/"fail"`) and missing the required `fingerprint {}` projection block. Now updated across **5 files** (caching, configuration, flows, synchronization, production, examples/steps).

The most substantive rewrites:

- **`docs/guides/caching.md`** — full rewrite of the Deduplication section (semantics, biphasic contract, attribute table, pipeline order, array-order caveat). The "Caching vs Deduplication" comparison table now contrasts the two correctly (cache by key, dedupe by canonical content fingerprint).
- **`docs/reference/configuration.md`** — the dedupe block reference now describes Phase A + Phase B, the `fingerprint {}` block, the `on_duplicate` vocabulary (`ack`/`reject`/`requeue`), and the canonical encoding rules.
- **`docs/core-concepts/flows.md`** — rewrote the "Dedupe Block" section with the new syntax + an attribute table + the pipeline-order note + the array-order caveat.
- **`docs/guides/synchronization.md`** — the Sequence Guard contrast with dedupe was rewritten. It used to say "boolean 'have I seen this exact key'" — no longer accurate; the new dedupe is content-based, not presence-based. The two now cleanly compose ("sequence_guard drops out-of-order replays; dedupe then drops content-identical no-ops").
- **`examples/steps/README.md`** — full rewrite of the Message Deduplication section with the new syntax + step-by-step "How It Works" walkthrough.

### 2. Pipeline order

Earlier documentation showed dedupe running **before** transform. Since v2.1.0 dedupe runs **after** transform because the fingerprint expressions reference `output.*` (the transformed payload). Updated diagrams and stage descriptions in:

- `docs/core-concepts/flows.md` ("Pipeline position" diagram)
- `docs/STUDIO-DEBUG-PROTOCOL.md` (pipeline order + stage description)
- `docs/guides/debugging.md` (debug stages table + `--break-at` help text)

And the one-line description in `docs/ROADMAP.md` now reflects content-based / fingerprint / self-locking / new on_duplicate vocabulary.

## Verification

Final sweep across `docs/`, `examples/`, and `tests/` after edits:

- ✅ Zero remaining `storage =` attributes inside `dedupe { }` blocks
- ✅ Zero remaining `on_duplicate = "skip"|"error"|"fail"` in active HCL examples
- ✅ Remaining mentions of the old API are inside prose paragraphs that document the migration (intentional)
- ✅ 7 example `dedupe { }` blocks across the docs — all using `cache = ...`, `fingerprint { }`, `on_duplicate ∈ {ack, reject, requeue}`
- ✅ `mycel validate --config ./examples/dedupe` still passes (no example files touched here, sanity check)

No code or test changes. No build/test impact.