### PR TITLE
chore: add FUNDING.yml linking Buy Me a Coffee

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# GitHub Funding configuration.
+# Surfaces a "Sponsor" button on the repo page and an entry in the right
+# sidebar. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+buy_me_a_coffee: matutetandil


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so GitHub surfaces the existing Buy Me a Coffee link as the **Sponsor** button on the repo page and an entry in the right sidebar.

```yaml
buy_me_a_coffee: matutetandil
```

No code changes; the README's existing sponsor link is unaffected. The button appears automatically after merge.