### PR TITLE
feat: per-class error dispositions (on_timeout / on_error) — v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-05-23
+
+### Added
+
+- **Per-class error dispositions: `on_timeout` and `on_error` blocks inside `error_handling`.** Beyond the existing `retry {}`, a flow can now declare what broker disposition to apply per **class** of failure:
+
+  ```hcl
+  error_handling {
+    retry { attempts = 3, delay = "2s", max_delay = "30s", backoff = "exponential" }
+    on_timeout { action = "ack" }      # timeout → drop, no retry, no requeue
+    on_error   { action = "requeue" }  # other transient errors → requeue
+  }
+  ```
+
+  `action` is one of `ack` (acknowledge/drop), `retry` (use the `retry {}` budget), `requeue` (nack with requeue), or `reject` (nack without requeue → DLQ). `on_timeout` matches timeout / `context.DeadlineExceeded` failures; `on_error` matches transient, non-timeout, non-permanent failures. Permanent errors (HTTP 4xx) are never routed here and keep their ack-and-drop behavior.
+
+  The motivating case: a consumer `POST`ing to a backend with a timeout. When the backend takes longer than the timeout, the HTTP client aborts but the backend keeps processing — so retrying fires a concurrent duplicate request. `on_timeout { action = "ack" }` drops the timed-out (idempotent) message instead of replaying it. See `examples/timeout-handling`.
+
+  **Backward compatible:** flows without `on_timeout` / `on_error` behave exactly as before (a timeout stays transient → retry budget → requeue). Implemented via a `DispositionError` that MQ consumers (RabbitMQ, Kafka) honor explicitly, falling back to the existing permanent-vs-transient inference when no disposition is set.
+
 ## [2.1.1] - 2026-05-22
 
 ### Fixed

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.1.1"
+	version = "2.2.0"
 	commit  = "dev"
 )
 

--- a/examples/timeout-handling/README.md
+++ b/examples/timeout-handling/README.md
@@ -1,0 +1,60 @@
+# Timeout Handling — per-class error dispositions
+
+Demonstrates `on_timeout` / `on_error` inside `error_handling`: deciding the
+broker disposition (ack / retry / requeue / reject) per **class** of failure.
+
+## The problem
+
+A consumer reads items off RabbitMQ and `POST`s each to a backend (Magento)
+with `timeout = "60s"`. When the backend takes longer than 60s:
+
+1. The HTTP client aborts with `context deadline exceeded`.
+2. **The backend keeps processing the original request** — the timeout only
+   cancelled the local wait.
+3. By default Mycel treats a timeout as transient → retries → fires a **second,
+   concurrent** `POST` for the same resource → race (deadlock / FK violation) →
+   loop.
+
+## The fix
+
+The request is idempotent and the upstream redelivers duplicates, so on timeout
+we **ack (drop)** instead of retrying:
+
+```hcl
+error_handling {
+  retry {
+    attempts  = 3
+    delay     = "2s"
+    max_delay = "30s"
+    backoff   = "exponential"
+  }
+
+  on_timeout { action = "ack" }      # timeout → drop, no retry, no requeue
+  on_error   { action = "requeue" }  # other transient errors → requeue
+}
+```
+
+## Actions
+
+| `action`  | Effect |
+|-----------|--------|
+| `ack`     | Acknowledge and drop. No retry, no requeue. |
+| `retry`   | Use the `retry {}` budget (the default for transient errors). |
+| `requeue` | Nack with requeue — broker redelivers. |
+| `reject`  | Nack without requeue — routes to a DLQ if one is configured. |
+
+## Classes
+
+- **`on_timeout`** — timeout / `context.DeadlineExceeded` failures.
+- **`on_error`** — transient, non-timeout, non-permanent failures.
+
+Permanent errors (HTTP 4xx) are never routed here; they keep their ack-and-drop
+behavior. **Backward compatible:** without `on_timeout`, a timeout stays
+transient (retry budget → requeue), exactly as before.
+
+## Run
+
+```bash
+mycel validate --config ./examples/timeout-handling
+mycel start --config ./examples/timeout-handling
+```

--- a/examples/timeout-handling/config.mycel
+++ b/examples/timeout-handling/config.mycel
@@ -1,0 +1,4 @@
+service {
+  name    = "timeout-handling-demo"
+  version = "1.0.0"
+}

--- a/examples/timeout-handling/connectors.mycel
+++ b/examples/timeout-handling/connectors.mycel
@@ -1,0 +1,28 @@
+# RabbitMQ consumer: items to push to the backend.
+connector "queue" {
+  type   = "mq"
+  driver = "rabbitmq"
+
+  host     = env("RABBITMQ_HOST", "localhost")
+  port     = 5672
+  username = env("RABBITMQ_USER", "guest")
+  password = env("RABBITMQ_PASS", "guest")
+
+  queue {
+    name    = "items.push"
+    durable = true
+  }
+
+  consumer {
+    auto_ack = false
+  }
+}
+
+# Backend HTTP API (e.g. Magento). When a request takes longer than `timeout`,
+# the HTTP client abandons it with a deadline-exceeded error — but the backend
+# keeps processing the original request.
+connector "backend" {
+  type     = "http"
+  base_url = env("BACKEND_URL", "http://localhost:8080")
+  timeout  = "60s"
+}

--- a/examples/timeout-handling/flows.mycel
+++ b/examples/timeout-handling/flows.mycel
@@ -1,0 +1,41 @@
+# Consume an item from the queue and POST it to the backend.
+#
+# If the backend takes longer than the connector timeout (60s), the HTTP client
+# aborts with a deadline-exceeded error — but the backend is still processing
+# the original request. Retrying would fire a second, concurrent POST for the
+# same resource and race the first one (deadlock / FK violation / loop).
+#
+# The request is idempotent and the upstream redelivers duplicates, so on
+# timeout we ACK (drop) instead of retrying or requeueing. Non-timeout
+# transient errors still use the retry budget and then requeue.
+flow "push_item" {
+  from {
+    connector = "queue"
+    operation = "items.push"
+  }
+
+  to {
+    connector = "backend"
+    operation = "POST /rest/V1/items"
+  }
+
+  error_handling {
+    retry {
+      attempts  = 3
+      delay     = "2s"
+      max_delay = "30s"
+      backoff   = "exponential"
+    }
+
+    # Timeout → ack-and-drop (no retry, no requeue): the backend is still
+    # working and the upstream will redeliver if needed.
+    on_timeout {
+      action = "ack"
+    }
+
+    # Other transient (non-timeout, non-permanent) errors → requeue.
+    on_error {
+      action = "requeue"
+    }
+  }
+}

--- a/internal/connector/disposition.go
+++ b/internal/connector/disposition.go
@@ -1,0 +1,65 @@
+package connector
+
+import "errors"
+
+// Disposition is the broker-level outcome a failed flow asks its source
+// consumer to apply. It is chosen declaratively by error_handling's per-class
+// handlers (on_timeout / on_error), as opposed to being inferred from
+// IsPermanent.
+type Disposition string
+
+const (
+	// DispositionAck acknowledges (drops) the message without retrying or
+	// requeueing. Used when the work is idempotent and an upstream will
+	// redeliver duplicates — so dropping loses nothing and avoids replaying
+	// a request whose remote side may still be in flight.
+	DispositionAck Disposition = "ack"
+
+	// DispositionRequeue nacks with requeue so the broker redelivers later.
+	DispositionRequeue Disposition = "requeue"
+
+	// DispositionReject nacks without requeue, routing the message to a dead
+	// letter queue if one is configured.
+	DispositionReject Disposition = "reject"
+)
+
+// DispositionError wraps a flow error with an explicit broker disposition.
+// MQ consumers detect it (via GetDisposition) and ack / requeue / reject
+// accordingly, instead of inferring the outcome from IsPermanent.
+//
+// It also satisfies PermanentError so that the retry budget and any consumer
+// path that only understands permanent-vs-transient still behaves correctly:
+// ack and reject are terminal (stop redelivery), requeue is not.
+type DispositionError struct {
+	// Err is the underlying flow error.
+	Err error
+	// Disposition is the broker outcome to apply.
+	Disposition Disposition
+}
+
+func (e *DispositionError) Error() string { return e.Err.Error() }
+
+func (e *DispositionError) Unwrap() error { return e.Err }
+
+// IsPermanent reports ack and reject as permanent (terminal) and requeue as
+// transient. This keeps the flow retry budget and any unmodified consumer
+// correct even before they learn to read the explicit disposition.
+func (e *DispositionError) IsPermanent() bool {
+	return e.Disposition == DispositionAck || e.Disposition == DispositionReject
+}
+
+// NewDispositionError wraps err with the given broker disposition.
+func NewDispositionError(err error, d Disposition) *DispositionError {
+	return &DispositionError{Err: err, Disposition: d}
+}
+
+// GetDisposition returns the broker disposition carried by err (or by any
+// error it wraps via %w), if any. The second return value reports whether a
+// disposition was found.
+func GetDisposition(err error) (Disposition, bool) {
+	var d *DispositionError
+	if errors.As(err, &d) {
+		return d.Disposition, true
+	}
+	return "", false
+}

--- a/internal/connector/error_classification.go
+++ b/internal/connector/error_classification.go
@@ -1,6 +1,10 @@
 package connector
 
-import "errors"
+import (
+	"context"
+	"errors"
+	"strings"
+)
 
 // PermanentError is implemented by error types that the runtime should not
 // retry. Concrete error types (HTTP 4xx, validation errors, etc.) opt in
@@ -33,4 +37,25 @@ func IsPermanent(err error) bool {
 		return p.IsPermanent()
 	}
 	return false
+}
+
+// IsTimeoutError reports whether err represents a timeout / context deadline
+// exceeded. It is used to route a timed-out request to an on_timeout handler.
+// It matches both the typed context.DeadlineExceeded (what net/http surfaces
+// when the client Timeout fires) and the string forms other clients produce
+// ("deadline exceeded", "timeout").
+//
+// A timeout is a special case: the local request was abandoned, but the
+// remote side may still be processing it. Blindly retrying can trigger a
+// concurrent duplicate operation on the same resource — which is exactly why
+// a flow may want to ack-and-drop on timeout instead of retrying.
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "timeout")
 }

--- a/internal/connector/mq/kafka/consumer.go
+++ b/internal/connector/mq/kafka/consumer.go
@@ -199,6 +199,38 @@ func (c *Connector) handleMessage(ctx context.Context, msg kafka.Message) error 
 			"topic", msg.Topic,
 			"error", err,
 		)
+		// Explicit disposition chosen by the flow's error_handling
+		// (on_timeout / on_error). Takes precedence over the IsPermanent
+		// inference below. Kafka has no per-message nack, so dispositions map
+		// onto offset semantics: ack/reject commit the offset (skip), and
+		// reject additionally republishes to <topic>.dlq; requeue returns the
+		// error so the offset is not committed and the message is re-consumed.
+		if disp, ok := connector.GetDisposition(err); ok {
+			switch disp {
+			case connector.DispositionAck:
+				c.logger.Warn("flow disposition: ack (commit/skip)",
+					"topic", msg.Topic,
+					"partition", msg.Partition,
+					"offset", msg.Offset,
+					"action", "commit",
+					"error", err,
+				)
+				return nil
+			case connector.DispositionReject:
+				dlqTopic := msg.Topic + ".dlq"
+				c.logger.Warn("flow disposition: reject (→ DLQ topic)",
+					"topic", msg.Topic,
+					"dlq_topic", dlqTopic,
+					"partition", msg.Partition,
+					"offset", msg.Offset,
+					"action", "republish_dlq",
+					"error", err,
+				)
+				return c.republishMessage(ctx, dlqTopic, msg)
+			case connector.DispositionRequeue:
+				return err
+			}
+		}
 		// Permanent failures (HTTP 4xx etc.) cannot be fixed by replaying.
 		// Return nil so the offset commits and the message is not
 		// re-consumed (Kafka offset semantics — equivalent to ack on

--- a/internal/connector/mq/rabbitmq/consumer.go
+++ b/internal/connector/mq/rabbitmq/consumer.go
@@ -208,6 +208,35 @@ func (c *Connector) handleDelivery(ctx context.Context, delivery amqp.Delivery) 
 			"routing_key", delivery.RoutingKey,
 			"error", err,
 		)
+		// Explicit disposition chosen by the flow's error_handling
+		// (on_timeout / on_error). Takes precedence over the IsPermanent
+		// inference below: the flow author decided what to do with this
+		// class of failure, so honor it directly.
+		if disp, ok := connector.GetDisposition(err); ok {
+			switch disp {
+			case connector.DispositionAck:
+				c.logger.Warn("flow disposition: ack (drop)",
+					"routing_key", delivery.RoutingKey,
+					"delivery_tag", delivery.DeliveryTag,
+					"message_id", delivery.MessageId,
+					"action", "ack",
+					"error", err,
+				)
+				return delivery.Ack(false)
+			case connector.DispositionReject:
+				c.logger.Warn("flow disposition: reject (→ DLQ)",
+					"routing_key", delivery.RoutingKey,
+					"delivery_tag", delivery.DeliveryTag,
+					"message_id", delivery.MessageId,
+					"action", "nack",
+					"requeue", false,
+					"error", err,
+				)
+				return delivery.Nack(false, false)
+			case connector.DispositionRequeue:
+				return c.handleRetry(delivery, err)
+			}
+		}
 		// Permanent failures (HTTP 4xx etc.) cannot be fixed by retrying
 		// — replaying the same payload would produce the same response.
 		// Ack-and-drop so the broker stops redelivering. Without this

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -552,6 +552,28 @@ type ErrorHandlingConfig struct {
 
 	// ErrorResponse defines a custom error response for HTTP connectors.
 	ErrorResponse *ErrorResponseConfig
+
+	// OnTimeout, when set, decides the broker disposition for timeout /
+	// context-deadline-exceeded failures, overriding the default
+	// transient-retry behavior for that class. The driving case: a POST that
+	// the local client abandons on timeout while the remote keeps processing
+	// — retrying would trigger a concurrent duplicate, so `action = "ack"`
+	// drops it instead.
+	OnTimeout *ErrorClassHandler
+
+	// OnError, when set, decides the broker disposition for transient,
+	// non-timeout, non-permanent failures. Permanent errors (HTTP 4xx) keep
+	// their existing ack-and-drop behavior and are not routed here.
+	OnError *ErrorClassHandler
+}
+
+// ErrorClassHandler maps a class of failure to a broker disposition action.
+// Used by the optional on_timeout / on_error blocks inside error_handling.
+type ErrorClassHandler struct {
+	// Action is the disposition to apply: one of "ack" (acknowledge/drop),
+	// "retry" (use the retry {} budget), "requeue" (nack with requeue), or
+	// "reject" (nack without requeue → DLQ).
+	Action string
 }
 
 // ErrorResponseConfig defines a custom HTTP error response.

--- a/internal/parser/error_class_handler_test.go
+++ b/internal/parser/error_class_handler_test.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func parseFlowSource(t *testing.T, hcl string) (*Configuration, error) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "flow.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	return NewHCLParser().ParseFile(context.Background(), tmpFile)
+}
+
+// TestParseOnTimeoutAndOnError: on_timeout / on_error blocks parse into the
+// ErrorHandlingConfig with their action.
+func TestParseOnTimeoutAndOnError(t *testing.T) {
+	hcl := `
+flow "process_orders" {
+  from {
+    connector = "rabbit"
+    operation = "orders.new"
+  }
+
+  error_handling {
+    retry {
+      attempts = 3
+      delay    = "2s"
+    }
+    on_timeout {
+      action = "ack"
+    }
+    on_error {
+      action = "requeue"
+    }
+  }
+
+  to {
+    connector = "db"
+    target    = "orders"
+  }
+}
+`
+	cfg, err := parseFlowSource(t, hcl)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(cfg.Flows) != 1 {
+		t.Fatalf("expected 1 flow, got %d", len(cfg.Flows))
+	}
+	eh := cfg.Flows[0].ErrorHandling
+	if eh == nil {
+		t.Fatal("expected error_handling block")
+	}
+	if eh.OnTimeout == nil || eh.OnTimeout.Action != "ack" {
+		t.Errorf("expected on_timeout action 'ack', got %+v", eh.OnTimeout)
+	}
+	if eh.OnError == nil || eh.OnError.Action != "requeue" {
+		t.Errorf("expected on_error action 'requeue', got %+v", eh.OnError)
+	}
+	// retry {} must still parse unchanged alongside the new blocks.
+	if eh.Retry == nil || eh.Retry.Attempts != 3 {
+		t.Errorf("expected retry attempts 3, got %+v", eh.Retry)
+	}
+}
+
+// TestParseOnTimeoutInvalidAction: an unknown action value is a parse error.
+func TestParseOnTimeoutInvalidAction(t *testing.T) {
+	hcl := `
+flow "process_orders" {
+  from {
+    connector = "rabbit"
+    operation = "orders.new"
+  }
+
+  error_handling {
+    on_timeout {
+      action = "drop"
+    }
+  }
+
+  to {
+    connector = "db"
+    target    = "orders"
+  }
+}
+`
+	_, err := parseFlowSource(t, hcl)
+	if err == nil {
+		t.Fatal("expected a parse error for invalid action 'drop'")
+	}
+	if !strings.Contains(err.Error(), "invalid action") {
+		t.Errorf("expected 'invalid action' in error, got: %v", err)
+	}
+}

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -950,6 +950,8 @@ func parseErrorHandlingBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Erro
 			{Type: "retry"},
 			{Type: "fallback"},
 			{Type: "error_response"},
+			{Type: "on_timeout"},
+			{Type: "on_error"},
 		},
 	}
 
@@ -980,10 +982,52 @@ func parseErrorHandlingBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Erro
 				return nil, fmt.Errorf("error_response block error: %w", err)
 			}
 			eh.ErrorResponse = errResp
+		case "on_timeout":
+			handler, err := parseErrorClassHandlerBlock(nestedBlock, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("on_timeout block error: %w", err)
+			}
+			eh.OnTimeout = handler
+		case "on_error":
+			handler, err := parseErrorClassHandlerBlock(nestedBlock, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("on_error block error: %w", err)
+			}
+			eh.OnError = handler
 		}
 	}
 
 	return eh, nil
+}
+
+// parseErrorClassHandlerBlock parses an on_timeout / on_error block, which maps
+// a class of failure to a broker disposition action.
+func parseErrorClassHandlerBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ErrorClassHandler, error) {
+	schema := &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "action", Required: true},
+		},
+	}
+
+	content, diags := block.Body.Content(schema)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("content error: %s", diags.Error())
+	}
+
+	val, diags := content.Attributes["action"].Expr.Value(ctx)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("action error: %s", diags.Error())
+	}
+
+	action := val.AsString()
+	switch action {
+	case "ack", "retry", "requeue", "reject":
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid action %q (must be one of: ack, retry, requeue, reject)", action)
+	}
+
+	return &flow.ErrorClassHandler{Action: action}, nil
 }
 
 // parseRetryConfigBlock parses a retry block within error_handling.

--- a/internal/runtime/error_class_handler_test.go
+++ b/internal/runtime/error_class_handler_test.go
@@ -1,0 +1,147 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	httpconn "github.com/matutetandil/mycel/internal/connector/http"
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+// newEHHandler builds a minimal FlowHandler carrying only an error_handling
+// config — enough to exercise executeWithRetry's class-handler routing without
+// a real source/destination.
+func newEHHandler(eh *flow.ErrorHandlingConfig) *FlowHandler {
+	return &FlowHandler{Config: &flow.Config{ErrorHandling: eh}}
+}
+
+// TestOnTimeoutAck: the driving case. A timeout with on_timeout{action="ack"}
+// must NOT consume the retry budget and must surface an ACK disposition so the
+// consumer drops the message instead of replaying it into a concurrent
+// duplicate on the remote side.
+func TestOnTimeoutAckNoRetryAndAcks(t *testing.T) {
+	h := newEHHandler(&flow.ErrorHandlingConfig{
+		Retry:     &flow.RetryConfig{Attempts: 3, Delay: "1ms"},
+		OnTimeout: &flow.ErrorClassHandler{Action: "ack"},
+	})
+
+	calls := 0
+	_, err := h.executeWithRetry(context.Background(), nil, func() (interface{}, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call (no retry on ack), got %d", calls)
+	}
+	disp, ok := connector.GetDisposition(err)
+	if !ok || disp != connector.DispositionAck {
+		t.Fatalf("expected ack disposition, got disp=%q ok=%v err=%v", disp, ok, err)
+	}
+	// ack must read as permanent so even a consumer that only knows
+	// permanent-vs-transient still drops it.
+	if !connector.IsPermanent(err) {
+		t.Error("ack disposition must be permanent for IsPermanent-only consumers")
+	}
+}
+
+// TestTimeoutWithoutHandlerRetriesAndRequeues: backward compatibility. Without
+// on_timeout, a timeout stays transient — full retry budget, then a plain
+// (non-permanent, no-disposition) error so the consumer requeues. This is the
+// pre-existing behavior and must not change.
+func TestTimeoutWithoutHandlerRetriesAndRequeues(t *testing.T) {
+	h := newEHHandler(&flow.ErrorHandlingConfig{
+		Retry: &flow.RetryConfig{Attempts: 3, Delay: "1ms"},
+	})
+
+	calls := 0
+	_, err := h.executeWithRetry(context.Background(), nil, func() (interface{}, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	})
+
+	if calls != 3 {
+		t.Fatalf("expected 3 calls (full retry budget), got %d", calls)
+	}
+	if disp, ok := connector.GetDisposition(err); ok {
+		t.Errorf("expected no explicit disposition (default requeue), got %q", disp)
+	}
+	if connector.IsPermanent(err) {
+		t.Error("timeout without handler must stay transient (requeue), not permanent")
+	}
+}
+
+// TestOnErrorRequeue: a generic transient error with on_error{action="requeue"}
+// surfaces a requeue disposition and short-circuits (no retry).
+func TestOnErrorRequeue(t *testing.T) {
+	h := newEHHandler(&flow.ErrorHandlingConfig{
+		Retry:   &flow.RetryConfig{Attempts: 3, Delay: "1ms"},
+		OnError: &flow.ErrorClassHandler{Action: "requeue"},
+	})
+
+	calls := 0
+	_, err := h.executeWithRetry(context.Background(), nil, func() (interface{}, error) {
+		calls++
+		return nil, errors.New("downstream blew up")
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected 1 call (requeue short-circuits), got %d", calls)
+	}
+	disp, ok := connector.GetDisposition(err)
+	if !ok || disp != connector.DispositionRequeue {
+		t.Fatalf("expected requeue disposition, got disp=%q ok=%v", disp, ok)
+	}
+	if connector.IsPermanent(err) {
+		t.Error("requeue disposition must not be permanent")
+	}
+}
+
+// TestOnTimeoutRetryUsesBudget: on_timeout{action="retry"} explicitly opts the
+// timeout class into the retry budget (falls through), matching the default.
+func TestOnTimeoutRetryUsesBudget(t *testing.T) {
+	h := newEHHandler(&flow.ErrorHandlingConfig{
+		Retry:     &flow.RetryConfig{Attempts: 3, Delay: "1ms"},
+		OnTimeout: &flow.ErrorClassHandler{Action: "retry"},
+	})
+
+	calls := 0
+	_, err := h.executeWithRetry(context.Background(), nil, func() (interface{}, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	})
+
+	if calls != 3 {
+		t.Fatalf("expected 3 calls (retry budget), got %d", calls)
+	}
+	if disp, ok := connector.GetDisposition(err); ok {
+		t.Errorf("retry must not attach a disposition after exhausting the budget, got %q", disp)
+	}
+}
+
+// TestOnErrorSkipsPermanent: on_error must NOT capture permanent errors (HTTP
+// 4xx). They break the retry loop early and keep their ack-and-drop behavior.
+func TestOnErrorSkipsPermanent(t *testing.T) {
+	h := newEHHandler(&flow.ErrorHandlingConfig{
+		Retry:   &flow.RetryConfig{Attempts: 3, Delay: "1ms"},
+		OnError: &flow.ErrorClassHandler{Action: "requeue"},
+	})
+
+	calls := 0
+	_, err := h.executeWithRetry(context.Background(), nil, func() (interface{}, error) {
+		calls++
+		return nil, &httpconn.HTTPError{StatusCode: 409}
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected 1 call (permanent breaks early), got %d", calls)
+	}
+	if disp, ok := connector.GetDisposition(err); ok {
+		t.Errorf("permanent error must not get an on_error disposition, got %q", disp)
+	}
+	if !connector.IsPermanent(err) {
+		t.Error("permanent error must stay permanent (ack-drop)")
+	}
+}

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -437,6 +437,32 @@ func classifyFlowError(err error) string {
 	}
 }
 
+// errorClassAction returns the disposition action configured for the class of
+// err, if a matching per-class handler is set. on_timeout matches timeout /
+// deadline-exceeded errors; on_error matches transient (non-timeout,
+// non-permanent) errors. Permanent errors (HTTP 4xx) are never routed here —
+// they keep their existing ack-and-drop behavior. The boolean reports whether
+// a handler matched.
+func (h *FlowHandler) errorClassAction(err error) (string, bool) {
+	eh := h.Config.ErrorHandling
+	if eh == nil {
+		return "", false
+	}
+	if connector.IsTimeoutError(err) {
+		if eh.OnTimeout != nil {
+			return eh.OnTimeout.Action, true
+		}
+		// No on_timeout handler → preserve the existing behavior for timeouts
+		// (transient → retry budget → requeue). Do NOT fall through to
+		// on_error: a timeout is its own class.
+		return "", false
+	}
+	if eh.OnError != nil && !connector.IsPermanent(err) {
+		return eh.OnError.Action, true
+	}
+	return "", false
+}
+
 // executeWithRetry executes the flow with retry and fallback handling.
 func (h *FlowHandler) executeWithRetry(ctx context.Context, input map[string]interface{}, executeFn func() (interface{}, error)) (interface{}, error) {
 	eh := h.Config.ErrorHandling
@@ -480,6 +506,26 @@ func (h *FlowHandler) executeWithRetry(ctx context.Context, input map[string]int
 		// Don't retry if context is cancelled
 		if ctx.Err() != nil {
 			break
+		}
+
+		// Per-class failure handler (on_timeout / on_error). When a handler
+		// matches the error's class, it decides the broker disposition
+		// immediately and short-circuits the retry budget — except
+		// action="retry", which falls through to the budget below. This is
+		// what lets `on_timeout { action = "ack" }` drop a timed-out (but
+		// idempotent) request instead of replaying it into a concurrent
+		// duplicate on the remote side.
+		if action, ok := h.errorClassAction(err); ok {
+			switch action {
+			case "ack":
+				return nil, connector.NewDispositionError(err, connector.DispositionAck)
+			case "requeue":
+				return nil, connector.NewDispositionError(err, connector.DispositionRequeue)
+			case "reject":
+				return nil, connector.NewDispositionError(err, connector.DispositionReject)
+			case "retry":
+				// fall through to the retry budget
+			}
 		}
 
 		// Don't retry on permanent HTTP errors. A 4xx response means the

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -335,6 +335,12 @@ func ErrorHandlingSchema() Block {
 			{Type: "error_response", Doc: "Custom HTTP error response", Open: true, Attrs: []Attr{
 				{Name: "status", Doc: "HTTP status code", Type: TypeNumber},
 			}},
+			{Type: "on_timeout", Doc: "Disposition for timeout / deadline-exceeded failures (overrides default retry)", Attrs: []Attr{
+				{Name: "action", Doc: "Broker disposition", Type: TypeString, Required: true, Values: []string{"ack", "retry", "requeue", "reject"}},
+			}},
+			{Type: "on_error", Doc: "Disposition for transient, non-timeout, non-permanent failures", Attrs: []Attr{
+				{Name: "action", Doc: "Broker disposition", Type: TypeString, Required: true, Values: []string{"ack", "retry", "requeue", "reject"}},
+			}},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Adds optional `on_timeout` and `on_error` blocks inside `error_handling`, letting a flow declare the broker disposition (`ack` / `retry` / `requeue` / `reject`) **per class of failure** — alongside the unchanged `retry {}` budget.

```hcl
error_handling {
  retry { attempts = 3, delay = "2s", max_delay = "30s", backoff = "exponential" }
  on_timeout { action = "ack" }      # timeout → drop, no retry, no requeue
  on_error   { action = "requeue" }  # other transient errors → requeue
}
```

## Why

A consumer `POST`s to a backend (Magento) with `timeout = "60s"`. When the backend takes longer than 60s, the HTTP client aborts with `context deadline exceeded` — **but the backend keeps processing the original request**. Mycel treats the timeout as transient → retries → fires a second concurrent `POST` for the same resource → race condition (deadlock / FK violation / loop).

The request is idempotent and the upstream redelivers duplicates, so `on_timeout { action = "ack" }` drops the timed-out message instead of replaying it.

## Actions & classes

| `action`  | Effect |
|-----------|--------|
| `ack`     | Acknowledge and drop. No retry, no requeue. |
| `retry`   | Use the `retry {}` budget (default for transient). |
| `requeue` | Nack with requeue. |
| `reject`  | Nack without requeue → DLQ if configured. |

- `on_timeout` → timeout / `context.DeadlineExceeded` failures.
- `on_error` → transient, non-timeout, non-permanent failures.
- Permanent errors (HTTP 4xx) are never routed here; they keep ack-and-drop.

## Design

- `connector.IsTimeoutError` — shared, cycle-free timeout detector.
- `connector.DispositionError` wraps the error with an explicit ack/requeue/reject outcome; RabbitMQ and Kafka consumers honor it via `GetDisposition`. It also implements `IsPermanent` (ack/reject terminal, requeue transient) so the retry budget and any unmodified consumer still behave correctly.
- `executeWithRetry` routes the error's class to its handler inside the retry loop: ack/requeue/reject short-circuit immediately; retry falls through to the budget.

## Backward compatibility

Flows without `on_timeout` / `on_error` behave **exactly as before** — a timeout stays transient (retry budget → requeue). Covered by a test.

## Tests & validation

- Runtime routing tests: timeout+ack (no retry, acks), timeout-without-handler (full budget → requeue), on_error requeue, on_timeout=retry (uses budget), on_error skips permanent.
- Parser tests: valid `on_timeout`/`on_error`, invalid `action` → parse error.
- `go build ./...` ✅, `go test ./...` ✅ (0 failures), `mycel validate examples/timeout-handling` ✅, all 55 example configs still valid.

## Example

`examples/timeout-handling/` — the RabbitMQ→backend scenario above.

Version bumped to **2.2.0** (new capability, backward compatible).