### PR TITLE
feat: transactional multi-statement write primitive (to { transaction })

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-05-26
+
+### Added
+
+- **Transactional, iterative, multi-statement write primitive: `to { transaction { } }`.** A flow destination can now run an ordered list of SQL statements inside a single pinned database connection wrapped in one `BEGIN`/`COMMIT` — all-or-nothing. This makes a complex aggregate write (clean previous rows, insert a parent and capture its autoincrement id, insert N children that reference it, route attributes by type) expressible declaratively, which the single-statement `to` write could not do.
+
+  ```hcl
+  to {
+    connector = "db"            # must be a database connector
+
+    transaction {
+      exec {
+        query  = "DELETE FROM child WHERE owner_id = :owner"
+        params = { owner = "output.owner_id" }
+        when   = "output.owner_id > 0"      # optional CEL gate; false = skip
+      }
+
+      exec {
+        query   = "INSERT INTO parent (owner_id, name) VALUES (:owner, :name)"
+        params  = { owner = "output.owner_id", name = "output.name" }
+        capture = "parent_id"               # INSERT → captured.parent_id = last insert id
+      }
+
+      each "child" in "output.children" {   # iterate a list from the payload
+        exec {
+          query   = "INSERT INTO child (parent_id, label, position) VALUES (:pid, :label, :pos)"
+          params  = {
+            pid   = "captured.parent_id"     # value captured above
+            label = "child.label"            # current element
+            pos   = "child_index"            # 0-based each index
+          }
+          capture = "child_id"
+        }
+
+        each "store" in "child.stores" {     # each is nestable
+          exec {
+            query  = "INSERT INTO child_value (child_id, store_id, val) VALUES (:cid, :sid, :v)"
+            params = { cid = "captured.child_id", sid = "store.id", v = "store.value" }
+          }
+        }
+      }
+
+      exec {
+        query   = "SELECT option_id FROM lookup WHERE code = :c LIMIT 1"
+        params  = { c = "output.code" }
+        capture = "option_id"               # SELECT → first column of first row (null if 0 rows)
+      }
+    }
+  }
+  ```
+
+  **Semantics:**
+  - **Pinned connection + transaction.** All statements run on one connection inside one transaction, so `LAST_INSERT_ID()`/`last_insert_rowid()` and captured `SELECT`s are coherent across statements. Commit on success; rollback on any error (a failed statement, an unresolved `when`/param CEL, or a panic), then the error propagates to the flow's `error_handling` (retry/ack/requeue/etc.) exactly like a failed classic write.
+  - **`exec`** runs one statement with `:named` params resolved from CEL. `capture` stores the last insert id for `INSERT/UPDATE/DELETE`, or the first column of the first row for `SELECT` (`null` when no rows).
+  - **`each "<var>" in "<listExpr>"`** evaluates a CEL list and runs its body per element, binding the element to `<var>` and its 0-based index to `<var>_index`. A non-list or empty result runs nothing. Nestable.
+  - **CEL scope:** `input`, `output` (transform result), `step`, `captured` (values captured so far), plus active `each` bindings.
+  - **Driver-agnostic:** the runtime depends only on a `connector.TxRunner` interface; MySQL/MariaDB and SQLite implement it today, and the interface leaves room for Postgres `RETURNING`.
+  - **Wrapped by the standard envelope:** dedupe, `after`/`on_error` aspects, and `error_handling` (retry, `on_timeout`/`on_error` dispositions) wrap the transaction just like any other `to` write.
+
+  **Validation (`mycel validate`):** rejects `transaction` combined with `query`/`target`/`operation`/`envelope` in the same `to`; requires the `to` connector to be of type `database`; requires each `exec` to have a non-empty `query`; requires `each` to be written as `each "<var>" in "<listExpr>"`.
+
+  **Backward compatible:** purely additive. Flows without a `transaction` block are unchanged.
+
 ## [2.3.0] - 2026-05-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ That's it. REST API + database, zero code.
 | [Elasticsearch](examples/elasticsearch) | Full-text search and analytics over Elasticsearch REST API ([docs](docs/connectors/elasticsearch.md)) |
 | [OAuth (Social Login)](examples/oauth) | Declarative social login: Google, GitHub, Apple, OIDC, custom ([docs](docs/connectors/oauth.md)) |
 | [Batch Processing](examples/batch) | Chunked data processing for migrations, ETL, reindexing ([docs](docs/guides/batch-processing.md)) |
+| [Transactional Writes](examples/transactional-write) | Atomic, iterative, multi-statement DB writes: `to { transaction { } }` with `exec`/`each`, `LAST_INSERT_ID`/SELECT capture, all-or-nothing commit |
 | [Sagas](examples/saga) | Distributed transactions with automatic compensation, delay/await steps, workflow persistence ([docs](docs/guides/sagas.md)) |
 | [State Machines](examples/state-machine) | Entity lifecycle with guards, actions, final states ([docs](docs/guides/sagas.md#state-machines)) |
 | [Long-Running Workflows](examples/workflows) | Persistent workflows with delay timers, await/signal events, timeout enforcement, REST API ([docs](docs/guides/sagas.md#long-running-workflows)) |

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.3.0"
+	version = "2.4.0"
 	commit  = "dev"
 )
 

--- a/docs/connectors/database.md
+++ b/docs/connectors/database.md
@@ -99,6 +99,14 @@ connector "mongo" {
 | `DELETE` | write | Delete rows |
 | target name (table) | read/write | Auto-detect from flow context |
 
+## Transactional writes
+
+To write several statements **atomically** on a single pinned connection (with
+`LAST_INSERT_ID` / `SELECT` capture and per-element iteration), use the
+`to { transaction { } }` block instead of a single `query`/`target`. See
+[Flows → Transactional write](../core-concepts/flows.md#transactional-write-transaction)
+and the [transactional-write example](../../examples/transactional-write/).
+
 ## Example
 
 ```hcl

--- a/docs/core-concepts/flows.md
+++ b/docs/core-concepts/flows.md
@@ -207,6 +207,87 @@ to {
 }
 ```
 
+### Transactional write (`transaction`)
+
+For a database connector, a `transaction` block runs an **ordered list of SQL
+statements inside a single pinned connection wrapped in one `BEGIN`/`COMMIT`** —
+all-or-nothing. Use it when one logical write spans several statements that must
+be atomic and need to pass values between them (a captured `LAST_INSERT_ID`, a
+looked-up id), which a single-statement `to` write cannot express.
+
+```hcl
+to {
+  connector = "db"            # must be a database connector
+
+  transaction {
+    exec {
+      query  = "DELETE FROM child WHERE owner_id = :owner"
+      params = { owner = "output.owner_id" }
+      when   = "output.owner_id > 0"        # optional CEL gate; false = skip
+    }
+
+    exec {
+      query   = "INSERT INTO parent (owner_id, name) VALUES (:owner, :name)"
+      params  = { owner = "output.owner_id", name = "output.name" }
+      capture = "parent_id"                 # INSERT → captured.parent_id = last insert id
+    }
+
+    each "child" in "output.children" {     # iterate a list from the payload
+      exec {
+        query   = "INSERT INTO child (parent_id, label, position) VALUES (:pid, :label, :pos)"
+        params  = {
+          pid   = "captured.parent_id"       # value captured above
+          label = "child.label"              # current element
+          pos   = "child_index"              # 0-based each index
+        }
+        capture = "child_id"
+      }
+
+      each "store" in "child.stores" {       # each is nestable
+        exec {
+          query  = "INSERT INTO child_value (child_id, store_id) VALUES (:cid, :sid)"
+          params = { cid = "captured.child_id", sid = "store.id" }
+        }
+      }
+    }
+
+    exec {
+      query   = "SELECT option_id FROM lookup WHERE code = :c LIMIT 1"
+      params  = { c = "output.code" }
+      capture = "option_id"                 # SELECT → first column of first row (null if 0 rows)
+    }
+  }
+}
+```
+
+**Statements (textual order is significant — captured values flow forward):**
+
+- **`exec`** runs one SQL statement.
+  - `query` — SQL with `:named` placeholders. *(required)*
+  - `params` — map of placeholder name → CEL expression.
+  - `when` — optional CEL gate; the statement is skipped (not an error) when false.
+  - `capture` — optional name stored under `captured.<name>`: the **last insert id**
+    for `INSERT`/`UPDATE`/`DELETE`, or the **first column of the first row** for a
+    `SELECT` (`null` when there are no rows).
+- **`each "<var>" in "<listExpr>"`** evaluates a CEL list and runs its body once
+  per element, binding the element to `<var>` and its 0-based index to
+  `<var>_index`. A non-list or empty result runs nothing. Nestable.
+
+**CEL scope inside a transaction:** `input`, `output` (the transform result),
+`step`, `captured` (values captured so far), plus the active `each` bindings.
+
+**Atomicity & error handling:** commit on success; any error — a failing
+statement, an unresolved `when`/param expression, or a panic — rolls back the
+**entire** transaction. The error then propagates to the flow's
+`error_handling` (retry / `on_timeout` / `on_error` dispositions) exactly like a
+failed single-statement write. The transaction is also wrapped by `dedupe` and
+`after`/`on_error` aspects as a single unit.
+
+**Rules:** the `to` connector must be of type `database`; `transaction` is
+mutually exclusive with `query` / `target` / `operation` / `envelope` in the
+same `to` block (`mycel validate` enforces both). See the
+[transactional-write example](https://github.com/matutetandil/mycel/tree/main/examples/transactional-write).
+
 ### Multi-to (fan-out)
 
 Write to multiple targets by declaring multiple `to` blocks:

--- a/examples/transactional-write/README.md
+++ b/examples/transactional-write/README.md
@@ -1,0 +1,55 @@
+# Transactional, multi-statement write
+
+Persist a product aggregate (product → options → option values) **atomically**
+with the `to { transaction { } }` primitive. All statements run on one pinned
+database connection inside a single `BEGIN`/`COMMIT`: a failure anywhere rolls
+back the whole aggregate, and captured ids (`LAST_INSERT_ID`) stay coherent
+across statements because they share the connection.
+
+## Run
+
+```bash
+mycel validate --config ./examples/transactional-write
+mycel start    --config ./examples/transactional-write
+```
+
+Create the tables once (SQLite):
+
+```sql
+CREATE TABLE product        (id INTEGER PRIMARY KEY AUTOINCREMENT, sku TEXT, name TEXT);
+CREATE TABLE product_option (id INTEGER PRIMARY KEY AUTOINCREMENT, product_id INTEGER, code TEXT, position INTEGER);
+CREATE TABLE option_value   (id INTEGER PRIMARY KEY AUTOINCREMENT, option_id INTEGER, label TEXT, price REAL);
+```
+
+Send an aggregate:
+
+```bash
+curl -X POST localhost:8080/products -H 'content-type: application/json' -d '{
+  "id": 0,
+  "sku": "TSHIRT-1",
+  "name": "T-Shirt",
+  "options": [
+    { "code": "size",  "values": [ {"label": "S", "price": 0}, {"label": "M", "price": 0} ] },
+    { "code": "color", "values": [ {"label": "Red", "price": 2.5} ] }
+  ]
+}'
+```
+
+This produces one `product` row, two `product_option` rows linked to it, and
+three `option_value` rows — or, if any statement fails, none at all.
+
+## What the flow shows
+
+| Feature | Where |
+|---|---|
+| Pinned connection + atomic commit/rollback | the whole `transaction` block |
+| `exec` with `:named` params from CEL | every statement |
+| `when` gate (skip when false) | the `DELETE` runs only when `input.id > 0` |
+| `capture` of `LAST_INSERT_ID` | `product_id`, `option_id` |
+| `each "<var>" in "<list>"` iteration | `options`, nested `values` |
+| `<var>_index` (0-based) | `option_index` → `position` |
+| forward reference to captured ids | `captured.product_id`, `captured.option_id` |
+
+The `transaction` is wrapped by the same dedupe / aspects / `error_handling`
+envelope as any other `to` write — add a `dedupe {}` or `error_handling {}`
+block to the flow and it applies to the transaction as a unit.

--- a/examples/transactional-write/config.mycel
+++ b/examples/transactional-write/config.mycel
@@ -1,0 +1,4 @@
+service {
+  name    = "transactional-write-demo"
+  version = "1.0.0"
+}

--- a/examples/transactional-write/connectors.mycel
+++ b/examples/transactional-write/connectors.mycel
@@ -1,0 +1,13 @@
+# REST entry point: receive an aggregate to persist.
+connector "api" {
+  type = "rest"
+  port = 8080
+}
+
+# Local SQLite database. The transaction primitive works with any database
+# connector (SQLite, MySQL/MariaDB); swap the driver/dsn to point at MySQL.
+connector "db" {
+  type   = "database"
+  driver = "sqlite"
+  path   = "./catalog.db"
+}

--- a/examples/transactional-write/flows.mycel
+++ b/examples/transactional-write/flows.mycel
@@ -1,0 +1,56 @@
+# Persist a product aggregate atomically:
+#   1. clear the product's existing options (idempotent re-write)
+#   2. insert the product, capturing its autoincrement id
+#   3. for each option, insert a row referencing that id and capture its id
+#   4. for each value of the option, insert a row referencing the option id
+#
+# Everything runs in one transaction over one pinned connection: a failure at
+# any step rolls back the whole aggregate, and the captured ids are coherent
+# because all statements share the connection.
+flow "save_product" {
+  from {
+    connector = "api"
+    operation = "POST /products"
+  }
+
+  to {
+    connector = "db"
+
+    transaction {
+      exec {
+        query  = "DELETE FROM product_option WHERE product_id = :pid"
+        params = { pid = "input.id" }
+        when   = "input.id > 0"
+      }
+
+      exec {
+        query   = "INSERT INTO product (sku, name) VALUES (:sku, :name)"
+        params  = { sku = "input.sku", name = "input.name" }
+        capture = "product_id"
+      }
+
+      each "option" in "input.options" {
+        exec {
+          query   = "INSERT INTO product_option (product_id, code, position) VALUES (:pid, :code, :pos)"
+          params  = {
+            pid  = "captured.product_id"
+            code = "option.code"
+            pos  = "option_index"
+          }
+          capture = "option_id"
+        }
+
+        each "value" in "option.values" {
+          exec {
+            query  = "INSERT INTO option_value (option_id, label, price) VALUES (:oid, :label, :price)"
+            params = {
+              oid   = "captured.option_id"
+              label = "value.label"
+              price = "value.price"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/connector/database/mysql/transaction.go
+++ b/internal/connector/database/mysql/transaction.go
@@ -1,0 +1,15 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/matutetandil/mycel/internal/connector"
+)
+
+// RunInTx implements connector.TxRunner: it runs fn inside a single pinned
+// connection wrapped in a transaction, committing on success and rolling back
+// on error. Named parameters are bound with the connector's MySQL/MariaDB
+// dialect (LAST_INSERT_ID() is reported via sql.Result.LastInsertId()).
+func (c *Connector) RunInTx(ctx context.Context, fn func(ops connector.TxOps) error) error {
+	return connector.RunInSQLTx(ctx, c.db, c.parseNamedParams, fn)
+}

--- a/internal/connector/database/sqlite/transaction.go
+++ b/internal/connector/database/sqlite/transaction.go
@@ -1,0 +1,14 @@
+package sqlite
+
+import (
+	"context"
+
+	"github.com/matutetandil/mycel/internal/connector"
+)
+
+// RunInTx implements connector.TxRunner: it runs fn inside a single pinned
+// connection wrapped in a transaction, committing on success and rolling back
+// on error. last_insert_rowid() is reported via sql.Result.LastInsertId().
+func (c *Connector) RunInTx(ctx context.Context, fn func(ops connector.TxOps) error) error {
+	return connector.RunInSQLTx(ctx, c.db, c.parseNamedParams, fn)
+}

--- a/internal/connector/transaction.go
+++ b/internal/connector/transaction.go
@@ -1,0 +1,127 @@
+package connector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// TxRunner is implemented by connectors that can execute a unit of work inside
+// a single pinned connection wrapped in a database transaction. The runtime's
+// transaction executor depends only on this interface, never on a concrete
+// driver: the connector owns named-parameter binding and last-insert-id
+// semantics so the executor stays driver-agnostic.
+type TxRunner interface {
+	// RunInTx opens a transaction on a pinned connection, invokes fn with a
+	// TxOps bound to that transaction, then commits if fn returns nil or rolls
+	// back if fn returns an error (or panics). The pinned connection is what
+	// makes LAST_INSERT_ID() and captured SELECTs coherent across statements.
+	RunInTx(ctx context.Context, fn func(ops TxOps) error) error
+}
+
+// TxOps is the driver-agnostic handle for running statements inside a pinned
+// transaction. Implementations resolve :named placeholders per their dialect.
+type TxOps interface {
+	// Exec runs a non-SELECT statement (INSERT/UPDATE/DELETE). It returns the
+	// last inserted id (driver-defined; 0 when the driver does not report one)
+	// and the number of rows affected.
+	Exec(ctx context.Context, query string, params map[string]interface{}) (lastInsertID int64, rowsAffected int64, err error)
+
+	// QueryScalar runs a SELECT and returns the first column of the first row,
+	// or nil when the result set is empty.
+	QueryScalar(ctx context.Context, query string, params map[string]interface{}) (interface{}, error)
+}
+
+// NamedParamParser rewrites a query with :name placeholders into the driver's
+// positional form and returns the ordered argument values. Database connectors
+// already implement this internally (parseNamedParams); they pass it to
+// RunInSQLTx so the shared transaction machinery stays driver-agnostic.
+type NamedParamParser func(query string, params map[string]interface{}) (string, []interface{})
+
+// RunInSQLTx is the shared database/sql implementation of TxRunner.RunInTx.
+// SQL database connectors implement RunInTx as a one-line delegation to this
+// helper, passing their *sql.DB and their parseNamedParams so there is a single
+// copy of the begin/commit/rollback + parameter-binding machinery.
+//
+// On a panic inside fn the transaction is rolled back and the panic is
+// re-raised, so a buggy executor can never leave a connection mid-transaction.
+func RunInSQLTx(ctx context.Context, db *sql.DB, parse NamedParamParser, fn func(ops TxOps) error) (err error) {
+	if db == nil {
+		return fmt.Errorf("database not connected")
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := fn(&sqlTxOps{tx: tx, parse: parse}); err != nil {
+		return err // deferred rollback fires
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// sqlTxOps is the database/sql-backed TxOps used by RunInSQLTx.
+type sqlTxOps struct {
+	tx    *sql.Tx
+	parse NamedParamParser
+}
+
+func (o *sqlTxOps) Exec(ctx context.Context, query string, params map[string]interface{}) (int64, int64, error) {
+	sqlText, args := o.bind(query, params)
+	res, err := o.tx.ExecContext(ctx, sqlText, args...)
+	if err != nil {
+		return 0, 0, err
+	}
+	// LastInsertId / RowsAffected are best-effort: some drivers do not report
+	// them. A capture of an unsupported last-insert-id yields 0, not an error.
+	lastID, _ := res.LastInsertId()
+	affected, _ := res.RowsAffected()
+	return lastID, affected, nil
+}
+
+func (o *sqlTxOps) QueryScalar(ctx context.Context, query string, params map[string]interface{}) (interface{}, error) {
+	sqlText, args := o.bind(query, params)
+	rows, err := o.tx.QueryContext(ctx, sqlText, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		// Zero rows -> null. Later `when` gates can test for it.
+		return nil, rows.Err()
+	}
+	var value interface{}
+	if err := rows.Scan(&value); err != nil {
+		return nil, err
+	}
+	// database/sql hands TEXT/VARCHAR back as []byte; normalize to string so
+	// CEL comparisons and JSON output behave like the rest of Mycel.
+	if b, ok := value.([]byte); ok {
+		value = string(b)
+	}
+	return value, rows.Err()
+}
+
+func (o *sqlTxOps) bind(query string, params map[string]interface{}) (string, []interface{}) {
+	if o.parse == nil {
+		return query, nil
+	}
+	return o.parse(query, params)
+}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -441,6 +441,12 @@ type ToConfig struct {
 	// `{ "<paramName>": { ...body... } }`. Empty means no wrapping.
 	Envelope string
 
+	// Transaction, when set, makes this destination a transactional,
+	// multi-statement, iterative write over a pinned database connection.
+	// Mutually exclusive with query/target/operation/envelope (the parser
+	// rejects the combination); the connector must be of type "database".
+	Transaction *TransactionConfig
+
 	// ConnectorParams holds all connector-specific parameters.
 	// Populated by the parser from the HCL block attributes.
 	// Access via getter methods (GetTarget, GetOperation, etc.).

--- a/internal/flow/transaction.go
+++ b/internal/flow/transaction.go
@@ -1,0 +1,87 @@
+package flow
+
+// TransactionConfig is the `to { transaction { } }` write primitive: an
+// ordered list of statements executed inside a single pinned database
+// connection wrapped in one BEGIN/COMMIT. It runs as "the write" of the flow,
+// so it is wrapped by the same dedupe / aspects / error_handling envelope as a
+// classic single-statement `to` write.
+//
+// When a `to` block has a Transaction, its query/target/operation/envelope
+// attributes are unused (the parser rejects that combination), and the `to`
+// connector must be of type "database".
+type TransactionConfig struct {
+	// Statements is the ordered list of exec/each entries. Order is textual
+	// (the order the blocks appear in the HCL file) and is significant:
+	// LAST_INSERT_ID / captured SELECT values flow forward to later statements.
+	Statements []TxStatement
+}
+
+// TxStatement is one ordered entry inside a transaction. Exactly one of Exec
+// or Each is non-nil — it is a tagged union kept as a struct (rather than an
+// interface) so the parser can preserve textual order in a single slice
+// without losing the discriminator.
+type TxStatement struct {
+	// Exec is set when this statement is a single SQL statement.
+	Exec *TxExec
+
+	// Each is set when this statement iterates a list and runs nested
+	// statements per element.
+	Each *TxEach
+}
+
+// TxExec is a single SQL statement within a transaction.
+type TxExec struct {
+	// Query is the SQL with :named placeholders, resolved from Params.
+	Query string
+
+	// Params maps placeholder name -> CEL expression, evaluated in the
+	// transaction scope (input/output/step/captured + active each bindings).
+	// Same shape as a classic to.params block.
+	Params map[string]string
+
+	// When is an optional CEL gate. If it evaluates to false the statement is
+	// skipped (not an error). Empty means always run.
+	When string
+
+	// Capture, when non-empty, stores a value under captured.<Capture> for use
+	// by later statements:
+	//   - INSERT/UPDATE/DELETE -> last insert id (driver-defined)
+	//   - SELECT               -> first column of the first row (nil if 0 rows)
+	Capture string
+}
+
+// TxEach iterates a CEL list expression and runs Body once per element. It is
+// nestable (Body may contain further each blocks).
+type TxEach struct {
+	// Var is the loop variable name. The current element is bound to <Var> and
+	// its 0-based index to <Var>_index in the CEL scope of the nested body.
+	Var string
+
+	// In is a CEL expression that evaluates to a list. A non-list or empty
+	// result runs nothing (not an error).
+	In string
+
+	// Body is the ordered list of statements run per element.
+	Body []TxStatement
+}
+
+// EachVarNames returns every each loop variable name declared anywhere in the
+// transaction (recursively), so the runtime can declare them — plus their
+// <name>_index companions — as variables in the scoped CEL environment.
+func (t *TransactionConfig) EachVarNames() []string {
+	if t == nil {
+		return nil
+	}
+	var names []string
+	var walk func(stmts []TxStatement)
+	walk = func(stmts []TxStatement) {
+		for _, s := range stmts {
+			if s.Each != nil {
+				names = append(names, s.Each.Var)
+				walk(s.Each.Body)
+			}
+		}
+	}
+	walk(t.Statements)
+	return names
+}

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -482,6 +482,7 @@ func parseToBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ToConfig, error
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "transform"},
+			{Type: "transaction"},
 		},
 	}
 
@@ -530,14 +531,21 @@ func parseToBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ToConfig, error
 		to.Envelope = val.AsString()
 	}
 
-	// Parse nested transform block
+	// Parse nested transform / transaction blocks
 	for _, nestedBlock := range content.Blocks {
-		if nestedBlock.Type == "transform" {
+		switch nestedBlock.Type {
+		case "transform":
 			transformMappings, err := parseTransformMappings(nestedBlock, ctx)
 			if err != nil {
 				return nil, fmt.Errorf("to transform error: %w", err)
 			}
 			to.Transform = transformMappings
+		case "transaction":
+			tx, err := parseTransactionBlock(nestedBlock, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("to transaction error: %w", err)
+			}
+			to.Transaction = tx
 		}
 	}
 
@@ -546,6 +554,19 @@ func parseToBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ToConfig, error
 
 	if to.Connector == "" {
 		return nil, fmt.Errorf("to block must specify a connector")
+	}
+
+	// transaction is mutually exclusive with the single-statement write
+	// attributes — they describe two different write modes.
+	if to.Transaction != nil {
+		for _, attr := range []string{"query", "target", "operation", "envelope"} {
+			if _, clash := to.ConnectorParams[attr]; clash {
+				return nil, fmt.Errorf("to block cannot combine transaction with %q (transaction is a multi-statement write; remove %q)", attr, attr)
+			}
+		}
+		if to.Envelope != "" {
+			return nil, fmt.Errorf("to block cannot combine transaction with envelope")
+		}
 	}
 
 	return to, nil

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -165,6 +165,30 @@ func (c *Configuration) Merge(other *Configuration) {
 	}
 }
 
+// ValidateTransactionTargets verifies that every flow whose `to` block uses a
+// transaction references a connector of type "database". The transaction
+// primitive pins a SQL connection and opens a BEGIN/COMMIT, so it only makes
+// sense for database connectors.
+func (c *Configuration) ValidateTransactionTargets() error {
+	typeByName := make(map[string]string, len(c.Connectors))
+	for _, conn := range c.Connectors {
+		typeByName[conn.Name] = conn.Type
+	}
+	for _, f := range c.Flows {
+		if f.To == nil || f.To.Transaction == nil {
+			continue
+		}
+		connType, known := typeByName[f.To.Connector]
+		if !known {
+			return fmt.Errorf("flow %q: transaction references unknown connector %q", f.Name, f.To.Connector)
+		}
+		if connType != "database" {
+			return fmt.Errorf("flow %q: transaction requires a database connector, but %q is of type %q", f.Name, f.To.Connector, connType)
+		}
+	}
+	return nil
+}
+
 // ValidateUniqueNames checks that no two items of the same type share a name.
 // Returns an error if duplicates are found, with file paths for both definitions.
 func (c *Configuration) ValidateUniqueNames() error {
@@ -360,6 +384,11 @@ func (p *HCLParser) Parse(ctx context.Context, configDir string) (*Configuration
 
 	// Validate that no two items of the same type share a name
 	if err := config.ValidateUniqueNames(); err != nil {
+		return nil, err
+	}
+
+	// Validate that transaction writes target a database connector
+	if err := config.ValidateTransactionTargets(); err != nil {
 		return nil, err
 	}
 

--- a/internal/parser/transaction.go
+++ b/internal/parser/transaction.go
@@ -1,0 +1,156 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+// parseTransactionBlock parses a `to { transaction { } }` block into an ordered
+// list of statements. Order is significant (captured values flow forward), so
+// it iterates the native hclsyntax body's Blocks directly rather than going
+// through a schema, which would not preserve textual order across a
+// heterogeneous exec/each mix.
+func parseTransactionBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.TransactionConfig, error) {
+	stmts, err := parseTxStatements(block.Body, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(stmts) == 0 {
+		return nil, fmt.Errorf("transaction block must contain at least one exec or each")
+	}
+	return &flow.TransactionConfig{Statements: stmts}, nil
+}
+
+// parseTxStatements reads the ordered exec/each children of a transaction (or
+// of an each body). It requires the native hclsyntax body so block order is
+// preserved.
+func parseTxStatements(body hcl.Body, ctx *hcl.EvalContext) ([]flow.TxStatement, error) {
+	syntaxBody, ok := body.(*hclsyntax.Body)
+	if !ok {
+		return nil, fmt.Errorf("transaction block must use native HCL syntax")
+	}
+
+	var stmts []flow.TxStatement
+	for _, nested := range syntaxBody.Blocks {
+		switch nested.Type {
+		case "exec":
+			ex, err := parseTxExecBlock(nested.AsHCLBlock(), ctx)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, flow.TxStatement{Exec: ex})
+		case "each":
+			each, err := parseTxEachBlock(nested.AsHCLBlock(), ctx)
+			if err != nil {
+				return nil, err
+			}
+			stmts = append(stmts, flow.TxStatement{Each: each})
+		default:
+			return nil, fmt.Errorf("unsupported block %q inside transaction (expected exec or each)", nested.Type)
+		}
+	}
+	return stmts, nil
+}
+
+// parseTxExecBlock parses a single `exec { }` statement.
+func parseTxExecBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.TxExec, error) {
+	attrs, diags := block.Body.JustAttributes()
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("exec block error: %s (exec takes attributes only: query, params, when, capture)", diags.Error())
+	}
+
+	ex := &flow.TxExec{Params: map[string]string{}}
+
+	for name, attr := range attrs {
+		switch name {
+		case "query":
+			val, d := attr.Expr.Value(ctx)
+			if d.HasErrors() {
+				return nil, fmt.Errorf("exec query error: %s", d.Error())
+			}
+			ex.Query = val.AsString()
+		case "capture":
+			val, d := attr.Expr.Value(ctx)
+			if d.HasErrors() {
+				return nil, fmt.Errorf("exec capture error: %s", d.Error())
+			}
+			ex.Capture = val.AsString()
+		case "when":
+			// CEL gate: prefer the evaluated string literal, fall back to the
+			// raw expression text when it references runtime variables.
+			val, d := attr.Expr.Value(ctx)
+			if d.HasErrors() {
+				ex.When = extractExpressionText(attr.Expr)
+			} else {
+				ex.When = val.AsString()
+			}
+		case "params":
+			params, err := parseTxParams(attr, ctx)
+			if err != nil {
+				return nil, err
+			}
+			ex.Params = params
+		default:
+			return nil, fmt.Errorf("unsupported attribute %q in exec (allowed: query, params, when, capture)", name)
+		}
+	}
+
+	if ex.Query == "" {
+		return nil, fmt.Errorf("exec block requires a non-empty query")
+	}
+	return ex, nil
+}
+
+// parseTxEachBlock parses an `each "<var>" in "<listExpr>" { }` block. In native
+// HCL the header is three labels — var, the literal keyword "in", and the list
+// expression — which keeps the syntax readable while staying valid HCL.
+func parseTxEachBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.TxEach, error) {
+	if len(block.Labels) != 3 || block.Labels[1] != "in" {
+		return nil, fmt.Errorf(`each block must be written as: each "<var>" in "<listExpr>" { ... }`)
+	}
+	varName := block.Labels[0]
+	listExpr := block.Labels[2]
+	if varName == "" {
+		return nil, fmt.Errorf("each block requires a non-empty loop variable name")
+	}
+	if listExpr == "" {
+		return nil, fmt.Errorf("each %q requires a non-empty list expression", varName)
+	}
+
+	body, err := parseTxStatements(block.Body, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("each %q must contain at least one exec or each", varName)
+	}
+
+	return &flow.TxEach{Var: varName, In: listExpr, Body: body}, nil
+}
+
+// parseTxParams reads an `params = { name = "<celExpr>" }` attribute into a
+// name->expression map. Values are quoted CEL strings (same convention as
+// transform expressions), so they evaluate to string literals here and are
+// resolved against the transaction scope at runtime.
+func parseTxParams(attr *hcl.Attribute, ctx *hcl.EvalContext) (map[string]string, error) {
+	val, diags := attr.Expr.Value(ctx)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("exec params error: %s (param values must be quoted CEL expressions, e.g. owner = \"output.owner_id\")", diags.Error())
+	}
+	if !val.Type().IsObjectType() && !val.Type().IsMapType() {
+		return nil, fmt.Errorf("exec params must be an object, e.g. params = { owner = \"output.owner_id\" }")
+	}
+
+	params := make(map[string]string)
+	for k, v := range val.AsValueMap() {
+		if v.IsNull() {
+			return nil, fmt.Errorf("exec param %q is null", k)
+		}
+		params[k] = v.AsString()
+	}
+	return params, nil
+}

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -172,6 +172,14 @@ type FlowHandler struct {
 	// transformerOnce ensures the CEL transformer is initialized only once (thread-safe).
 	transformerOnce sync.Once
 	transformerErr  error
+
+	// txEvalOnce guards the scoped CEL transformer used by the to{transaction}
+	// executor, which declares `captured` plus each loop variables on top of
+	// the standard scope. Built once per handler (it rebuilds the whole CEL
+	// env) and reused across deliveries.
+	txEvalOnce sync.Once
+	txEval     *transform.CELTransformer
+	txEvalErr  error
 }
 
 // FilteredResult is returned when a request is filtered out by the from.filter expression.
@@ -1663,6 +1671,13 @@ func (h *FlowHandler) executeFlowCoreInternal(ctx context.Context, input map[str
 		return h.handleSubscriptionPublish(ctx, input)
 	}
 
+	// Transactional multi-statement write: runs as "the write" of the flow,
+	// regardless of the derived operation method, so it is wrapped by the same
+	// dedupe / aspects / error_handling envelope as a classic to-write.
+	if h.Config.To != nil && h.Config.To.Transaction != nil {
+		return h.handleTransaction(ctx, input)
+	}
+
 	// For flows with steps, execute steps + transform instead of reading from destination
 	// This supports orchestration flows where data comes from multiple sources
 	if len(h.Config.Steps) > 0 && operation.Method == "GET" {
@@ -3106,10 +3121,21 @@ func (h *FlowHandler) applyResponseTransform(ctx context.Context, input map[stri
 	return transformed, nil
 }
 
+// applyTransforms applies the flow transform (and its steps/enrichments) and
+// returns the resulting payload. It is the common path for to-writes.
 func (h *FlowHandler) applyTransforms(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	payload, _, err := h.applyTransformsWithSteps(ctx, input)
+	return payload, err
+}
+
+// applyTransformsWithSteps is applyTransforms plus the intermediate step
+// results, which the transaction executor exposes in its CEL scope as `step`.
+// Steps run exactly once here (they are side-effecting), so this is the single
+// place that both the payload and the step results are produced.
+func (h *FlowHandler) applyTransformsWithSteps(ctx context.Context, input map[string]interface{}) (map[string]interface{}, map[string]interface{}, error) {
 	// No transform configured and no steps - return input as-is
 	if h.Config.Transform == nil && len(h.Config.Enrichments) == 0 && len(h.Config.Steps) == 0 {
-		return input, nil
+		return input, nil, nil
 	}
 
 	// Initialize CEL transformer if needed (thread-safe for concurrent async flows)
@@ -3118,13 +3144,13 @@ func (h *FlowHandler) applyTransforms(ctx context.Context, input map[string]inte
 		h.Transformer, h.transformerErr = transform.NewCELTransformerWithOptions(celOptions...)
 	})
 	if h.transformerErr != nil {
-		return nil, fmt.Errorf("failed to create CEL transformer: %w", h.transformerErr)
+		return nil, nil, fmt.Errorf("failed to create CEL transformer: %w", h.transformerErr)
 	}
 
 	// Execute steps first (their results are available in transforms)
 	stepResults, err := h.executeSteps(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("step execution failed: %w", err)
+		return nil, nil, fmt.Errorf("step execution failed: %w", err)
 	}
 
 	// Collect all enrichments (flow-level + transform-level)
@@ -3155,12 +3181,12 @@ func (h *FlowHandler) applyTransforms(ctx context.Context, input map[string]inte
 	// Execute enrichments
 	enriched, err := h.executeEnrichments(ctx, input, allEnrichments)
 	if err != nil {
-		return nil, fmt.Errorf("enrichment failed: %w", err)
+		return nil, nil, fmt.Errorf("enrichment failed: %w", err)
 	}
 
 	// No transform configured, just return input (steps and enrichments were for side effects)
 	if h.Config.Transform == nil {
-		return input, nil
+		return input, stepResults, nil
 	}
 
 	// Build transform rules from config
@@ -3170,7 +3196,7 @@ func (h *FlowHandler) applyTransforms(ctx context.Context, input map[string]inte
 	if h.Config.Transform.Use != "" {
 		named, ok := h.NamedTransforms[h.Config.Transform.Use]
 		if !ok {
-			return nil, fmt.Errorf("named transform not found: %s", h.Config.Transform.Use)
+			return nil, nil, fmt.Errorf("named transform not found: %s", h.Config.Transform.Use)
 		}
 		for target, expr := range named.Mappings {
 			rules = append(rules, transform.Rule{
@@ -3190,7 +3216,7 @@ func (h *FlowHandler) applyTransforms(ctx context.Context, input map[string]inte
 
 	// No rules to apply
 	if len(rules) == 0 {
-		return input, nil
+		return input, stepResults, nil
 	}
 
 	// Apply transforms using CEL with enriched data and step results
@@ -3198,7 +3224,7 @@ func (h *FlowHandler) applyTransforms(ctx context.Context, input map[string]inte
 		return h.Transformer.TransformWithSteps(ctx, input, enriched, stepResults, rules)
 	})
 	if transformErr != nil {
-		return nil, transformErr
+		return nil, nil, transformErr
 	}
 	if m, ok := transformResult.(map[string]interface{}); ok {
 		// Capture for downstream consumers (coordinate.signal.emit needs
@@ -3206,9 +3232,9 @@ func (h *FlowHandler) applyTransforms(ctx context.Context, input map[string]inte
 		if slot := flow.TransformOutputFromContext(ctx); slot != nil {
 			slot.Set(m)
 		}
-		return m, nil
+		return m, stepResults, nil
 	}
-	return nil, fmt.Errorf("transform returned unexpected type")
+	return nil, nil, fmt.Errorf("transform returned unexpected type")
 }
 
 // resolveValidatorRefs adds custom validator constraints to fields that reference

--- a/internal/runtime/transaction.go
+++ b/internal/runtime/transaction.go
@@ -1,0 +1,296 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/flow"
+	"github.com/matutetandil/mycel/internal/trace"
+	"github.com/matutetandil/mycel/internal/transform"
+)
+
+// handleTransaction executes a `to { transaction { } }` block as the write of
+// the flow. It pins one database connection, opens a transaction, runs the
+// ordered statements (exec / each) with value capture and CEL-scoped params,
+// and commits on success or rolls back on any error. It is invoked from the
+// same point as a classic to-write, so dedupe / aspects / error_handling wrap
+// it identically.
+func (h *FlowHandler) handleTransaction(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+	txCfg := h.Config.To.Transaction
+
+	runner, ok := h.Dest.(connector.TxRunner)
+	if !ok {
+		return nil, fmt.Errorf("flow %q: connector %q does not support transactions (the to connector must be a database connector)", h.Config.Name, h.Config.To.Connector)
+	}
+
+	// The transform output is the `output` binding of the transaction scope;
+	// step results are exposed as `step`.
+	payload, steps, err := h.applyTransformsWithSteps(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("transform error: %w", err)
+	}
+	if steps == nil {
+		steps = map[string]interface{}{}
+	}
+
+	eval, err := h.transactionEvaluator()
+	if err != nil {
+		return nil, err
+	}
+
+	// Dry-run: report intent without touching the database.
+	if tc := trace.FromContext(ctx); tc != nil && tc.DryRun {
+		tc.Record(trace.Event{
+			Stage:  trace.StageWrite,
+			Name:   h.Config.To.Connector,
+			Input:  trace.Snapshot(payload),
+			DryRun: true,
+			Detail: fmt.Sprintf("transaction: %d statement(s)", len(txCfg.Statements)),
+		})
+		return map[string]interface{}{
+			"dry_run":     true,
+			"transaction": true,
+			"connector":   h.Config.To.Connector,
+		}, nil
+	}
+
+	// captured is shared between the executor and the CEL scope: as each exec
+	// captures a value it becomes visible to later statements' expressions.
+	captured := map[string]interface{}{}
+	var affected int64
+
+	writeResult, writeErr := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
+		return trace.RecordStage(ctx, trace.StageWrite, h.Config.To.Connector, trace.Snapshot(payload), func() (interface{}, error) {
+			runErr := runner.RunInTx(ctx, func(ops connector.TxOps) error {
+				ex := &txExecutor{
+					eval:     eval,
+					ops:      ops,
+					captured: captured,
+					scope: map[string]interface{}{
+						"input":    input,
+						"output":   payload,
+						"step":     steps,
+						"captured": captured,
+					},
+				}
+				a, runErr := ex.run(ctx, txCfg.Statements)
+				affected = a
+				return runErr
+			})
+			if runErr != nil {
+				return nil, runErr
+			}
+			return &connector.Result{
+				Affected: affected,
+				Metadata: map[string]interface{}{"captured": captured},
+			}, nil
+		})
+	})
+	if writeErr != nil {
+		return nil, writeErr
+	}
+
+	// Dedupe match: propagate the filtered result so the MQ consumer can
+	// ack/reject/requeue per policy.
+	if filtered, ok := writeResult.(*flow.FilteredResultWithPolicy); ok {
+		return filtered, nil
+	}
+
+	result := writeResult.(*connector.Result)
+	return map[string]interface{}{
+		"affected": result.Affected,
+		"captured": captured,
+	}, nil
+}
+
+// transactionEvaluator lazily builds (and caches) the CEL transformer used to
+// evaluate transaction expressions. It extends the standard scope with the
+// `captured` map and one variable per each loop name (plus its <name>_index
+// companion). Built once per handler because constructing a CEL environment
+// rebuilds the full function set.
+func (h *FlowHandler) transactionEvaluator() (*transform.CELTransformer, error) {
+	h.txEvalOnce.Do(func() {
+		opts := transform.CreateWASMFunctionOptions(h.FunctionsRegistry)
+		opts = append(opts, cel.Variable("captured", cel.MapType(cel.StringType, cel.DynType)))
+
+		seen := map[string]bool{}
+		for _, name := range h.Config.To.Transaction.EachVarNames() {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			opts = append(opts,
+				cel.Variable(name, cel.DynType),
+				cel.Variable(name+"_index", cel.IntType),
+			)
+		}
+
+		h.txEval, h.txEvalErr = transform.NewCELTransformerWithOptions(opts...)
+	})
+	return h.txEval, h.txEvalErr
+}
+
+// txExecutor runs an ordered list of transaction statements against a pinned
+// TxOps. It is single-threaded within one transaction, so the shared scope and
+// captured maps need no synchronization.
+type txExecutor struct {
+	eval     *transform.CELTransformer
+	ops      connector.TxOps
+	captured map[string]interface{}
+	scope    map[string]interface{}
+}
+
+// run executes statements in order, returning the total rows affected.
+func (e *txExecutor) run(ctx context.Context, stmts []flow.TxStatement) (int64, error) {
+	var affected int64
+	for _, s := range stmts {
+		switch {
+		case s.Exec != nil:
+			a, err := e.runExec(ctx, s.Exec)
+			if err != nil {
+				return affected, err
+			}
+			affected += a
+		case s.Each != nil:
+			a, err := e.runEach(ctx, s.Each)
+			if err != nil {
+				return affected, err
+			}
+			affected += a
+		}
+	}
+	return affected, nil
+}
+
+// runExec evaluates the optional when gate and params, runs the statement, and
+// captures its result when requested.
+func (e *txExecutor) runExec(ctx context.Context, ex *flow.TxExec) (int64, error) {
+	if ex.When != "" {
+		ok, err := e.evalBool(ctx, ex.When)
+		if err != nil {
+			return 0, fmt.Errorf("transaction when %q: %w", ex.When, err)
+		}
+		if !ok {
+			return 0, nil
+		}
+	}
+
+	params := make(map[string]interface{}, len(ex.Params))
+	for name, expr := range ex.Params {
+		v, err := e.eval.EvaluateWith(ctx, expr, e.scope)
+		if err != nil {
+			return 0, fmt.Errorf("transaction param %q (%q): %w", name, expr, err)
+		}
+		params[name] = v
+	}
+
+	if isSelectStatement(ex.Query) {
+		val, err := e.ops.QueryScalar(ctx, ex.Query, params)
+		if err != nil {
+			return 0, err
+		}
+		if ex.Capture != "" {
+			e.captured[ex.Capture] = val
+		}
+		return 0, nil
+	}
+
+	lastID, affected, err := e.ops.Exec(ctx, ex.Query, params)
+	if err != nil {
+		return 0, err
+	}
+	if ex.Capture != "" {
+		e.captured[ex.Capture] = lastID
+	}
+	return affected, nil
+}
+
+// runEach evaluates the list expression and runs the body once per element,
+// binding the element to each.Var and its 0-based index to <Var>_index. A
+// non-list or empty result runs nothing. Bindings are restored afterwards so
+// sibling/nested each blocks don't leak into one another's scope.
+func (e *txExecutor) runEach(ctx context.Context, each *flow.TxEach) (int64, error) {
+	listVal, err := e.eval.EvaluateWith(ctx, each.In, e.scope)
+	if err != nil {
+		return 0, fmt.Errorf("transaction each %q in %q: %w", each.Var, each.In, err)
+	}
+	list, ok := toList(listVal)
+	if !ok {
+		return 0, nil
+	}
+
+	idxKey := each.Var + "_index"
+	prevVar, hadVar := e.scope[each.Var]
+	prevIdx, hadIdx := e.scope[idxKey]
+	defer func() {
+		if hadVar {
+			e.scope[each.Var] = prevVar
+		} else {
+			delete(e.scope, each.Var)
+		}
+		if hadIdx {
+			e.scope[idxKey] = prevIdx
+		} else {
+			delete(e.scope, idxKey)
+		}
+	}()
+
+	var affected int64
+	for i, item := range list {
+		e.scope[each.Var] = item
+		e.scope[idxKey] = int64(i)
+		a, err := e.run(ctx, each.Body)
+		if err != nil {
+			return affected, err
+		}
+		affected += a
+	}
+	return affected, nil
+}
+
+// evalBool evaluates expr and coerces the result to a bool.
+func (e *txExecutor) evalBool(ctx context.Context, expr string) (bool, error) {
+	v, err := e.eval.EvaluateWith(ctx, expr, e.scope)
+	if err != nil {
+		return false, err
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("expression %q did not evaluate to a boolean (got %T)", expr, v)
+	}
+	return b, nil
+}
+
+// isSelectStatement reports whether a query reads rows (SELECT/WITH), in which
+// case a capture takes the first column of the first row rather than a last
+// insert id.
+func isSelectStatement(query string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(query))
+	return strings.HasPrefix(upper, "SELECT") || strings.HasPrefix(upper, "WITH")
+}
+
+// toList converts a CEL-evaluated value into a slice. It returns ok=false for
+// nil or non-list values so an each over a missing/empty field is a no-op.
+func toList(v interface{}) ([]interface{}, bool) {
+	if v == nil {
+		return nil, false
+	}
+	if items, ok := v.([]interface{}); ok {
+		return items, true
+	}
+	// Fall back to reflection for typed slices (e.g. []map[string]interface{}).
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil, false
+	}
+	items := make([]interface{}, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		items[i] = rv.Index(i).Interface()
+	}
+	return items, true
+}

--- a/internal/runtime/transaction_test.go
+++ b/internal/runtime/transaction_test.go
@@ -1,0 +1,353 @@
+package runtime
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/connector/database/sqlite"
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+// newTxHandler wires a FlowHandler whose destination is a real sqlite connector
+// (a temp-file DB so every pooled connection sees the same tables) with the
+// given transaction config. It returns the handler and the underlying *sql.DB
+// for assertions.
+func newTxHandler(t *testing.T, txCfg *flow.TransactionConfig) (*FlowHandler, *sql.DB) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "tx.db")
+	conn := sqlite.New("db", dbPath, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := conn.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(context.Background()) })
+
+	db := conn.DB()
+	schema := []string{
+		`CREATE TABLE parent (id INTEGER PRIMARY KEY AUTOINCREMENT, owner_id INTEGER, name TEXT)`,
+		`CREATE TABLE child (id INTEGER PRIMARY KEY AUTOINCREMENT, parent_id INTEGER, label TEXT, position INTEGER)`,
+		`CREATE TABLE child_value (id INTEGER PRIMARY KEY AUTOINCREMENT, child_id INTEGER, store_id INTEGER, val TEXT)`,
+		`CREATE TABLE lookup (option_id INTEGER, code TEXT, label TEXT)`,
+	}
+	for _, s := range schema {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("schema %q: %v", s, err)
+		}
+	}
+
+	registry := connector.NewRegistry()
+	registry.Replace("db", conn)
+
+	h := &FlowHandler{
+		Config: &flow.Config{
+			Name: "tx_flow",
+			From: &flow.FromConfig{
+				Connector:       "db",
+				ConnectorParams: map[string]interface{}{"operation": "INSERT"},
+			},
+			To: &flow.ToConfig{Connector: "db", Transaction: txCfg},
+		},
+		Dest:       conn,
+		Connectors: registry,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return h, db
+}
+
+func mkExec(query, capture, when string, params map[string]string) flow.TxStatement {
+	return flow.TxStatement{Exec: &flow.TxExec{Query: query, Capture: capture, When: when, Params: params}}
+}
+
+func count(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// TestTransactionOrderCaptureEach covers the common aggregate write: a clean
+// step, a parent insert capturing its autoincrement id, then a per-child insert
+// referencing the captured id and the each index — all atomic.
+func TestTransactionOrderCaptureEach(t *testing.T) {
+	txCfg := &flow.TransactionConfig{Statements: []flow.TxStatement{
+		mkExec(`DELETE FROM child WHERE parent_id IN (SELECT id FROM parent WHERE owner_id = :owner)`, "", "output.owner_id > 0",
+			map[string]string{"owner": "output.owner_id"}),
+		mkExec(`INSERT INTO parent (owner_id, name) VALUES (:owner, :name)`, "parent_id", "",
+			map[string]string{"owner": "output.owner_id", "name": "output.name"}),
+		{Each: &flow.TxEach{
+			Var: "child", In: "output.children",
+			Body: []flow.TxStatement{
+				mkExec(`INSERT INTO child (parent_id, label, position) VALUES (:pid, :label, :pos)`, "child_id", "",
+					map[string]string{"pid": "captured.parent_id", "label": "child.label", "pos": "child_index"}),
+			},
+		}},
+	}}
+
+	h, db := newTxHandler(t, txCfg)
+	input := map[string]interface{}{
+		"owner_id": 7,
+		"name":     "agg",
+		"children": []interface{}{
+			map[string]interface{}{"label": "a"},
+			map[string]interface{}{"label": "b"},
+			map[string]interface{}{"label": "c"},
+		},
+	}
+
+	if _, err := h.executeFlowCore(context.Background(), input); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if got := count(t, db, "parent"); got != 1 {
+		t.Fatalf("parent rows = %d, want 1", got)
+	}
+	if got := count(t, db, "child"); got != 3 {
+		t.Fatalf("child rows = %d, want 3", got)
+	}
+
+	// position must equal the 0-based each index, and all children must point
+	// at the single parent's captured id.
+	rows, err := db.Query(`SELECT c.label, c.position, c.parent_id, p.owner_id FROM child c JOIN parent p ON p.id = c.parent_id ORDER BY c.position`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	wantLabels := []string{"a", "b", "c"}
+	i := 0
+	for rows.Next() {
+		var label string
+		var pos, parentID, ownerID int
+		if err := rows.Scan(&label, &pos, &parentID, &ownerID); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if label != wantLabels[i] || pos != i {
+			t.Fatalf("row %d: label=%q pos=%d, want label=%q pos=%d", i, label, pos, wantLabels[i], i)
+		}
+		if ownerID != 7 {
+			t.Fatalf("row %d: owner_id=%d, want 7 (captured parent link broken)", i, ownerID)
+		}
+		i++
+	}
+	if i != 3 {
+		t.Fatalf("iterated %d child rows, want 3", i)
+	}
+}
+
+// TestTransactionNestedEach covers each inside each.
+func TestTransactionNestedEach(t *testing.T) {
+	txCfg := &flow.TransactionConfig{Statements: []flow.TxStatement{
+		mkExec(`INSERT INTO parent (name) VALUES (:name)`, "parent_id", "", map[string]string{"name": "output.name"}),
+		{Each: &flow.TxEach{
+			Var: "child", In: "output.children",
+			Body: []flow.TxStatement{
+				mkExec(`INSERT INTO child (parent_id, label) VALUES (:pid, :label)`, "child_id", "",
+					map[string]string{"pid": "captured.parent_id", "label": "child.label"}),
+				{Each: &flow.TxEach{
+					Var: "store", In: "child.stores",
+					Body: []flow.TxStatement{
+						mkExec(`INSERT INTO child_value (child_id, store_id, val) VALUES (:cid, :sid, :v)`, "", "",
+							map[string]string{"cid": "captured.child_id", "sid": "store.id", "v": "store.value"}),
+					},
+				}},
+			},
+		}},
+	}}
+
+	h, db := newTxHandler(t, txCfg)
+	input := map[string]interface{}{
+		"name": "agg",
+		"children": []interface{}{
+			map[string]interface{}{"label": "a", "stores": []interface{}{
+				map[string]interface{}{"id": 1, "value": "x"},
+				map[string]interface{}{"id": 2, "value": "y"},
+			}},
+			map[string]interface{}{"label": "b", "stores": []interface{}{
+				map[string]interface{}{"id": 3, "value": "z"},
+			}},
+		},
+	}
+
+	if _, err := h.executeFlowCore(context.Background(), input); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := count(t, db, "child"); got != 2 {
+		t.Fatalf("child rows = %d, want 2", got)
+	}
+	if got := count(t, db, "child_value"); got != 3 {
+		t.Fatalf("child_value rows = %d, want 3 (nested each)", got)
+	}
+}
+
+// TestTransactionCaptureScalarSelect covers capturing a scalar from a SELECT,
+// the 0-rows -> null case, and a `when` gate testing the captured null.
+func TestTransactionCaptureScalarSelect(t *testing.T) {
+	h, db := newTxHandler(t, nil) // build DB first to seed lookup
+	if _, err := db.Exec(`INSERT INTO lookup (option_id, code, label) VALUES (42, 'C', 'L')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	h.Config.To.Transaction = &flow.TransactionConfig{Statements: []flow.TxStatement{
+		// Existing row -> captures 42, then inserts a parent named "42".
+		mkExec(`SELECT option_id FROM lookup WHERE code = :c AND label = :l LIMIT 1`, "found", "",
+			map[string]string{"c": "output.code", "l": "output.label"}),
+		mkExec(`INSERT INTO parent (owner_id, name) VALUES (:oid, 'hit')`, "", "captured.found != null",
+			map[string]string{"oid": "captured.found"}),
+		// Missing row -> captures null, dependent insert is skipped.
+		mkExec(`SELECT option_id FROM lookup WHERE code = :c LIMIT 1`, "missing", "",
+			map[string]string{"c": "output.absent"}),
+		mkExec(`INSERT INTO parent (name) VALUES ('miss')`, "", "captured.missing != null", nil),
+	}}
+
+	input := map[string]interface{}{"code": "C", "label": "L", "absent": "ZZZ"}
+	if _, err := h.executeFlowCore(context.Background(), input); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	// Only the "hit" row should exist (owner_id captured from SELECT = 42).
+	var name string
+	var ownerID int
+	if err := db.QueryRow(`SELECT name, owner_id FROM parent`).Scan(&name, &ownerID); err != nil {
+		t.Fatalf("query parent: %v", err)
+	}
+	if name != "hit" || ownerID != 42 {
+		t.Fatalf("parent = (%q, %d), want (\"hit\", 42)", name, ownerID)
+	}
+	if got := count(t, db, "parent"); got != 1 {
+		t.Fatalf("parent rows = %d, want 1 (the null-capture insert must be skipped)", got)
+	}
+}
+
+// TestTransactionWhenFalseSkips confirms a false when gate skips the statement
+// without error.
+func TestTransactionWhenFalseSkips(t *testing.T) {
+	txCfg := &flow.TransactionConfig{Statements: []flow.TxStatement{
+		mkExec(`INSERT INTO parent (name) VALUES ('skipped')`, "", "output.go == true", nil),
+		mkExec(`INSERT INTO parent (name) VALUES ('ran')`, "", "", nil),
+	}}
+	h, db := newTxHandler(t, txCfg)
+
+	if _, err := h.executeFlowCore(context.Background(), map[string]interface{}{"go": false}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := count(t, db, "parent"); got != 1 {
+		t.Fatalf("parent rows = %d, want 1 (gated insert must be skipped)", got)
+	}
+	var name string
+	_ = db.QueryRow(`SELECT name FROM parent`).Scan(&name)
+	if name != "ran" {
+		t.Fatalf("name = %q, want \"ran\"", name)
+	}
+}
+
+// TestTransactionRollbackOnError confirms a failing statement rolls back every
+// prior write in the same transaction and surfaces the error.
+func TestTransactionRollbackOnError(t *testing.T) {
+	txCfg := &flow.TransactionConfig{Statements: []flow.TxStatement{
+		mkExec(`INSERT INTO parent (name) VALUES ('before-error')`, "parent_id", "", nil),
+		mkExec(`INSERT INTO child (parent_id, label) VALUES (:pid, :label)`, "", "",
+			map[string]string{"pid": "captured.parent_id", "label": "output.label"}),
+		mkExec(`INSERT INTO nonexistent_table (x) VALUES (1)`, "", "", nil), // boom
+	}}
+	h, db := newTxHandler(t, txCfg)
+
+	_, err := h.executeFlowCore(context.Background(), map[string]interface{}{"label": "a"})
+	if err == nil {
+		t.Fatal("expected error from failing statement, got nil")
+	}
+	if got := count(t, db, "parent"); got != 0 {
+		t.Fatalf("parent rows = %d, want 0 (rollback must undo the parent insert)", got)
+	}
+	if got := count(t, db, "child"); got != 0 {
+		t.Fatalf("child rows = %d, want 0 (rollback must undo the child insert)", got)
+	}
+}
+
+// --- error_handling envelope: a mock TxRunner that fails then succeeds ---
+
+type mockTxConn struct {
+	name      string
+	failFirst int // number of leading RunInTx calls to fail
+	calls     int
+}
+
+func (m *mockTxConn) Name() string                      { return m.name }
+func (m *mockTxConn) Type() string                      { return "database" }
+func (m *mockTxConn) Connect(ctx context.Context) error { return nil }
+func (m *mockTxConn) Close(ctx context.Context) error   { return nil }
+func (m *mockTxConn) Health(ctx context.Context) error  { return nil }
+func (m *mockTxConn) Write(ctx context.Context, data *connector.Data) (*connector.Result, error) {
+	return &connector.Result{}, nil
+}
+
+func (m *mockTxConn) RunInTx(ctx context.Context, fn func(connector.TxOps) error) error {
+	m.calls++
+	if m.calls <= m.failFirst {
+		return fmt.Errorf("simulated transient failure %d", m.calls)
+	}
+	return fn(noopTxOps{})
+}
+
+type noopTxOps struct{}
+
+func (noopTxOps) Exec(ctx context.Context, q string, p map[string]interface{}) (int64, int64, error) {
+	return 1, 1, nil
+}
+func (noopTxOps) QueryScalar(ctx context.Context, q string, p map[string]interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+// TestTransactionWrappedByRetry confirms the transaction runs inside the flow's
+// error_handling/retry envelope: a transient failure is retried and the second
+// attempt commits.
+func TestTransactionWrappedByRetry(t *testing.T) {
+	conn := &mockTxConn{name: "db", failFirst: 1}
+	registry := connector.NewRegistry()
+	registry.Replace("db", conn)
+
+	h := &FlowHandler{
+		Config: &flow.Config{
+			Name: "tx_retry",
+			From: &flow.FromConfig{Connector: "db", ConnectorParams: map[string]interface{}{"operation": "INSERT"}},
+			To: &flow.ToConfig{Connector: "db", Transaction: &flow.TransactionConfig{Statements: []flow.TxStatement{
+				mkExec(`INSERT INTO parent (name) VALUES ('x')`, "", "", nil),
+			}}},
+			ErrorHandling: &flow.ErrorHandlingConfig{Retry: &flow.RetryConfig{Attempts: 3, Delay: "1ms", Backoff: "constant"}},
+		},
+		Dest:       conn,
+		Connectors: registry,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if _, err := h.HandleRequest(context.Background(), map[string]interface{}{}); err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+	if conn.calls != 2 {
+		t.Fatalf("RunInTx calls = %d, want 2 (one failure + one retry success)", conn.calls)
+	}
+}
+
+// TestTransactionBackwardCompatClassicWrite confirms a classic to.query write
+// (no transaction) still works through the same handler/connector.
+func TestTransactionBackwardCompatClassicWrite(t *testing.T) {
+	h, db := newTxHandler(t, nil)
+	h.Config.To.Transaction = nil
+	h.Config.To.ConnectorParams = map[string]interface{}{
+		"query":     "INSERT INTO parent (name) VALUES (:name)",
+		"operation": "INSERT",
+	}
+
+	if _, err := h.executeFlowCore(context.Background(), map[string]interface{}{"name": "classic"}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := count(t, db, "parent"); got != 1 {
+		t.Fatalf("parent rows = %d, want 1 (classic write must still work)", got)
+	}
+}

--- a/internal/transform/cel.go
+++ b/internal/transform/cel.go
@@ -886,6 +886,27 @@ func (t *CELTransformer) Evaluate(ctx context.Context, expr string, input map[st
 	return CELValueToNative(result), nil
 }
 
+// EvaluateWith compiles expr and evaluates it against the provided activation
+// map directly, returning the result as a native Go value. Unlike Evaluate,
+// the caller supplies the full activation, so every variable the expression
+// references must be present and declared in this transformer's environment.
+//
+// It exists for the transaction executor, whose scope (captured values plus
+// dynamically-named each loop bindings) is only known at runtime: construct a
+// transformer via NewCELTransformerWithOptions declaring those extra variables,
+// then evaluate each expression with EvaluateWith.
+func (t *CELTransformer) EvaluateWith(ctx context.Context, expr string, activation map[string]interface{}) (interface{}, error) {
+	prog, err := t.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	result, _, err := prog.Eval(activation)
+	if err != nil {
+		return nil, fmt.Errorf("CEL eval error: %w", err)
+	}
+	return CELValueToNative(result), nil
+}
+
 // Transform applies transformation rules to input data using CEL.
 func (t *CELTransformer) Transform(ctx context.Context, input map[string]interface{}, rules []Rule) (map[string]interface{}, error) {
 	output := make(map[string]interface{})

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -109,6 +109,46 @@ func ToSchema() Block {
 			{Name: "format", Doc: "Output format", Type: TypeString, Values: []string{"json", "xml", "csv", "tsv"}},
 			{Name: "filter", Doc: "Per-user filter (WebSocket, SSE, subscriptions)", Type: TypeString},
 		},
+		Children: []Block{
+			TransactionSchema(),
+		},
+	}
+}
+
+// TransactionSchema describes the to{transaction} multi-statement write: an
+// ordered list of exec/each statements run in a single database transaction.
+func TransactionSchema() Block {
+	return Block{
+		Type: "transaction",
+		Doc:  "Multi-statement, iterative write run atomically in one DB transaction (database connectors only). Mutually exclusive with query/target/operation/envelope.",
+		Children: []Block{
+			TxExecSchema(),
+			TxEachSchema(),
+		},
+	}
+}
+
+func TxExecSchema() Block {
+	return Block{
+		Type: "exec",
+		Doc:  "A single SQL statement inside a transaction.",
+		Attrs: []Attr{
+			{Name: "query", Doc: "SQL with :named placeholders", Type: TypeString, Required: true},
+			{Name: "params", Doc: "Map of placeholder name -> CEL expression (scope: input, output, step, captured, each vars)", Type: TypeMap},
+			{Name: "when", Doc: "CEL gate — statement is skipped when false", Type: TypeString},
+			{Name: "capture", Doc: "Store the result under captured.<name>: last insert id for INSERT/UPDATE/DELETE, first column of first row for SELECT", Type: TypeString},
+		},
+	}
+}
+
+func TxEachSchema() Block {
+	return Block{
+		Type:   "each",
+		Doc:    `Iterate a CEL list, running nested statements per element. Written as: each "<var>" in "<listExpr>" { ... }. The element binds to <var> and its index to <var>_index.`,
+		Labels: 3, // <var> in <listExpr>
+		Children: []Block{
+			TxExecSchema(),
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a **`to { transaction { } }`** write primitive: a flow destination can run an ordered list of SQL statements inside a single pinned database connection wrapped in one `BEGIN`/`COMMIT` — all-or-nothing. This makes a complex aggregate write (clean previous rows, insert a parent and capture its autoincrement id, insert N children that reference it, route attributes by type) expressible declaratively, which the single-statement `to` write could not do.

```hcl
to {
  connector = "db"            # must be a database connector

  transaction {
    exec {
      query  = "DELETE FROM child WHERE owner_id = :owner"
      params = { owner = "output.owner_id" }
      when   = "output.owner_id > 0"
    }
    exec {
      query   = "INSERT INTO parent (owner_id, name) VALUES (:owner, :name)"
      params  = { owner = "output.owner_id", name = "output.name" }
      capture = "parent_id"               # INSERT → captured.parent_id
    }
    each "child" in "output.children" {
      exec {
        query   = "INSERT INTO child (parent_id, label, position) VALUES (:pid, :label, :pos)"
        params  = { pid = "captured.parent_id", label = "child.label", pos = "child_index" }
        capture = "child_id"
      }
      each "store" in "child.stores" {     # nestable
        exec {
          query  = "INSERT INTO child_value (child_id, store_id) VALUES (:cid, :sid)"
          params = { cid = "captured.child_id", sid = "store.id" }
        }
      }
    }
    exec {
      query   = "SELECT option_id FROM lookup WHERE code = :c LIMIT 1"
      params  = { c = "output.code" }
      capture = "option_id"               # SELECT → first col of first row (null if 0 rows)
    }
  }
}
```

## Semantics

- **Pinned connection + atomic commit/rollback.** All statements run on one connection in one transaction, so `LAST_INSERT_ID()`/`last_insert_rowid()` and captured `SELECT`s are coherent. Any error (failing statement, unresolved `when`/param CEL, or panic) rolls back the whole transaction and propagates to the flow's `error_handling`.
- **`exec`** — one statement; `:named` params from CEL; optional `when` gate (false = skip); optional `capture` (last insert id for write, first column of first row for SELECT).
- **`each "<var>" in "<listExpr>"`** — iterate a CEL list, binding `<var>` and `<var>_index` (0-based); non-list/empty runs nothing; nestable.
- **CEL scope:** `input`, `output`, `step`, `captured` + active `each` bindings.
- **Driver-agnostic:** runtime depends only on `connector.TxRunner` (shared `RunInSQLTx`); MySQL/MariaDB + SQLite implement it; leaves room for Postgres `RETURNING`.
- **Same envelope as a classic write:** dedupe, `after`/`on_error` aspects, and `error_handling` (retry, `on_timeout`/`on_error`) wrap the transaction as one unit.

## Validation (`mycel validate`)

Rejects `transaction` combined with `query`/`target`/`operation`/`envelope`; requires a `database` connector; requires non-empty `exec.query`; requires `each` written as `each "<var>" in "<listExpr>"`.

## Backward compatibility

Purely additive — flows without a `transaction` block behave identically. Minor version bump **2.3.0 → 2.4.0**.

## Tests

New runtime tests (SQLite in-memory + a mock `TxRunner`): execution order, `LAST_INSERT_ID` capture used downstream, scalar `SELECT` capture incl. 0-rows → null, `each` + index, nested `each`, `when=false` skip, **rollback on error** (nothing written), commit on success, wrapped by retry/error_handling, and classic-write backward compat. Full suite green (70 packages), `go vet` clean.

## Files

- **New:** `internal/flow/transaction.go`, `internal/connector/transaction.go`, `internal/connector/database/{mysql,sqlite}/transaction.go`, `internal/runtime/transaction.go` (+ test), `internal/parser/transaction.go`, `examples/transactional-write/`
- **Modified:** `internal/flow/flow.go`, `internal/transform/cel.go`, `internal/runtime/flow_registry.go`, `internal/parser/{flow,parser}.go`, `pkg/schema/builtins.go`, `cmd/mycel/main.go`
- **Docs:** `CHANGELOG.md`, `README.md`, `docs/core-concepts/flows.md`, `docs/connectors/database.md`