### PR TITLE
fix: make all example configs valid and functional (v2.1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ benchmark/
 
 # MkDocs build output
 site/
+
+# Marketing / article drafts (not part of the codebase)
+/articles/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-05-22
+
+### Fixed
+
+- **Connector attribute parser out of sync with schemas.** The connector parser validated attributes against a hardcoded allow-list that was missing attributes already defined in several connector schemas, so valid configs failed with `Unsupported argument`. Added the missing attributes for CDC (`slot_name`, `publication`), WebSocket (`ping_interval`, `pong_timeout`), SSE (`heartbeat_interval`, `origins`), Elasticsearch (`nodes`, `index`), and OAuth (`client_secret`, `redirect_uri`, `scopes`, `issuer_url`, `auth_url`, `token_url`, `userinfo_url`).
+- **Event-driven sources wrote to databases as `SELECT` instead of `INSERT`.** A flow sourced from WebSocket, SSE, or TCP that wrote to a database kept the default `GET` method and ran a read query, silently discarding the inbound payload. WebSocket/SSE/TCP are now treated as event-driven sources, so such flows correctly write. Verified end-to-end (WebSocket chat message persisted; REST→WebSocket broadcast and REST→SSE push delivered to clients).
+- **Example configurations.** Fixed 14 example projects that no longer validated against the current parser: outdated database connection attributes (`source`/`dsn` → `database`), inline type constraints that the type parser does not accept, dotted `output.` transform keys (now flat keys), the `workflow {}` block (only `storage` is supported), `lock`/`semaphore` inline storage (now a `storage {}` block), and an invalid `to { response }` (now a `response {}` block). All example configs now validate.
+
+### Documentation
+
+- Added the [Resilience & Failure Recovery guide](docs/guides/resilience.md): availability vs. durability, broker redelivery, synchronous vs. event-driven ingestion, and idempotency.
+
 ## [2.1.0] - 2026-05-20
 
 ### ⚠️ BREAKING — `dedupe {}` block replaced

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.1.0"
+	version = "2.1.1"
 	commit  = "dev"
 )
 

--- a/docs/guides/resilience.md
+++ b/docs/guides/resilience.md
@@ -74,12 +74,32 @@ This is the crux. Whether in-flight work survives a crash depends entirely on **
 
 When the source is a message broker, Mycel uses standard **at-least-once** delivery semantics. The broker holds the message until Mycel explicitly acknowledges it *after* the flow completes successfully.
 
+The queue lives on the connector; a flow consumes by referencing that connector and matching a routing key in its `operation`:
+
 ```hcl
+connector "orders_queue" {
+  type   = "mq"
+  driver = "rabbitmq"
+
+  host     = env("RABBITMQ_HOST", "localhost")
+  port     = 5672
+  username = env("RABBITMQ_USER", "guest")
+  password = env("RABBITMQ_PASS", "guest")
+
+  queue {
+    name    = "orders"
+    durable = true
+  }
+
+  consumer {
+    auto_ack = false   # ack only after the flow succeeds — this is what makes it durable
+  }
+}
+
 flow "ingest_order" {
   from {
-    connector = "rabbit"
-    operation = "consume"
-    queue     = "orders"
+    connector = "orders_queue"
+    operation = "order.*"        # routing key pattern
   }
   to {
     connector = "db"
@@ -148,14 +168,26 @@ If you need a synchronous API but durable recovery, the standard pattern is to *
 ```hcl
 # Front door: accept and enqueue durably, return immediately
 flow "accept_order" {
-  from { connector = "api",    operation = "POST /orders" }
-  to   { connector = "rabbit", target    = "orders" }
+  from {
+    connector = "api"
+    operation = "POST /orders"
+  }
+  to {
+    connector = "orders_queue"
+    target    = "order.created"   # routing key
+  }
 }
 
 # Worker: durable, redelivered on crash
 flow "process_order" {
-  from { connector = "rabbit", operation = "consume", queue = "orders" }
-  to   { connector = "db",     target    = "orders" }
+  from {
+    connector = "orders_queue"
+    operation = "order.*"
+  }
+  to {
+    connector = "db"
+    target    = "orders"
+  }
 }
 ```
 
@@ -167,8 +199,14 @@ Because at-least-once delivery and client retries both create duplicates, the an
 
 ```hcl
 flow "charge_payment" {
-  from { connector = "api", operation = "POST /payments" }
-  to   { connector = "db",  target    = "payments" }
+  from {
+    connector = "api"
+    operation = "POST /payments"
+  }
+  to {
+    connector = "db"
+    target    = "payments"
+  }
 
   idempotency {
     storage = "redis_cache"

--- a/examples/batch/connectors.mycel
+++ b/examples/batch/connectors.mycel
@@ -5,14 +5,14 @@ connector "api" {
 
 connector "old_db" {
   type   = "database"
-  driver = "sqlite"
-  dsn    = "old.db"
+  driver   = "sqlite"
+  database = "old.db"
 }
 
 connector "new_db" {
-  type   = "database"
-  driver = "sqlite"
-  dsn    = "new.db"
+  type     = "database"
+  driver   = "sqlite"
+  database = "new.db"
 }
 
 connector "es" {

--- a/examples/batch/flows.mycel
+++ b/examples/batch/flows.mycel
@@ -12,9 +12,9 @@ flow "migrate_users" {
     on_error   = "continue"
 
     transform {
-      output.email       = "input.email.lowerAscii()"
-      output.name        = "input.name"
-      output.migrated    = "true"
+      email       = "input.email.lowerAscii()"
+      name        = "input.name"
+      migrated    = "true"
     }
 
     to {

--- a/examples/cdc/flows.mycel
+++ b/examples/cdc/flows.mycel
@@ -6,10 +6,10 @@ flow "on_user_created" {
   }
 
   transform {
-    output.event      = "'user.created'"
-    output.user_id    = "input.new.id"
-    output.email      = "input.new.email"
-    output.created_at = "input.timestamp"
+    event      = "'user.created'"
+    user_id    = "input.new.id"
+    email      = "input.new.email"
+    created_at = "input.timestamp"
   }
 
   to {
@@ -27,11 +27,11 @@ flow "on_order_updated" {
   }
 
   transform {
-    output.event      = "'order.status_changed'"
-    output.order_id   = "input.new.id"
-    output.old_status = "input.old.status"
-    output.new_status = "input.new.status"
-    output.changed_at = "input.timestamp"
+    event      = "'order.status_changed'"
+    order_id   = "input.new.id"
+    old_status = "input.old.status"
+    new_status = "input.new.status"
+    changed_at = "input.timestamp"
   }
 
   to {
@@ -48,9 +48,9 @@ flow "on_session_deleted" {
   }
 
   transform {
-    output.event   = "'session.ended'"
-    output.user_id = "input.old.user_id"
-    output.token   = "input.old.token"
+    event   = "'session.ended'"
+    user_id = "input.old.user_id"
+    token   = "input.old.token"
   }
 
   to {
@@ -67,8 +67,8 @@ flow "on_product_change" {
   }
 
   transform {
-    output.event = "'product.' + lower(input.trigger)"
-    output.data  = "input.new != null ? input.new : input.old"
+    event = "'product.' + lower(input.trigger)"
+    data  = "input.new != null ? input.new : input.old"
   }
 
   to {

--- a/examples/elasticsearch/flows.mycel
+++ b/examples/elasticsearch/flows.mycel
@@ -19,11 +19,9 @@ flow "search_products" {
     }
   }
 
-  transform {
-    output.results = "step.results"
+  response {
+    results = "step.results"
   }
-
-  to { response }
 }
 
 # Get single product by ID

--- a/examples/error-handling/connectors/queue.mycel
+++ b/examples/error-handling/connectors/queue.mycel
@@ -1,8 +1,11 @@
 # RabbitMQ connector for dead letter queue (DLQ)
 
 connector "rabbit" {
-  type     = "mq"
-  driver   = "rabbitmq"
-  url      = env("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
-  exchange = "error_handling_example"
+  type   = "mq"
+  driver = "rabbitmq"
+  url    = env("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+
+  exchange {
+    name = "error_handling_example"
+  }
 }

--- a/examples/error-handling/flows/custom_errors.mycel
+++ b/examples/error-handling/flows/custom_errors.mycel
@@ -33,8 +33,8 @@ flow "create_payment" {
         "Retry-After" = "30"
       }
       body {
-        output.error   = "'service_unavailable'"
-        output.message = "'Payment service is temporarily unavailable. Please retry later.'"
+        error   = "'service_unavailable'"
+        message = "'Payment service is temporarily unavailable. Please retry later.'"
       }
     }
   }
@@ -56,8 +56,8 @@ flow "get_order" {
     error_response {
       status = 404
       body {
-        output.error   = "'not_found'"
-        output.message = "'The requested order was not found.'"
+        error   = "'not_found'"
+        message = "'The requested order was not found.'"
       }
     }
   }

--- a/examples/error-handling/flows/retry.mycel
+++ b/examples/error-handling/flows/retry.mycel
@@ -15,11 +15,11 @@ flow "create_order" {
   }
 
   transform {
-    output.product_id = "input.product_id"
-    output.quantity   = "input.quantity"
-    output.email      = "input.email.lowerAscii()"
-    output.status     = "'pending'"
-    output.created_at = "now()"
+    product_id = "input.product_id"
+    quantity   = "input.quantity"
+    email      = "input.email.lowerAscii()"
+    status     = "'pending'"
+    created_at = "now()"
   }
 
   to {
@@ -42,9 +42,9 @@ flow "create_order" {
       include_error = true
 
       transform {
-        output.original_payload = "input"
-        output.flow             = "'create_order'"
-        output.failed_at        = "now()"
+        original_payload = "input"
+        flow             = "'create_order'"
+        failed_at        = "now()"
       }
     }
   }

--- a/examples/error-handling/flows/skip_steps.mycel
+++ b/examples/error-handling/flows/skip_steps.mycel
@@ -45,14 +45,14 @@ flow "get_order_details" {
   }
 
   transform {
-    output.id             = "step.order.id"
-    output.product_id     = "step.order.product_id"
-    output.quantity        = "step.order.quantity"
-    output.status         = "step.order.status"
-    output.customer_name  = "step.customer.name"
-    output.customer_email = "step.customer.email"
-    output.shipping_days  = "step.shipping.estimated_days"
-    output.carrier        = "step.shipping.carrier"
-    output.loyalty_points = "step.loyalty.points"
+    id             = "step.order.id"
+    product_id     = "step.order.product_id"
+    quantity       = "step.order.quantity"
+    status         = "step.order.status"
+    customer_name  = "step.customer.name"
+    customer_email = "step.customer.email"
+    shipping_days  = "step.shipping.estimated_days"
+    carrier        = "step.shipping.carrier"
+    loyalty_points = "step.loyalty.points"
   }
 }

--- a/examples/error-handling/types/order.mycel
+++ b/examples/error-handling/types/order.mycel
@@ -1,7 +1,7 @@
 # Order input type for validation
 
 type "order" {
-  product_id = string { required = true }
-  quantity   = number { min = 1, max = 100 }
-  email      = string { format = "email" }
+  product_id = string
+  quantity   = number
+  email      = string
 }

--- a/examples/format/flows/mixed_format.mycel
+++ b/examples/format/flows/mixed_format.mycel
@@ -23,10 +23,10 @@ flow "enrich_product" {
 
   # Step 3: Merge and return as JSON (default)
   transform {
-    output.id          = step.save.id
-    output.name        = step.save.name
-    output.price       = step.save.price
-    output.legacy_code = step.get_legacy_info.product_code
-    output.warehouse   = step.get_legacy_info.warehouse
+    id          = "step.save.id"
+    name        = "step.save.name"
+    price       = "step.save.price"
+    legacy_code = "step.get_legacy_info.product_code"
+    warehouse   = "step.get_legacy_info.warehouse"
   }
 }

--- a/examples/graphql-federation/types.mycel
+++ b/examples/graphql-federation/types.mycel
@@ -12,9 +12,9 @@ type "Product" {
   _key       = "sku"
   _shareable = true
 
-  sku         = string { required = true }
-  name        = string { required = true }
-  price       = number { min = 0 }
+  sku         = string
+  name        = string
+  price       = number
   description = string
   category    = string
   inStock     = boolean
@@ -27,9 +27,9 @@ type "Product" {
 type "Review" {
   _key = "id"
 
-  id         = string { required = true }
-  productSku = string { required = true }
-  rating     = number { min = 1, max = 5 }
+  id         = string
+  productSku = string
+  rating     = number
   comment    = string
   author     = string
   createdAt  = string
@@ -37,17 +37,17 @@ type "Review" {
 
 # Input type for creating a product
 type "ProductInput" {
-  sku         = string { required = true }
-  name        = string { required = true }
-  price       = number { min = 0 }
+  sku         = string
+  name        = string
+  price       = number
   description = string
   category    = string
 }
 
 # Input type for creating a review
 type "ReviewInput" {
-  productSku = string { required = true }
-  rating     = number { min = 1, max = 5, required = true }
+  productSku = string
+  rating     = number
   comment    = string
-  author     = string { required = true }
+  author     = string
 }

--- a/examples/integration/rabbit-to-exec/flows.mycel
+++ b/examples/integration/rabbit-to-exec/flows.mycel
@@ -30,7 +30,9 @@ flow "process_data" {
 # Pattern 3: Image processing with semaphore
 flow "process_image" {
   semaphore {
-    storage     = "memory"
+    storage {
+      driver = "memory"
+    }
     key         = "'image_processing'"
     max_permits = 3
     timeout     = "5m"
@@ -50,7 +52,9 @@ flow "process_image" {
 # Pattern 4: Video transcoding with lock
 flow "transcode_video" {
   lock {
-    storage = "memory"
+    storage {
+      driver = "memory"
+    }
     key     = "'video:' + input.body.video_id"
     timeout = "30m"
     wait    = false

--- a/examples/integration/rabbit-to-rest/flows.mycel
+++ b/examples/integration/rabbit-to-rest/flows.mycel
@@ -45,7 +45,9 @@ flow "notify_order_status" {
 # Pattern 3: With semaphore for rate-limited external API
 flow "sync_to_crm" {
   semaphore {
-    storage     = "memory"
+    storage {
+      driver = "memory"
+    }
     key         = "'crm_api'"
     max_permits = 5
     timeout     = "30s"

--- a/examples/oauth/connectors.mycel
+++ b/examples/oauth/connectors.mycel
@@ -26,5 +26,5 @@ connector "github_auth" {
 connector "db" {
   type   = "database"
   driver = "sqlite"
-  dsn    = "users.db"
+  database = "users.db"
 }

--- a/examples/oauth/flows.mycel
+++ b/examples/oauth/flows.mycel
@@ -28,11 +28,11 @@ flow "google_callback" {
   }
 
   transform {
-    output.email       = "step.auth.email"
-    output.name        = "step.auth.name"
-    output.picture     = "step.auth.picture"
-    output.provider    = "'google'"
-    output.provider_id = "step.auth.provider_id"
+    email       = "step.auth.email"
+    name        = "step.auth.name"
+    picture     = "step.auth.picture"
+    provider    = "'google'"
+    provider_id = "step.auth.provider_id"
   }
 
   to {
@@ -71,11 +71,11 @@ flow "github_callback" {
   }
 
   transform {
-    output.email       = "step.auth.email"
-    output.name        = "step.auth.name"
-    output.picture     = "step.auth.picture"
-    output.provider    = "'github'"
-    output.provider_id = "step.auth.provider_id"
+    email       = "step.auth.email"
+    name        = "step.auth.name"
+    picture     = "step.auth.picture"
+    provider    = "'github'"
+    provider_id = "step.auth.provider_id"
   }
 
   to {

--- a/examples/saga/connectors.mycel
+++ b/examples/saga/connectors.mycel
@@ -4,9 +4,9 @@ connector "api" {
 }
 
 connector "orders_db" {
-  type   = "database"
-  driver = "sqlite"
-  source = ":memory:"
+  type     = "database"
+  driver   = "sqlite"
+  database = ":memory:"
 }
 
 connector "payments_api" {

--- a/examples/scheduled/flows/scheduled.mycel
+++ b/examples/scheduled/flows/scheduled.mycel
@@ -17,8 +17,8 @@ flow "health_ping" {
   when = "@every 5m"
 
   transform {
-    output.service = "scheduled-jobs-service"
-    output.status  = "alive"
+    service = "'scheduled-jobs-service'"
+    status  = "'alive'"
   }
 
   to {
@@ -38,10 +38,10 @@ flow "weekly_report" {
   }
 
   transform {
-    output.total_logs   = input.total_logs
-    output.period_start = input.period_start
-    output.period_end   = input.period_end
-    output.generated_at = now()
+    total_logs   = "input.total_logs"
+    period_start = "input.period_start"
+    period_end   = "input.period_end"
+    generated_at = "now()"
   }
 
   to {

--- a/examples/soap/types/user.mycel
+++ b/examples/soap/types/user.mycel
@@ -1,12 +1,6 @@
 # User input validation schema
+# Fields declared in a type are required by default.
 type "user" {
-  email = string {
-    format   = "email"
-    required = true
-  }
-
-  name = string {
-    min_length = 1
-    required   = true
-  }
+  email = string
+  name  = string
 }

--- a/examples/state-machine/connectors.mycel
+++ b/examples/state-machine/connectors.mycel
@@ -4,9 +4,9 @@ connector "api" {
 }
 
 connector "orders_db" {
-  type   = "database"
-  driver = "sqlite"
-  source = ":memory:"
+  type     = "database"
+  driver   = "sqlite"
+  database = ":memory:"
 }
 
 connector "notifications" {

--- a/examples/websocket/flows.mycel
+++ b/examples/websocket/flows.mycel
@@ -6,10 +6,10 @@ flow "handle_chat" {
   }
 
   transform {
-    output.id         = "uuid()"
-    output.text       = "input.text"
-    output.room       = "input.room"
-    output.created_at = "now()"
+    id         = "uuid()"
+    text       = "input.text"
+    room       = "input.room"
+    created_at = "now()"
   }
 
   to {

--- a/examples/workflows/config.mycel
+++ b/examples/workflows/config.mycel
@@ -4,9 +4,8 @@ service {
 
   # Enable long-running workflow persistence.
   # Workflows survive restarts and support delay/await steps.
+  # storage references the connector used to persist workflow state.
   workflow {
-    storage      = "db"
-    connector    = "postgres"
-    auto_create  = true
+    storage = "postgres"
   }
 }

--- a/examples/workflows/connectors/database.mycel
+++ b/examples/workflows/connectors/database.mycel
@@ -1,7 +1,12 @@
 connector "postgres" {
-  type   = "database"
-  driver = "postgres"
-  source = env("DATABASE_URL", "postgres://mycel:mycel@localhost:5432/orders?sslmode=disable")
+  type     = "database"
+  driver   = "postgres"
+  host     = env("DB_HOST", "localhost")
+  port     = 5432
+  database = env("DB_NAME", "orders")
+  user     = env("DB_USER", "mycel")
+  password = env("DB_PASSWORD", "mycel")
+  sslmode  = "disable"
 }
 
 connector "shipping_api" {

--- a/internal/parser/connector.go
+++ b/internal/parser/connector.go
@@ -196,6 +196,31 @@ func parseConnectorBlock(block *hcl.Block, ctx *hcl.EvalContext) (*connector.Con
 			{Name: "channels"}, // Channels to subscribe to
 			{Name: "patterns"}, // Glob patterns for PSUBSCRIBE
 			{Name: "db"},       // Redis database number
+
+			// CDC specific (Change Data Capture)
+			{Name: "slot_name"},   // PostgreSQL logical replication slot
+			{Name: "publication"}, // PostgreSQL publication name
+
+			// WebSocket specific
+			{Name: "ping_interval"}, // Ping frame interval
+			{Name: "pong_timeout"},  // Pong response timeout
+
+			// SSE specific (Server-Sent Events)
+			{Name: "heartbeat_interval"}, // Heartbeat comment interval
+			{Name: "origins"},            // Allowed origins (SSE/WebSocket)
+
+			// Elasticsearch specific
+			{Name: "nodes"}, // Cluster node URLs
+			{Name: "index"}, // Default index name
+
+			// OAuth specific
+			{Name: "client_secret"}, // OAuth client secret
+			{Name: "redirect_uri"},  // OAuth redirect URI
+			{Name: "scopes"},        // Requested OAuth scopes
+			{Name: "issuer_url"},    // OIDC issuer URL
+			{Name: "auth_url"},      // Authorization endpoint
+			{Name: "token_url"},     // Token endpoint
+			{Name: "userinfo_url"},  // Userinfo endpoint
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "pool"},

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -2527,7 +2527,7 @@ type Operation struct {
 // and write to the destination (message queues, CDC, file watchers).
 func isEventDrivenSource(sourceType string) bool {
 	switch sourceType {
-	case "mq", "mqtt", "cdc", "file":
+	case "mq", "mqtt", "cdc", "file", "websocket", "sse", "tcp":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

14 example projects no longer validated against the current parser, and some that *did* parse didn't actually **work** at runtime. This branch makes every example config valid **and** functional, fixing two underlying bugs surfaced in the process.

## Two bugs fixed

1. **Parser attribute allow-list out of sync with connector schemas** (`internal/parser/connector.go`)
   The connector parser validates attributes against a hardcoded allow-list and rejects anything else with `Unsupported argument`. Attributes already defined in the CDC, WebSocket, SSE, Elasticsearch and OAuth connector schemas were missing from it. Added: `slot_name`, `publication`, `ping_interval`, `pong_timeout`, `heartbeat_interval`, `origins`, `nodes`, `index`, `client_secret`, `redirect_uri`, `scopes`, `issuer_url`, `auth_url`, `token_url`, `userinfo_url`. The connector code already consumed these.

2. **Event-driven sources wrote to databases as `SELECT` instead of `INSERT`** (`internal/runtime/flow_registry.go`)
   `isEventDrivenSource` only listed `mq/mqtt/cdc/file`, so a flow sourced from WebSocket/SSE/TCP that wrote to a database kept `method=GET` and ran a read query, silently discarding the payload. Added `websocket/sse/tcp`.

## Functional verification (not just parsing)

- **WebSocket** — inbound chat message → transform → **INSERTed** into SQLite; REST→WebSocket broadcast delivered to a connected client.
- **SSE** — REST POST → push → delivered to a connected SSE stream client.
- **OAuth** — `/auth/google` generates the correct Google authorize URL from `client_id`/`redirect_uri`/`scopes`.
- **CDC** — boots and reports `slot=… publication=…` (consumes the new attrs).
- **Elasticsearch** — connector initializes from `nodes`/`index` (only fails the health check against a non-running server, as expected).

## Example config fixes (config-only)

`source`/`dsn` → `database`; dropped inline type constraints the parser rejects; dotted `output.` transform keys → flat keys; `workflow {}` block trimmed to the supported `storage`; `lock`/`semaphore` inline storage → `storage {}` block; invalid `to { response }` → `response {}` block.

## Docs

- New [Resilience & Failure Recovery guide](docs/guides/resilience.md).

## Result

- All **54** example configs validate (was 14 failing).
- `go test ./...` passes (0 failures, 70 packages).
- Version bumped to **2.1.1**.