### PR TITLE
chore: add community health files (license, contributing, CoC, security, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill in the details below.
+        For **security vulnerabilities**, do not file a public issue — see
+        [SECURITY.md](../../security/policy).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal config to reproduce
+      description: The smallest `.mycel` config (connectors + flow) that triggers the issue. Redact any secrets.
+      render: hcl
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How you triggered it (the request, message, or command).
+      placeholder: |
+        1. `mycel start --config ./...`
+        2. `curl -X POST localhost:8080/...`
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Mycel version
+      description: Output of `mycel version` (or the Docker image tag).
+      placeholder: "2.4.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: connector
+    attributes:
+      label: Connector(s) involved
+      description: Which connector type(s) are part of the flow, if any.
+      multiple: true
+      options:
+        - REST / HTTP
+        - Database (SQLite/PostgreSQL/MySQL)
+        - MongoDB
+        - GraphQL
+        - gRPC
+        - Message queue (RabbitMQ/Kafka/Redis)
+        - MQTT
+        - TCP
+        - Files / S3 / FTP
+        - WebSocket / SSE / CDC
+        - Cache
+        - Notifications
+        - WASM plugin
+        - Other / not connector-specific
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Relevant logs, stack traces, or error output (secrets redacted).
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, architecture, and how you run Mycel (binary, Docker, k8s/Helm).
+      placeholder: "macOS arm64, Docker mdenda/mycel:2.4.0"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/matutetandil/mycel/discussions
+    about: Ask how to do something, share an idea, or get help with your config.
+  - name: Documentation
+    url: https://github.com/matutetandil/mycel/tree/main/docs
+    about: Guides and connector references — many "how do I…" questions are answered here.
+  - name: Report a security vulnerability
+    url: https://github.com/matutetandil/mycel/security/policy
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Suggest a new capability or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Mycel is *configuration, not code* — please frame
+        the request in terms of what you'd declare in HCL and what the runtime
+        should do with it.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The use case or pain point. What can't you express today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the config look like, and how should the runtime behave?
+      render: hcl
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried (existing connectors, transforms, steps, aspects, WASM plugins).
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - New connector
+        - Existing connector enhancement
+        - Flow / orchestration
+        - Transforms / CEL
+        - Auth / security
+        - Observability (metrics/health/tracing)
+        - Plugins / WASM
+        - CLI / tooling
+        - Docs
+        - Other
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Thanks for contributing to Mycel! Please fill in the sections below.
+See CONTRIBUTING.md for conventions.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking, additive)
+- [ ] Breaking change (behavior or config changes that aren't backward compatible)
+- [ ] Docs only
+- [ ] Refactor / chore
+
+## How it was tested
+
+<!-- Unit tests, example validated, integration suite, manual steps, etc. -->
+
+## Checklist
+
+- [ ] `go build ./...`, `go vet ./...`, and `go test ./...` all pass
+- [ ] Added/updated tests for the change
+- [ ] Updated docs (`docs/`, `README.md`, and any affected example)
+- [ ] Updated `CHANGELOG.md` for user-facing changes
+- [ ] New/changed `examples/` validate with `mycel validate`
+- [ ] Breaking changes are called out above and in `CHANGELOG.md`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our pledge
+
+We want Mycel to be a welcoming, friendly, and harassment-free project for
+everyone, regardless of background or experience level. As contributors and
+maintainers, we pledge to make participation a positive experience for all.
+
+## Our standard
+
+This project adopts the **Contributor Covenant**, version 2.1, as its Code of
+Conduct. Please read the full text here:
+
+> https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+In short: be respectful and constructive, assume good intent, welcome newcomers,
+and keep discussions focused on the work. Behavior that makes others feel
+unsafe or unwelcome is not acceptable.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the repository, issues,
+pull requests, discussions — and when an individual is representing the project
+in public spaces.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it privately to
+the maintainer at **matutetandil@gmail.com**. All reports will be reviewed and
+handled confidentially. The maintainer is responsible for clarifying and
+enforcing the standards above and may take any action deemed appropriate,
+including warnings or removal from project spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to Mycel
+
+Thanks for your interest in contributing! Mycel is a declarative microservice
+framework — *configuration, not code*. The runtime interprets HCL2 config; users
+describe **what** they want and Mycel handles the **how**. Keeping that promise
+is the north star for every change.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report bugs** and **request features** via [issues](../../issues) (use the templates).
+- **Improve docs** — the `docs/` tree, `README.md`, and example READMEs.
+- **Add or fix examples** under `examples/` (every example must validate).
+- **Fix bugs / add features** with tests.
+- **Report security issues privately** — see [SECURITY.md](SECURITY.md), *not* a public issue.
+
+## Development setup
+
+Mycel is **pure Go (no CGO)**. You need Go (see `go.mod` for the version).
+
+```bash
+git clone https://github.com/matutetandil/mycel
+cd mycel
+go build ./...        # build everything
+go test ./...         # run all unit tests
+```
+
+Common commands while developing:
+
+```bash
+go build -o bin/mycel ./cmd/mycel
+./bin/mycel validate --config ./examples/basic   # validate a config
+./bin/mycel start    --config ./examples/basic   # run a service
+go vet ./...                                      # static checks
+```
+
+Integration tests that need external services (Postgres, RabbitMQ, Kafka, …)
+live under `tests/integration/` and run via Docker Compose:
+
+```bash
+tests/integration/run.sh
+```
+
+## Project conventions
+
+These are enforced in review — following them gets your PR merged faster:
+
+1. **Pure Go, no CGO.** All connectors must compile without CGO.
+2. **HCL first.** All configuration is HCL2; the binary is the same, only config
+   differs. Config files use the `.mycel` extension.
+3. **Connector Owns Config.** New connectors self-describe their parameters
+   (via `SourceValidator`/`TargetValidator` and the schema in `pkg/schema/`)
+   rather than requiring parser changes.
+4. **One concern per file.** Keep types, parsers, and executors in their own
+   logical files — avoid dumping unrelated code into one file.
+5. **Standard protocols in/out.** Connectors speak standard protocols (REST,
+   gRPC, queues, …); a Mycel service is indistinguishable from a hand-written one.
+6. **Connector names use underscores**, not hyphens (e.g. `my_api`, not `my-api`).
+7. **Recursive scanning.** All config directories are scanned recursively for
+   `.mycel` files.
+
+## Tests
+
+Every package must have tests, and the full suite must stay green:
+
+```bash
+go test ./...
+```
+
+- Add tests with your change. For runtime/flow behavior, an in-memory SQLite
+  connector or a mock connector is usually enough (see existing `*_test.go`
+  files for the patterns).
+- New or changed `examples/` must pass `mycel validate`.
+- For features touching external services, add an integration suite under
+  `tests/integration/` (skip gracefully when the service isn't available).
+
+## Commit & PR guidelines
+
+- Branch off `main` (e.g. `feature/...`, `fix/...`, `docs/...`, `chore/...`).
+- Write **clear commit messages in English**. We follow
+  [Conventional Commits](https://www.conventionalcommits.org/) loosely
+  (`feat:`, `fix:`, `docs:`, `chore:`, …) with a focused subject and a body that
+  explains the *why*.
+- **Update docs with code.** If you change behavior or add a feature, update the
+  relevant `docs/`, `README.md`, and the example.
+- **Update `CHANGELOG.md`** for any user-facing change (the project keeps a
+  version-by-version changelog).
+- Make sure `go build ./...`, `go vet ./...`, and `go test ./...` all pass before
+  opening the PR.
+- Fill in the pull request template and link any related issue.
+
+We use Semantic Versioning: additive, backward-compatible changes are minor
+bumps; breaking changes are major and must be called out explicitly in the PR
+and `CHANGELOG.md`.
+
+## Questions
+
+Open a [discussion](../../discussions) or a question issue. For anything
+security-related, follow [SECURITY.md](SECURITY.md) instead of filing publicly.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Matías Denda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -349,8 +349,10 @@ If you find this project useful, consider supporting its development:
 
 ## Contributing
 
-Contributions are welcome! Please read the contributing guidelines before submitting a pull request.
+Contributions are welcome! Please read the [contributing guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before submitting a pull request.
+For security issues, see the [security policy](SECURITY.md).
 
 ## License
 
-MIT
+Released under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security issues through public GitHub issues, discussions,
+or pull requests.**
+
+Report them privately through GitHub's **Private Vulnerability Reporting**:
+
+> Go to the repository's **Security** tab → **Report a vulnerability**.
+
+(If that option is not visible, ask a maintainer to enable it under
+*Settings → Security → Private vulnerability reporting*.)
+
+Please include enough detail to reproduce and assess the issue:
+
+- A description of the issue and its impact.
+- Steps to reproduce (a minimal `.mycel` config and request, if applicable).
+- The Mycel version (`mycel version`) and how it is deployed.
+- Any relevant logs (with secrets redacted).
+
+You can expect an initial acknowledgement within a few business days. We will
+keep you informed about progress toward a fix and coordinate disclosure timing
+with you.
+
+## Supported versions
+
+Mycel follows Semantic Versioning. Security fixes are released against the
+**latest minor version** on the `main` line. Please upgrade to the latest
+release before reporting, in case the issue is already fixed.
+
+## Scope
+
+**In scope** — issues in the Mycel runtime and connectors, such as:
+
+- Input-handling flaws reachable through a connector (injection, parsing, etc.).
+- Authentication/authorization bypasses in the built-in auth system.
+- Sandbox-escape from WASM plugins/validators into the host process.
+- Denial-of-service that a single malformed request/message can trigger
+  (algorithmic blow-ups, unbounded memory).
+- Secret leakage (e.g. credentials surfacing in logs or traces).
+
+**Out of scope:**
+
+- Vulnerabilities in **your** configuration or in the backend services Mycel
+  talks to (databases, brokers, HTTP APIs). Mycel runs the config you give it.
+- Issues requiring a malicious operator who already controls the config files or
+  the host.
+- Findings against outdated versions already fixed in a newer release.
+
+## A note on the framework vs. your service
+
+Mycel is a **framework/runtime**: it gives you the security tools
+(secure-by-default input sanitization, injection/XXE protections, an auth system
+with MFA/WebAuthn, rate limiting and circuit breakers, retry/DLQ). The framework
+itself is not what carries a compliance certification (PCI, SOC 2, …) — those
+apply to the **service you deploy**. Mycel hardens the boundary; the security
+posture of the running service still depends on how you configure and operate it.
+
+Thank you for helping keep Mycel and its users safe.


### PR DESCRIPTION
## Summary

Adds the GitHub **community standards** that were missing from the repo. No code changes.

| File | Notes |
|---|---|
| `LICENSE` | MIT — the README already declared MIT (badge + section) but the file didn't exist. |
| `CONTRIBUTING.md` | Dev setup, build/test/validate commands, project conventions (pure Go, HCL-first, Connector Owns Config, one concern per file, `.mycel`, underscore connector names), commit & PR guidelines, CHANGELOG/SemVer expectations. |
| `CODE_OF_CONDUCT.md` | Adopts **Contributor Covenant 2.1** by reference, private contact `matutetandil@gmail.com`. |
| `SECURITY.md` | Private vulnerability reporting via **GitHub Private Vulnerability Reporting**, supported versions, in/out scope, and the framework-vs-deployed-service note. |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Issue form: Mycel version, minimal config, repro, connector(s), logs, environment. |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Issue form framed around declarative config. |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues; links discussions / docs / security policy. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Checklist for build/vet/test, tests, docs, CHANGELOG, examples, breaking changes. |

README's Contributing/License sections now link these files (the Contributing line previously referenced guidelines that didn't exist).

## Action required after merge

To make **Private Vulnerability Reporting** work (referenced by `SECURITY.md` and the issue config), enable it once in **Settings → Security → Private vulnerability reporting**.