### PR TITLE
feat(dedupe): commit fingerprint on ack disposition — v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-05-23
+
+### Changed
+
+- **Dedupe now commits the fingerprint when a failed write's disposition is `ack`.** The biphasic dedupe primitive persists the fingerprint in Phase B not only after a successful write, but also when the write failed and the flow's `error_handling` will ack it (e.g. `on_timeout { action = "ack" }`). Rationale: `ack` means "treat this as processed/terminal", so the duplicate the upstream redelivers must be filtered — not reprocessed into a concurrent second operation on the backend.
+
+  This closes the gap left by v2.2.0's `on_timeout { action = "ack" }`: previously a timed-out (but still-processing) backend POST was acked, but because the write "failed" the fingerprint was not stored, so the redelivered duplicate slipped past Phase A and was reprocessed concurrently. Now the fingerprint is committed on the ack path.
+
+  **Backward compatible:** a failed write with no class handler — or with `requeue`/`reject` — still skips Phase B exactly as before, so the message is reprocessed cleanly on redelivery. Only the `ack` disposition commits.
+
 ## [2.2.0] - 2026-05-23
 
 ### Added

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.2.0"
+	version = "2.3.0"
 	commit  = "dev"
 )
 

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -7,9 +7,13 @@
 //	    compare byte-for-byte. On match the message is dropped according
 //	    to on_duplicate without invoking `to`.
 //
-//	Phase B (after `to` ONLY on success): SET the new fingerprint for the
-//	    key. Writing earlier would let a failed+retried message
-//	    self-discard and lose a real change.
+//	Phase B (after `to`): SET the new fingerprint for the key when the
+//	    message's final disposition is terminal-as-processed — i.e. on a
+//	    successful write, or when the write failed but error_handling will
+//	    ack it (e.g. on_timeout {action="ack"}). Writing on any other
+//	    failure (no class handler, or requeue/reject) would let a
+//	    failed+retried message self-discard and lose a real change, so it
+//	    is skipped.
 //
 // Both phases run under an in-process lock keyed on the dedupe.key, so two
 // workers in the same process cannot both pass Phase A with identical
@@ -127,21 +131,36 @@ func (h *FlowHandler) dedupeAwareWrite(
 		// Not a duplicate — run the actual write.
 		result, writeErr := write()
 		if writeErr != nil {
-			// Phase B intentionally skipped: a failed write must not poison
-			// the fingerprint cache. The next retry will re-attempt.
-			return result, writeErr
+			// Phase B runs after a failed write ONLY when the flow's
+			// error_handling will ack this failure (e.g. on_timeout
+			// {action="ack"}). "ack" means "treat this as processed/
+			// terminal": the local call was abandoned but we assume the
+			// effect was applied (idempotent work, remote still finishing),
+			// so the duplicate the upstream redelivers must be filtered —
+			// not reprocessed into a concurrent second operation.
+			//
+			// For any other failure — no class handler, or requeue/reject —
+			// Phase B is skipped so a failed write does not poison the cache
+			// and the message is reprocessed cleanly on the next delivery.
+			if action, ok := h.errorClassAction(writeErr); !ok || action != "ack" {
+				return result, writeErr
+			}
+			// Fall through to commit the fingerprint, then still return the
+			// original error so error_handling applies the ack disposition.
 		}
 
-		// Phase B: SET the new fingerprint. Best-effort — a failure here
-		// just means the next identical message will not be deduped; the
-		// current message already succeeded downstream.
+		// Phase B: SET the new fingerprint. Runs on a successful write, or on
+		// an ack-disposition failure (see above). Best-effort — a failure
+		// here just means the next identical message will not be deduped.
 		if setErr := h.DedupeCache.Set(ctx, storageKey, fp, ttl); setErr != nil {
 			slog.Warn("dedupe commit failed; next identical message will not be filtered",
 				"flow", h.Config.Name,
 				"key", key,
 				"error", setErr)
 		}
-		return result, nil
+		// writeErr is nil on success, or the original error on the ack path;
+		// returning it preserves the error_handling disposition either way.
+		return result, writeErr
 	})
 }
 

--- a/internal/runtime/dedupe_ack_commit_test.go
+++ b/internal/runtime/dedupe_ack_commit_test.go
@@ -1,0 +1,163 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+var dedupeTestPayload = map[string]interface{}{
+	"name":     "Widget",
+	"price":    10,
+	"websites": map[string]interface{}{"us": true},
+}
+
+// TestDedupe_AckOnTimeoutCommitsFingerprint is the headline change: when a
+// write times out but the flow's on_timeout disposition is "ack", Phase B
+// commits the fingerprint anyway. The duplicate the upstream redelivers is
+// then filtered instead of being reprocessed into a concurrent second
+// operation on the backend.
+func TestDedupe_AckOnTimeoutCommitsFingerprint(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+	h.Config.ErrorHandling = &flow.ErrorHandlingConfig{
+		OnTimeout: &flow.ErrorClassHandler{Action: "ack"},
+	}
+
+	input := map[string]interface{}{"sku": "X1"}
+
+	var calls int
+	write := func() (interface{}, error) {
+		calls++
+		return nil, context.DeadlineExceeded // simulate the backend timeout
+	}
+
+	// First call: the write "times out". The original error must still
+	// propagate so error_handling can apply the ack disposition...
+	_, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first call: expected deadline-exceeded to propagate, got %v", err)
+	}
+
+	// ...but the fingerprint must have been committed (Phase B ran), so the
+	// redelivered duplicate is filtered and the write is NOT called again.
+	r2, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if _, filtered := r2.(*flow.FilteredResultWithPolicy); !filtered {
+		t.Fatalf("second call must be filtered (ack committed the fingerprint); got %#v", r2)
+	}
+	if calls != 1 {
+		t.Errorf("write calls = %d, want 1 (duplicate filtered, not reprocessed)", calls)
+	}
+}
+
+// TestDedupe_RequeueOnErrorSkipsCommit: a failed write whose disposition is
+// requeue must NOT commit — the message will be redelivered and must be
+// reprocessed, so Phase A must not find a stored fingerprint.
+func TestDedupe_RequeueOnErrorSkipsCommit(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+	h.Config.ErrorHandling = &flow.ErrorHandlingConfig{
+		OnError: &flow.ErrorClassHandler{Action: "requeue"},
+	}
+
+	input := map[string]interface{}{"sku": "X1"}
+
+	boom := errors.New("downstream blew up")
+	var calls int
+	write := func() (interface{}, error) {
+		calls++
+		if calls == 1 {
+			return nil, boom
+		}
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	if _, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write); !errors.Is(err, boom) {
+		t.Fatalf("first call: expected boom, got %v", err)
+	}
+
+	// Not committed → second call re-runs the write (not filtered).
+	r2, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if _, filtered := r2.(*flow.FilteredResultWithPolicy); filtered {
+		t.Fatalf("requeue disposition must NOT commit; second call should reprocess, got %#v", r2)
+	}
+	if calls != 2 {
+		t.Errorf("write calls = %d, want 2 (requeue reprocesses)", calls)
+	}
+}
+
+// TestDedupe_NoHandlerSkipsCommit: backward compatibility. A failed write with
+// NO class handler — even a timeout — must not commit, exactly as before.
+func TestDedupe_NoHandlerSkipsCommit(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+	// No ErrorHandling configured — the pre-existing default.
+
+	input := map[string]interface{}{"sku": "X1"}
+
+	var calls int
+	write := func() (interface{}, error) {
+		calls++
+		if calls == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	if _, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first call: expected deadline-exceeded, got %v", err)
+	}
+
+	r2, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if _, filtered := r2.(*flow.FilteredResultWithPolicy); filtered {
+		t.Fatalf("no class handler: a failed write must not commit; got filtered %#v", r2)
+	}
+	if calls != 2 {
+		t.Errorf("write calls = %d, want 2 (no commit → reprocess)", calls)
+	}
+}
+
+// TestDedupe_SuccessStillCommits: sanity that the success path is unchanged by
+// the new ack branch — a successful write commits and dedupes the next
+// identical message. error_handling is present to exercise the new code path.
+func TestDedupe_SuccessStillCommits(t *testing.T) {
+	h, done := newDedupeHandler(t)
+	defer done()
+	h.Config.ErrorHandling = &flow.ErrorHandlingConfig{
+		OnTimeout: &flow.ErrorClassHandler{Action: "ack"},
+	}
+
+	input := map[string]interface{}{"sku": "X1"}
+
+	var calls int
+	write := func() (interface{}, error) {
+		calls++
+		return &connector.Result{Affected: 1}, nil
+	}
+
+	if _, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	r2, err := h.dedupeAwareWrite(context.Background(), input, dedupeTestPayload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if _, filtered := r2.(*flow.FilteredResultWithPolicy); !filtered {
+		t.Fatalf("successful write must commit; second identical message should be filtered, got %#v", r2)
+	}
+	if calls != 1 {
+		t.Errorf("write calls = %d, want 1 (second filtered)", calls)
+	}
+}


### PR DESCRIPTION
## Summary

The biphasic dedupe primitive now commits the fingerprint (Phase B) not only after a **successful** write, but also when the write **failed and the flow's `error_handling` will ack it** (e.g. `on_timeout { action = "ack" }`).

## Why

This closes the gap left by v2.2.0's `on_timeout { action = "ack" }`:

- A consumer `POST`s to a backend with a timeout. The backend takes >timeout → the HTTP client aborts, **but the backend keeps processing** (idempotent).
- `on_timeout { action = "ack" }` acks the message instead of retrying — good.
- **But** because the write "failed", dedupe Phase B was skipped → the fingerprint was never stored → the duplicate the upstream redelivers slipped past Phase A → reprocessed → **second concurrent operation on the same resource** → the exact race the ack was meant to avoid.

Committing on the ack path makes the redelivered duplicate filter correctly.

## Rule

Persist the fingerprint when the message's final disposition is terminal-as-processed:

| Case | Phase B |
|------|---------|
| write success → ack | **commits** (unchanged) |
| write timeout + `on_timeout { action = "ack" }` | **commits** (new) |
| write error + `on_error { action = "ack" }` | **commits** (new) |
| write error + `on_error { action = "requeue" / "reject" }` | skips (reprocess) |
| write error, no class handler | skips (reprocess) — **backward compatible** |

## Implementation

In `dedupeAwareWrite`, a failed write consults the existing `errorClassAction(writeErr)`. If it returns `("ack", true)`, Phase B runs (best-effort `Set`, same as the success path) before the original error is returned so `error_handling` still applies the ack. The fingerprint computed in Phase A is reused. Single `Set` call for both paths.

## Tests & validation

- New: ack-on-timeout commits (redelivered duplicate filtered, not reprocessed); requeue-on-error skips; no-handler skips (incl. timeout); success still commits.
- Existing dedupe tests unchanged (incl. `WriteFailureSkipsCommit` → backward compat).
- `go build ./...` ✅, `go test ./...` ✅ (0 failures), `mycel validate examples/dedupe` ✅.

Files: `internal/runtime/dedupe.go` (logic + comments), `internal/runtime/dedupe_ack_commit_test.go`. Version bumped to **2.3.0**.