### PR TITLE
Reusable inline blocks (v2.6.0): name once, reference with use = "<kind>.<name>"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-05-29
+
+### Added
+
+- **Reusable inline blocks.** Every inline block that used to be copy-pasted flow after flow can now be declared **once** at the top level with a name and referenced from any number of flows via `use = "<kind>.<name>"`, with optional attribute-level overrides. This extends the mechanism `transform` and `cache` already had to ten more kinds:
+
+  | Category | Kinds |
+  |---|---|
+  | Flat | `dedupe`, `retry`, `lock`, `semaphore`, `sequence_guard` |
+  | Sub-block | `coordinate`, `transaction`, `error_handling` |
+  | Mapping | `accept`, `response` |
+
+  ```hcl
+  dedupe "standard" {
+    cache = "fingerprints"
+    key   = "'item:' + input.id"
+    ttl   = "30d"
+    fingerprint { id = "output.id"  price = "output.price" }
+  }
+
+  flow "ingest_products" {
+    # ...
+    dedupe { use = "dedupe.standard" }
+  }
+
+  flow "ingest_orders" {
+    # ...
+    dedupe {
+      use = "dedupe.standard"
+      key = "'order:' + input.id"   # override just the key
+      ttl = "7d"                    # cache + fingerprint inherited
+    }
+  }
+  ```
+
+  Merge rules: scalars override when set; map fields (dedupe `fingerprint`, `response` mappings) merge key by key; sub-blocks (lock `storage`, error_handling `retry`, …) are replaced wholesale. A named `error_handling` may itself reference a named `retry` (resolved outer-first). References are validated at config load — a `use` pointing at a non-existent name fails `mycel validate` with the list of available names, never at runtime.
+
+  `error_response`, `on_timeout`, and `on_error` are intentionally **not** independently nameable: they live inside `error_handling`, which holds a single one of each, so reusing the whole named `error_handling` already covers them.
+
+  Strictly **additive and backward-compatible**: every existing inline block (written without `use`) behaves exactly as before. Names live in a per-kind namespace. See [`examples/reusable-blocks/`](examples/reusable-blocks/) and [`docs/core-concepts/reusable-blocks.md`](docs/core-concepts/reusable-blocks.md).
+
+### Internal
+
+- Reusable-block plumbing is table-driven: a single `reusableKinds` registry in `internal/parser/reusable.go` drives the top-level parse dispatch, name-uniqueness validation, and reference resolution, so each kind contributes only its parse/merge functions. References are folded into self-contained blocks by a new `ResolveReferences` pass at parse time; the runtime is unchanged.
+
 ## [2.5.0] - 2026-05-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ That's it. REST API + database, zero code.
 | Accept Gate | Business-level message routing with `on_reject` policy (ack/reject/requeue) ([docs](docs/core-concepts/flows.md#the-accept-block)) |
 | Source Fan-Out | Multiple flows from the same connector+operation, concurrent execution ([docs](docs/core-concepts/flows.md#source-fan-out-multiple-flows-from-same-source)) |
 | [Named Operations](examples/named-operations) | Reusable parameterized operations |
+| [Reusable Inline Blocks](examples/reusable-blocks) | Declare dedupe/retry/lock/accept/response/etc. once, reference from many flows with `use = "<kind>.<name>"` ([docs](docs/core-concepts/reusable-blocks.md)) |
 | [Data Enrichment](examples/enrich) | Combine data from multiple sources |
 | [Auth (JWT, MFA, WebAuthn)](examples/auth) | Authentication with presets and MFA ([docs](docs/guides/auth.md)) |
 | [Rate Limiting / Circuit Breaker](examples/rate-limit) | Traffic control and fault tolerance |

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ That's it. REST API + database, zero code.
 | Accept Gate | Business-level message routing with `on_reject` policy (ack/reject/requeue) ([docs](docs/core-concepts/flows.md#the-accept-block)) |
 | Source Fan-Out | Multiple flows from the same connector+operation, concurrent execution ([docs](docs/core-concepts/flows.md#source-fan-out-multiple-flows-from-same-source)) |
 | [Named Operations](examples/named-operations) | Reusable parameterized operations |
-| [Reusable Inline Blocks](examples/reusable-blocks) | Declare dedupe/retry/lock/accept/response/etc. once, reference from many flows with `use = "<kind>.<name>"` ([docs](docs/core-concepts/reusable-blocks.md)) |
+| [Reusable Blocks](examples/reusable-blocks) | **Recommended:** declare dedupe/retry/lock/accept/response/etc. once with a name, reference from many flows with `use = "<kind>.<name>"` — named vs anonymous, like functions ([docs](docs/core-concepts/reusable-blocks.md)) |
 | [Data Enrichment](examples/enrich) | Combine data from multiple sources |
 | [Auth (JWT, MFA, WebAuthn)](examples/auth) | Authentication with presets and MFA ([docs](docs/guides/auth.md)) |
 | [Rate Limiting / Circuit Breaker](examples/rate-limit) | Traffic control and fault tolerance |

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.5.0"
+	version = "2.6.0"
 	commit  = "dev"
 )
 

--- a/docs/core-concepts/reusable-blocks.md
+++ b/docs/core-concepts/reusable-blocks.md
@@ -1,0 +1,130 @@
+# Reusable Inline Blocks
+
+> Since v2.6.0
+
+Many flows share the same deduplication policy, the same retry/error strategy,
+the same lock backend, the same response envelope. Instead of copy-pasting those
+blocks into every flow, declare each one **once** at the top level with a name,
+then **reference** it from any flow with `use = "<kind>.<name>"`.
+
+This is the same mechanism `transform` and `cache` already used — now extended
+to every inline block.
+
+```hcl
+# Declare once, top level:
+dedupe "standard" {
+  cache = "fingerprints"
+  key   = "'item:' + input.id"
+  ttl   = "30d"
+  fingerprint {
+    id    = "output.id"
+    price = "output.price"
+  }
+}
+
+# Reference from any number of flows:
+flow "ingest_products" {
+  # ...
+  dedupe { use = "dedupe.standard" }
+  # ...
+}
+```
+
+## Overriding
+
+A referencing block can override individual attributes inline. Anything it does
+not mention is inherited from the named base.
+
+```hcl
+flow "ingest_orders" {
+  # ...
+  dedupe {
+    use = "dedupe.standard"
+    key = "'order:' + input.id"   # override just the key
+    ttl = "7d"                    # and the retention
+    # cache + fingerprint inherited from "standard"
+  }
+}
+```
+
+The merge rules depend on the field type:
+
+| Field type | Override behavior |
+|---|---|
+| Scalar (string, number, bool) | Inline value wins when set; otherwise inherits the base. |
+| Map (e.g. dedupe `fingerprint`, `response` mappings) | Merged key by key — inline keys win, base-only keys are preserved. |
+| Sub-block (e.g. lock `storage`, error_handling `retry`) | Replaced **wholesale** when the inline block defines one — no deep merge. |
+
+> Note on booleans: because a bool cannot distinguish "unset" from "false", an
+> inline `wait = true` overrides the base, but an omitted/`false` `wait` inherits
+> the base value. To force the opposite of a base, define a separate named block.
+
+## What's reusable
+
+| Kind | Where the reference goes | Notes |
+|---|---|---|
+| `dedupe` | `flow { dedupe { use = … } }` | fingerprint map merges key by key |
+| `retry` | `error_handling { retry { use = … } }` | lives inside `error_handling` |
+| `lock` | `flow { lock { use = … } }` | `storage` sub-block replaced wholesale |
+| `semaphore` | `flow { semaphore { use = … } }` | `storage` sub-block replaced wholesale |
+| `sequence_guard` | `flow { sequence_guard { use = … } }` | `storage` sub-block replaced wholesale |
+| `coordinate` | `flow { coordinate { use = … } }` | wait/signal/preflight replaced wholesale |
+| `transaction` | `to { transaction { use = … } }` | inline statements replace the base's wholesale |
+| `error_handling` | `flow { error_handling { use = … } }` | sub-blocks replaced wholesale; may itself reference a named `retry` |
+| `accept` | `flow { accept { use = … } }` | |
+| `response` | `flow { response { use = … } }` | mappings merge key by key |
+| `transform` | `flow { transform { use = … } }` | (since earlier; mappings merge key by key) |
+| `cache` | `flow { cache { use = … } }` | (since earlier) |
+
+`error_response`, `on_timeout`, and `on_error` are **not** independently
+nameable: they live inside `error_handling`, which holds a single one of each,
+so reusing the whole named `error_handling` already covers them.
+
+## Nesting
+
+A named `error_handling` can itself reference a named `retry`:
+
+```hcl
+retry "resilient" {
+  attempts = 5
+  backoff  = "exponential"
+}
+
+error_handling "resilient" {
+  retry { use = "retry.resilient" }
+  on_timeout { action = "ack" }
+}
+
+flow "x" {
+  error_handling { use = "error_handling.resilient" }   # resolves both levels
+}
+```
+
+The references are resolved outer-first, so the nested `retry` reference is
+folded in after the `error_handling` is materialized onto the flow.
+
+## CEL scope
+
+A named block's CEL expressions (`input.x`, `output.y`, `step.z`,
+`captured.w`) are evaluated in the **consuming flow's** scope. A named block is
+therefore only portable across flows that share the relevant input/output shape
+— this is the author's responsibility; Mycel does not infer types across the
+reference.
+
+## Validation
+
+References are resolved and validated at config load (parse time), not at
+runtime. A `use` that names a block that does not exist fails `mycel validate`
+immediately, with a message listing the available names:
+
+```
+flow "x": dedupe references unknown name "standar" (available: standard)
+```
+
+## Backward compatibility
+
+Strictly additive. Every existing inline block — written without `use` — behaves
+exactly as before. Names live in a per-kind namespace, so `flow "x"` and
+`dedupe "x"` never collide.
+
+See the runnable example in [`examples/reusable-blocks/`](../../examples/reusable-blocks/).

--- a/docs/core-concepts/reusable-blocks.md
+++ b/docs/core-concepts/reusable-blocks.md
@@ -1,17 +1,25 @@
-# Reusable Inline Blocks
+# Reusable Blocks
 
 > Since v2.6.0
 
-Many flows share the same deduplication policy, the same retry/error strategy,
-the same lock backend, the same response envelope. Instead of copy-pasting those
-blocks into every flow, declare each one **once** at the top level with a name,
-then **reference** it from any flow with `use = "<kind>.<name>"`.
+Think of an inline block as an **anonymous function** and a named block as a
+**named function**. Writing a `dedupe`/`retry`/`lock`/`response`/… block
+directly inside a flow is the anonymous form: quick, local, fine for a genuine
+one-off. The moment the same policy shows up in a second flow, you're
+copy-pasting an anonymous function — and you should give it a name instead.
 
-This is the same mechanism `transform` and `cache` already used — now extended
-to every inline block.
+**Naming reusable blocks is the recommended way to write Mycel configs.**
+Declare the block **once** at the top level with a name, then **reference** it
+from any flow with `use = "<kind>.<name>"`. One definition becomes the single
+source of truth: change the retry budget or the dedupe key once and every flow
+that references it follows. It also makes each flow read as intent ("dedupe with
+the standard policy") instead of a wall of repeated configuration.
+
+This is the same mechanism `transform` and `cache` always used — now available
+for every inline block.
 
 ```hcl
-# Declare once, top level:
+# Declare once, top level — the "named function":
 dedupe "standard" {
   cache = "fingerprints"
   key   = "'item:' + input.id"
@@ -22,13 +30,25 @@ dedupe "standard" {
   }
 }
 
-# Reference from any number of flows:
+# Reference it from any number of flows:
 flow "ingest_products" {
   # ...
   dedupe { use = "dedupe.standard" }
   # ...
 }
 ```
+
+## When to name, when to inline
+
+| Use a **named** block (recommended) | Inline (anonymous) is fine |
+|---|---|
+| The policy is, or might be, shared by more than one flow | A genuinely one-off block used by a single flow |
+| You want one place to tune retries / TTLs / lock keys | A throwaway value while prototyping |
+| You want flows to read as intent, not configuration | |
+
+A good rule of thumb: **if you copy-paste a block, name it instead.** There is
+no runtime cost — references are resolved once at config load into the same
+self-contained block the runtime would have seen inline.
 
 ## Overriding
 

--- a/examples/reusable-blocks/README.md
+++ b/examples/reusable-blocks/README.md
@@ -1,0 +1,40 @@
+# Reusable Inline Blocks
+
+Demonstrates declaring inline blocks **once** at the top level and referencing
+them from multiple flows with `use = "<kind>.<name>"`, with optional inline
+overrides. Introduced in Mycel v2.6.0.
+
+## Files
+
+- `reusable.mycel` — named blocks: `dedupe "standard"`, `retry "resilient"`,
+  `error_handling "resilient"` (which references the named retry),
+  `accept "mine"`, `response "envelope"`.
+- `flows.mycel` — two flows:
+  - `ingest_products` references the named blocks as-is.
+  - `ingest_orders` references the same blocks but overrides a few attributes
+    inline (dedupe key/ttl, retry attempts/backoff, response status).
+- `connectors.mycel` — a REST entry point, a downstream target, and a memory
+  cache for the dedupe fingerprints.
+
+## Run
+
+```bash
+mycel validate --config .
+mycel start --config .
+```
+
+```bash
+# Accepted (tenant matches the named accept gate), deduped, written downstream,
+# and returned through the named response envelope.
+curl -X POST localhost:8080/products \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"p1","name":"Widget","price":10,"tenant":"acme"}'
+
+# Same building blocks, with the order flow's inline overrides applied.
+curl -X POST localhost:8080/orders \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"o1","customer":"Acme Inc","total":99}'
+```
+
+See [docs/core-concepts/reusable-blocks.md](../../docs/core-concepts/reusable-blocks.md)
+for the full matrix of what is reusable and the override/merge rules.

--- a/examples/reusable-blocks/README.md
+++ b/examples/reusable-blocks/README.md
@@ -1,8 +1,11 @@
-# Reusable Inline Blocks
+# Reusable Blocks
 
-Demonstrates declaring inline blocks **once** at the top level and referencing
-them from multiple flows with `use = "<kind>.<name>"`, with optional inline
-overrides. Introduced in Mycel v2.6.0.
+Demonstrates the **recommended** way to write Mycel configs: declare a block
+**once** at the top level with a name and reference it from multiple flows with
+`use = "<kind>.<name>"` (with optional inline overrides), instead of
+copy-pasting the same block into every flow. Think named vs anonymous functions
+— inline is fine for a one-off, but the moment a policy is shared, name it.
+Introduced in Mycel v2.6.0.
 
 ## Files
 

--- a/examples/reusable-blocks/config.mycel
+++ b/examples/reusable-blocks/config.mycel
@@ -1,0 +1,4 @@
+service {
+  name    = "reusable-blocks-demo"
+  version = "1.0.0"
+}

--- a/examples/reusable-blocks/connectors.mycel
+++ b/examples/reusable-blocks/connectors.mycel
@@ -1,0 +1,18 @@
+# REST entry point for the demo flows.
+connector "api" {
+  type = "rest"
+  port = 8080
+}
+
+# Downstream the flows write to. Swap for any real target.
+connector "downstream" {
+  type = "rest"
+  url  = "http://localhost:9000"
+}
+
+# Cache backing the dedupe fingerprints (memory keeps the demo self-contained;
+# swap driver = "redis" + url in production).
+connector "fingerprints" {
+  type   = "cache"
+  driver = "memory"
+}

--- a/examples/reusable-blocks/flows.mycel
+++ b/examples/reusable-blocks/flows.mycel
@@ -1,0 +1,78 @@
+# Flows that reuse the named blocks from reusable.mycel.
+
+# Ingest products: reuses the standard dedupe, the resilient error policy, the
+# tenant gate, and the response envelope — all by reference, no copy-paste.
+flow "ingest_products" {
+  from {
+    connector = "api"
+    operation = "POST /products"
+  }
+
+  accept {
+    use = "accept.mine"
+  }
+
+  transform {
+    id    = "input.id"
+    name  = "input.name"
+    price = "input.price"
+  }
+
+  dedupe {
+    use = "dedupe.standard"
+  }
+
+  error_handling {
+    use = "error_handling.resilient"
+  }
+
+  to {
+    connector = "downstream"
+    target    = "/products"
+    operation = "POST"
+  }
+
+  response {
+    use = "response.envelope"
+  }
+}
+
+# Ingest orders: same building blocks, but this flow overrides a couple of
+# attributes inline. The override wins; everything else is inherited.
+flow "ingest_orders" {
+  from {
+    connector = "api"
+    operation = "POST /orders"
+  }
+
+  transform {
+    id    = "input.id"
+    name  = "input.customer"
+    price = "input.total"
+  }
+
+  dedupe {
+    use = "dedupe.standard"
+    key = "'order:' + input.id" # override just the key; cache/ttl/fingerprint inherited
+    ttl = "7d"                  # shorter retention for orders
+  }
+
+  error_handling {
+    use = "error_handling.resilient"
+    retry {
+      attempts = 2 # this flow tolerates fewer retries; delay/backoff inherited
+      backoff  = "linear"
+    }
+  }
+
+  to {
+    connector = "downstream"
+    target    = "/orders"
+    operation = "POST"
+  }
+
+  response {
+    use    = "response.envelope"
+    status = "'created'" # override the status; id inherited
+  }
+}

--- a/examples/reusable-blocks/reusable.mycel
+++ b/examples/reusable-blocks/reusable.mycel
@@ -1,0 +1,50 @@
+# Reusable inline blocks (v2.6.0).
+#
+# Declare a block once at the top level with a name, then reference it from any
+# number of flows with `use = "<kind>.<name>"`. A referencing flow can override
+# individual attributes inline; everything it does not mention is inherited from
+# the named base. This is the same mechanism transform and cache already used,
+# now available for every inline block.
+
+# A standard content-dedup policy shared across ingestion flows.
+dedupe "standard" {
+  cache        = "fingerprints"
+  key          = "'item:' + input.id"
+  ttl          = "30d"
+  on_duplicate = "ack"
+  fingerprint {
+    id    = "output.id"
+    name  = "output.name"
+    price = "output.price"
+  }
+}
+
+# A resilient error policy: a few exponential retries, and on a downstream
+# timeout we acknowledge rather than risk a duplicate write.
+retry "resilient" {
+  attempts  = 5
+  delay     = "500ms"
+  max_delay = "30s"
+  backoff   = "exponential"
+}
+
+error_handling "resilient" {
+  retry {
+    use = "retry.resilient"
+  }
+  on_timeout {
+    action = "ack"
+  }
+}
+
+# A business gate: only process events addressed to this tenant.
+accept "mine" {
+  when      = "input.tenant == 'acme'"
+  on_reject = "ack"
+}
+
+# A standard response envelope returned to callers.
+response "envelope" {
+  id     = "output.id"
+  status = "'ok'"
+}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -875,6 +875,11 @@ type LockConfig struct {
 
 // SemaphoreConfig holds semaphore configuration for a flow.
 type SemaphoreConfig struct {
+	// Reusable carries the Name/Use fields. A named semaphore is referenced
+	// from a flow-level semaphore block via use = "semaphore.<name>". An
+	// inline storage block replaces the named base's storage wholesale.
+	Reusable
+
 	// Storage defines the storage backend for this semaphore.
 	Storage *SyncStorageConfig
 
@@ -903,6 +908,12 @@ type SemaphoreConfig struct {
 // outer lock guarantees the read-decide-write pattern is atomic across
 // concurrent workers without explicit CAS.
 type SequenceGuardConfig struct {
+	// Reusable carries the Name/Use fields. A named sequence_guard is
+	// referenced from a flow-level sequence_guard block via
+	// use = "sequence_guard.<name>". An inline storage block replaces the
+	// named base's storage wholesale.
+	Reusable
+
 	// Storage defines the storage backend (Redis or in-memory). Same shape
 	// as LockConfig / CoordinateConfig — accepts either a `url` or
 	// `host`/`port`/`password`/`db`.

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -146,6 +146,14 @@ type Config struct {
 	// For echo flows (no "to" block), only input is available.
 	Response map[string]string
 
+	// ResponseUse, when set, names a top-level reusable response block whose
+	// mappings form the base for Response. The flow's own Response entries (if
+	// any) override the named base key by key, same as transform. It is a
+	// parse-time marker resolved by the parser's ResolveReferences pass into a
+	// fully materialized Response map; the runtime only ever reads Response and
+	// ignores this field. Kept after resolution for tracing/debugging.
+	ResponseUse string
+
 	// Require defines authorization requirements.
 	Require *RequireConfig
 
@@ -303,9 +311,27 @@ func (f *FromConfig) FilterCondition() string {
 }
 
 // AcceptConfig holds the accept gate configuration.
+// ResponseConfig is a top-level, reusable response mapping. Only the named
+// form uses this struct; an inline flow-level `response {}` is still parsed
+// straight into Flow.Config.Response (a map). A flow references one via
+// `response { use = "response.<name>" }`, and the parser folds Mappings into
+// the flow's Response map (inline entries override key by key, like transform).
+type ResponseConfig struct {
+	// Reusable carries the Name/Use fields. Use is unused on the named form.
+	Reusable
+
+	// Mappings holds the field = "<celExpr>" pairs, same shape as a flow's
+	// inline response block.
+	Mappings map[string]string
+}
+
 // Accept runs after filter but before transform, for business-level decisions.
 // Example: "this message is my type, but is it specifically for me?"
 type AcceptConfig struct {
+	// Reusable carries the Name/Use fields. A named accept is referenced from
+	// a flow-level accept block via use = "accept.<name>".
+	Reusable
+
 	// When is the CEL expression to evaluate. Must return true to proceed.
 	When string
 

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -550,6 +550,14 @@ type RequireConfig struct {
 
 // ErrorHandlingConfig holds error handling settings.
 type ErrorHandlingConfig struct {
+	// Reusable carries the Name/Use fields. A named error_handling block is
+	// referenced from a flow via use = "error_handling.<name>". Inline
+	// sub-blocks (retry/fallback/error_response/on_timeout/on_error) replace
+	// the named base's wholesale. A retry pulled in this way that itself
+	// carries use = "retry.<name>" is resolved afterwards (error_handling is
+	// resolved before retry — see the reusableKinds registry).
+	Reusable
+
 	// Retry settings for automatic retries on failure.
 	Retry *RetryConfig
 
@@ -941,6 +949,12 @@ type SequenceGuardConfig struct {
 
 // CoordinateConfig holds coordination configuration for a flow.
 type CoordinateConfig struct {
+	// Reusable carries the Name/Use fields. A named coordinate is referenced
+	// from a flow-level coordinate block via use = "coordinate.<name>".
+	// Inline sub-blocks (storage/wait/signal/preflight) replace the named
+	// base's wholesale; scalars override individually.
+	Reusable
+
 	// Storage defines the storage backend for this coordinator.
 	Storage *SyncStorageConfig
 

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -596,6 +596,17 @@ type ErrorResponseConfig struct {
 
 // RetryConfig holds retry settings.
 type RetryConfig struct {
+	// Name is set when the block is declared top-level (e.g.
+	// `retry "aggressive" { ... }`) and registered as reusable. Empty for
+	// inline blocks defined directly inside an error_handling block.
+	Name string
+
+	// Use names a top-level retry block whose fields are pulled in as the
+	// base. Inline fields on this block override the corresponding fields
+	// of the named base, attribute by attribute. Empty when no reuse is
+	// requested.
+	Use string
+
 	// Attempts is the maximum number of retry attempts.
 	Attempts int
 

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -846,6 +846,18 @@ type SyncStorageConfig struct {
 
 // LockConfig holds mutex lock configuration for a flow.
 type LockConfig struct {
+	// Name is set when the block is declared top-level (e.g.
+	// `lock "user_mutex" { ... }`) and registered as reusable. Empty for
+	// inline blocks defined directly inside a flow.
+	Name string
+
+	// Use names a top-level lock block whose fields are pulled in as the
+	// base. Inline fields on this block override the corresponding fields
+	// of the named base, attribute by attribute. An inline storage block
+	// replaces the named base's storage block wholesale (no deep merge).
+	// Empty when no reuse is requested.
+	Use string
+
 	// Storage defines the storage backend for this lock.
 	Storage *SyncStorageConfig
 

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -596,16 +596,9 @@ type ErrorResponseConfig struct {
 
 // RetryConfig holds retry settings.
 type RetryConfig struct {
-	// Name is set when the block is declared top-level (e.g.
-	// `retry "aggressive" { ... }`) and registered as reusable. Empty for
-	// inline blocks defined directly inside an error_handling block.
-	Name string
-
-	// Use names a top-level retry block whose fields are pulled in as the
-	// base. Inline fields on this block override the corresponding fields
-	// of the named base, attribute by attribute. Empty when no reuse is
-	// requested.
-	Use string
+	// Reusable carries the Name/Use fields. A named retry is referenced from
+	// an error_handling.retry block via use = "retry.<name>".
+	Reusable
 
 	// Attempts is the maximum number of retry attempts.
 	Attempts int
@@ -674,6 +667,24 @@ func NewFlowError(err error, status int, body map[string]interface{}, headers ma
 	}
 }
 
+// Reusable is embedded in config structs (dedupe, retry, lock, semaphore,
+// sequence_guard, ...) that can be declared top-level with a name and then
+// referenced from a flow via use = "<kind>.<name>". It holds the two
+// cross-cutting fields the parser registers on and the reference-resolution
+// pass folds against; embedding keeps them identical across every kind.
+type Reusable struct {
+	// Name is set when the block is declared top-level (e.g.
+	// `dedupe "standard" { ... }`) and registered as reusable. Empty for
+	// inline blocks defined directly inside a flow.
+	Name string
+
+	// Use names a top-level block of the same kind whose fields are pulled
+	// in as the base. Inline fields on the referencing block override the
+	// corresponding fields of the named base, attribute by attribute. Empty
+	// when no reuse is requested.
+	Use string
+}
+
 // DedupeConfig holds content-based, biphasic deduplication for a flow.
 //
 // Semantics (since v2.1.0):
@@ -696,16 +707,9 @@ func NewFlowError(err error, status int, body map[string]interface{}, headers ma
 // is the only one who knows which fields actually count; the primitive
 // cannot infer it.
 type DedupeConfig struct {
-	// Name is set when the block is declared top-level (e.g.
-	// `dedupe "standard" { ... }`) and registered as reusable. Empty for
-	// inline blocks defined directly inside a flow.
-	Name string
-
-	// Use names a top-level dedupe block whose fields are pulled in as the
-	// base. Inline fields on this block override the corresponding fields
-	// of the named base, attribute by attribute. Empty when no reuse is
-	// requested.
-	Use string
+	// Reusable carries the Name/Use fields shared by every nameable +
+	// referenceable inline block. See the Reusable type doc.
+	Reusable
 
 	// Cache is the name of a cache-typed connector used to store
 	// fingerprints. Driver-agnostic: works with "memory" (unit tests) or
@@ -846,17 +850,11 @@ type SyncStorageConfig struct {
 
 // LockConfig holds mutex lock configuration for a flow.
 type LockConfig struct {
-	// Name is set when the block is declared top-level (e.g.
-	// `lock "user_mutex" { ... }`) and registered as reusable. Empty for
-	// inline blocks defined directly inside a flow.
-	Name string
-
-	// Use names a top-level lock block whose fields are pulled in as the
-	// base. Inline fields on this block override the corresponding fields
-	// of the named base, attribute by attribute. An inline storage block
-	// replaces the named base's storage block wholesale (no deep merge).
-	// Empty when no reuse is requested.
-	Use string
+	// Reusable carries the Name/Use fields. A named lock is referenced from a
+	// flow-level lock block via use = "lock.<name>". When overriding, an
+	// inline storage block replaces the named base's storage wholesale (no
+	// deep merge) — see mergeLock.
+	Reusable
 
 	// Storage defines the storage backend for this lock.
 	Storage *SyncStorageConfig

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -685,6 +685,17 @@ func NewFlowError(err error, status int, body map[string]interface{}, headers ma
 // is the only one who knows which fields actually count; the primitive
 // cannot infer it.
 type DedupeConfig struct {
+	// Name is set when the block is declared top-level (e.g.
+	// `dedupe "standard" { ... }`) and registered as reusable. Empty for
+	// inline blocks defined directly inside a flow.
+	Name string
+
+	// Use names a top-level dedupe block whose fields are pulled in as the
+	// base. Inline fields on this block override the corresponding fields
+	// of the named base, attribute by attribute. Empty when no reuse is
+	// requested.
+	Use string
+
 	// Cache is the name of a cache-typed connector used to store
 	// fingerprints. Driver-agnostic: works with "memory" (unit tests) or
 	// "redis" (production). The connector's pool is initialized once at

--- a/internal/flow/transaction.go
+++ b/internal/flow/transaction.go
@@ -10,6 +10,12 @@ package flow
 // attributes are unused (the parser rejects that combination), and the `to`
 // connector must be of type "database".
 type TransactionConfig struct {
+	// Reusable carries the Name/Use fields. A named transaction is declared
+	// top-level and referenced from a `to { transaction { use = ... } }`
+	// block. Override is wholesale: if the referencing block lists its own
+	// statements they replace the named base's entirely.
+	Reusable
+
 	// Statements is the ordered list of exec/each entries. Order is textual
 	// (the order the blocks appear in the HCL file) and is significant:
 	// LAST_INSERT_ID / captured SELECT values flow forward to later statements.

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -46,12 +46,12 @@ func parseFlowBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Config, error
 			{Type: "require"},
 			{Type: "after"},
 			{Type: "error_handling"},
-			{Type: "dedupe"},            // Deduplication
-			{Type: "idempotency"},       // Idempotency keys
-			{Type: "async"},             // Async execution (202 + polling)
-		{Type: "accept"},           // Accept gate (business-level filter)
-		{Type: "batch"},            // Batch processing
-		{Type: "state_transition"}, // State machine transition
+			{Type: "dedupe"},           // Deduplication
+			{Type: "idempotency"},      // Idempotency keys
+			{Type: "async"},            // Async execution (202 + polling)
+			{Type: "accept"},           // Accept gate (business-level filter)
+			{Type: "batch"},            // Batch processing
+			{Type: "state_transition"}, // State machine transition
 		},
 	}
 
@@ -2195,11 +2195,39 @@ func parseLockBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.L
 //	  on_older = "ack"
 //	  ttl      = "30d"
 //	}
+//
+// When `use = "sequence_guard.<name>"` is present, the block references a
+// top-level reusable sequence_guard block and every other field is an optional
+// override.
 func parseSequenceGuardBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.SequenceGuardConfig, error) {
+	return parseSequenceGuardBody(block, ctx, false)
+}
+
+// parseNamedSequenceGuardBlock parses a top-level
+// `sequence_guard "<name>" { ... }` block, registered in
+// Configuration.NamedSequenceGuards and referenced via
+// use = "sequence_guard.<name>".
+func parseNamedSequenceGuardBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.SequenceGuardConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("sequence_guard block requires a name label when declared at top level")
+	}
+	sg, err := parseSequenceGuardBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	sg.Name = block.Labels[0]
+	return sg, nil
+}
+
+// parseSequenceGuardBody is shared by inline and named sequence_guard blocks.
+// Strict (named top-level) requires key + sequence + storage and forbids
+// `use`. Inline blocks require the same unless they reference a named base.
+func parseSequenceGuardBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.SequenceGuardConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
-			{Name: "key", Required: true},
-			{Name: "sequence", Required: true},
+			{Name: "use"},
+			{Name: "key"},
+			{Name: "sequence"},
 			{Name: "on_older"},
 			{Name: "ttl"},
 		},
@@ -2214,6 +2242,14 @@ func parseSequenceGuardBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Sequ
 	}
 
 	sg := &flow.SequenceGuardConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("sequence_guard use error: %s", diags.Error())
+		}
+		sg.Use = parseRefName("sequence_guard", val.AsString())
+	}
 
 	for _, nestedBlock := range content.Blocks {
 		if nestedBlock.Type == "storage" {
@@ -2263,19 +2299,68 @@ func parseSequenceGuardBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Sequ
 		sg.TTL = val.AsString()
 	}
 
-	if sg.Storage == nil {
-		return nil, fmt.Errorf("sequence_guard requires a storage block")
+	if strict {
+		if sg.Use != "" {
+			return nil, fmt.Errorf("top-level sequence_guard %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if sg.Key == "" {
+			return nil, fmt.Errorf("top-level sequence_guard %q must specify a key expression", block.Labels[0])
+		}
+		if sg.Sequence == "" {
+			return nil, fmt.Errorf("top-level sequence_guard %q must specify a sequence expression", block.Labels[0])
+		}
+		if sg.Storage == nil {
+			return nil, fmt.Errorf("top-level sequence_guard %q requires a storage block", block.Labels[0])
+		}
+	} else if sg.Use == "" {
+		// Self-contained inline sequence_guard (current behavior): key +
+		// sequence + storage all required.
+		if sg.Key == "" {
+			return nil, fmt.Errorf("sequence_guard block must specify a key expression (or `use` a named one)")
+		}
+		if sg.Sequence == "" {
+			return nil, fmt.Errorf("sequence_guard block must specify a sequence expression (or `use` a named one)")
+		}
+		if sg.Storage == nil {
+			return nil, fmt.Errorf("sequence_guard requires a storage block (or `use` a named one)")
+		}
 	}
 
 	return sg, nil
 }
 
 // parseSemaphoreBlock parses a semaphore block in a flow.
+//
+// When `use = "semaphore.<name>"` is present, the block references a top-level
+// reusable semaphore block and every other field is an optional override.
 func parseSemaphoreBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.SemaphoreConfig, error) {
+	return parseSemaphoreBody(block, ctx, false)
+}
+
+// parseNamedSemaphoreBlock parses a top-level `semaphore "<name>" { ... }`
+// block, registered in Configuration.NamedSemaphores and referenced via
+// use = "semaphore.<name>".
+func parseNamedSemaphoreBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.SemaphoreConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("semaphore block requires a name label when declared at top level")
+	}
+	sem, err := parseSemaphoreBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	sem.Name = block.Labels[0]
+	return sem, nil
+}
+
+// parseSemaphoreBody is shared by inline and named semaphore blocks. Strict
+// (named top-level) requires key + a positive max_permits and forbids `use`.
+// Inline blocks require the same unless they reference a named base.
+func parseSemaphoreBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.SemaphoreConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
-			{Name: "key", Required: true},
-			{Name: "max_permits", Required: true},
+			{Name: "use"},
+			{Name: "key"},
+			{Name: "max_permits"},
 			{Name: "timeout"},
 			{Name: "lease"},
 		},
@@ -2290,6 +2375,14 @@ func parseSemaphoreBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Semaphor
 	}
 
 	sem := &flow.SemaphoreConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("semaphore use error: %s", diags.Error())
+		}
+		sem.Use = parseRefName("semaphore", val.AsString())
+	}
 
 	for _, nestedBlock := range content.Blocks {
 		if nestedBlock.Type == "storage" {
@@ -2335,6 +2428,26 @@ func parseSemaphoreBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Semaphor
 			return nil, fmt.Errorf("semaphore lease error: %s", diags.Error())
 		}
 		sem.Lease = val.AsString()
+	}
+
+	if strict {
+		if sem.Use != "" {
+			return nil, fmt.Errorf("top-level semaphore %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if sem.Key == "" {
+			return nil, fmt.Errorf("top-level semaphore %q must specify a key expression", block.Labels[0])
+		}
+		if sem.MaxPermits <= 0 {
+			return nil, fmt.Errorf("top-level semaphore %q must specify a positive max_permits", block.Labels[0])
+		}
+	} else if sem.Use == "" {
+		// Self-contained inline semaphore (current behavior): key + max_permits required.
+		if sem.Key == "" {
+			return nil, fmt.Errorf("semaphore block must specify a key expression (or `use` a named one)")
+		}
+		if sem.MaxPermits <= 0 {
+			return nil, fmt.Errorf("semaphore block must specify a positive max_permits (or `use` a named one)")
+		}
 	}
 
 	return sem, nil

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -2066,10 +2066,41 @@ func parseNamedCacheBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.NamedCa
 //	  wait    = true
 //	  retry   = "100ms"
 //	}
+//
+// When `use = "lock.<name>"` is present, the block becomes a reference to a
+// top-level reusable lock block (see parseNamedLockBlock). All other fields
+// are optional in that case and act as attribute-level overrides on top of
+// the named base; the reference is folded in by ResolveReferences.
 func parseLockBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.LockConfig, error) {
+	return parseLockBody(block, ctx, false)
+}
+
+// parseNamedLockBlock parses a top-level `lock "<name>" { ... }` block. It
+// must specify a key because there is no base to merge against. The resulting
+// LockConfig is registered in Configuration.NamedLocks and can be referenced
+// from flow-level lock blocks via `use = "lock.<name>"`.
+func parseNamedLockBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.LockConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("lock block requires a name label when declared at top level")
+	}
+	lock, err := parseLockBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	lock.Name = block.Labels[0]
+	return lock, nil
+}
+
+// parseLockBody is the shared implementation used by inline and named lock
+// blocks. When strict is true (named top-level) the block must specify a key
+// and cannot carry a `use`. When strict is false (inline) the key is optional
+// only when this block references a named base (`use != ""`); a self-contained
+// inline lock still requires a key.
+func parseLockBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.LockConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
-			{Name: "key", Required: true},
+			{Name: "use"},
+			{Name: "key"},
 			{Name: "timeout"},
 			{Name: "wait"},
 			{Name: "retry"},
@@ -2085,6 +2116,14 @@ func parseLockBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.LockConfig, e
 	}
 
 	lock := &flow.LockConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("lock use error: %s", diags.Error())
+		}
+		lock.Use = parseRefName("lock", val.AsString())
+	}
 
 	for _, nestedBlock := range content.Blocks {
 		if nestedBlock.Type == "storage" {
@@ -2126,6 +2165,18 @@ func parseLockBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.LockConfig, e
 			return nil, fmt.Errorf("lock retry error: %s", diags.Error())
 		}
 		lock.Retry = val.AsString()
+	}
+
+	if strict {
+		if lock.Use != "" {
+			return nil, fmt.Errorf("top-level lock %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if lock.Key == "" {
+			return nil, fmt.Errorf("top-level lock %q must specify a key expression", block.Labels[0])
+		}
+	} else if lock.Use == "" && lock.Key == "" {
+		// Inline lock without `use` must be self-contained (current behavior).
+		return nil, fmt.Errorf("lock block must specify a key expression (or `use` a named one)")
 	}
 
 	return lock, nil

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -851,12 +851,10 @@ func parseTransformBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Transfor
 	return transform, nil
 }
 
-// parseTransformReference parses a transform reference.
+// parseTransformReference parses a transform reference like "transform.foo" → "foo".
+// Kept as a thin wrapper around parseRefName for symmetry with other callers.
 func parseTransformReference(ref string) string {
-	if strings.HasPrefix(ref, "transform.") {
-		return strings.TrimPrefix(ref, "transform.")
-	}
-	return ref
+	return parseRefName("transform", ref)
 }
 
 // extractExpressionText extracts the raw text from an HCL expression.
@@ -1698,11 +1696,9 @@ func ctyValueToInterface(val cty.Value) interface{} {
 }
 
 // parseCacheReference parses a cache reference (e.g., "cache.products" -> "products").
+// Kept as a thin wrapper around parseRefName for symmetry with other callers.
 func parseCacheReference(ref string) string {
-	if strings.HasPrefix(ref, "cache.") {
-		return strings.TrimPrefix(ref, "cache.")
-	}
-	return ref
+	return parseRefName("cache", ref)
 }
 
 // parseCacheBlock parses a cache block in a flow.

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -189,6 +189,15 @@ func parseFlowBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Config, error
 			if err != nil {
 				return nil, fmt.Errorf("response block error: %w", err)
 			}
+			// A `use = "response.<name>"` entry turns this into a reference to a
+			// top-level reusable response. Pull it out of the mappings (it is not
+			// an output field) into the ResponseUse marker; the remaining entries
+			// stay as inline overrides, folded over the named base by
+			// ResolveReferences. Runtime only ever reads Response.
+			if ref, ok := mappings["use"]; ok {
+				config.ResponseUse = parseRefName("response", ref)
+				delete(mappings, "use")
+			}
 			config.Response = mappings
 
 		case "require":
@@ -408,10 +417,37 @@ func parseFilterBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.FilterConfi
 
 // parseAcceptBlock parses an accept block from a flow.
 // Accept is a business-level gate that runs after filter but before transform.
+// parseAcceptBlock parses an inline accept gate.
+//
+// When `use = "accept.<name>"` is present, the block references a top-level
+// reusable accept block and the other fields are optional overrides.
 func parseAcceptBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.AcceptConfig, error) {
+	return parseAcceptBody(block, ctx, false)
+}
+
+// parseNamedAcceptBlock parses a top-level `accept "<name>" { ... }` block,
+// registered in Configuration.NamedAccepts and referenced via
+// use = "accept.<name>".
+func parseNamedAcceptBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.AcceptConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("accept block requires a name label when declared at top level")
+	}
+	cfg, err := parseAcceptBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Name = block.Labels[0]
+	return cfg, nil
+}
+
+// parseAcceptBody is shared by inline and named accept blocks. Strict (named
+// top-level) requires a `when` expression and forbids `use`. A self-contained
+// inline block also requires `when`; a reference does not.
+func parseAcceptBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.AcceptConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
-			{Name: "when", Required: true},
+			{Name: "use"},
+			{Name: "when"},
 			{Name: "on_reject"},
 		},
 	}
@@ -421,8 +457,14 @@ func parseAcceptBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.AcceptConfi
 		return nil, fmt.Errorf("accept block content error: %s", diags.Error())
 	}
 
-	cfg := &flow.AcceptConfig{
-		OnReject: "ack",
+	cfg := &flow.AcceptConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("accept use error: %s", diags.Error())
+		}
+		cfg.Use = parseRefName("accept", val.AsString())
 	}
 
 	if attr, ok := content.Attributes["when"]; ok {
@@ -447,10 +489,47 @@ func parseAcceptBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.AcceptConfi
 		}
 	}
 
-	if cfg.When == "" {
-		return nil, fmt.Errorf("accept block must specify a when expression")
+	if strict {
+		if cfg.Use != "" {
+			return nil, fmt.Errorf("top-level accept %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if cfg.When == "" {
+			return nil, fmt.Errorf("top-level accept %q must specify a when expression", block.Labels[0])
+		}
+	} else if cfg.Use == "" && cfg.When == "" {
+		return nil, fmt.Errorf("accept block must specify a when expression (or `use` a named one)")
 	}
 
+	// Default disposition for self-contained blocks. Reference-mode blocks
+	// leave this empty so the named base wins unless explicitly overridden.
+	if cfg.OnReject == "" && (strict || cfg.Use == "") {
+		cfg.OnReject = "ack"
+	}
+
+	return cfg, nil
+}
+
+// parseNamedResponseBlock parses a top-level `response "<name>" { field = "expr" }`
+// block into a ResponseConfig, registered in Configuration.NamedResponses and
+// referenced from a flow via `response { use = "response.<name>" }`. It uses the
+// same mapping shape as an inline response/transform; a `use` key is rejected
+// because a named block has no base to reference.
+func parseNamedResponseBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ResponseConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("response block requires a name label when declared at top level")
+	}
+	mappings, err := parseTransformMappings(block, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("response %q error: %w", block.Labels[0], err)
+	}
+	if _, ok := mappings["use"]; ok {
+		return nil, fmt.Errorf("top-level response %q cannot use `use` — that's for inline references", block.Labels[0])
+	}
+	if len(mappings) == 0 {
+		return nil, fmt.Errorf("top-level response %q must define at least one field mapping", block.Labels[0])
+	}
+	cfg := &flow.ResponseConfig{Mappings: mappings}
+	cfg.Name = block.Labels[0]
 	return cfg, nil
 }
 

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -1250,16 +1250,48 @@ func parseTransformMappings(block *hcl.Block, ctx *hcl.EvalContext) (map[string]
 // Example:
 //
 //	dedupe {
-//	  storage      = "redis"
+//	  cache        = "redis"
 //	  key          = "input.message_id"
 //	  ttl          = "1h"
-//	  on_duplicate = "skip"
+//	  on_duplicate = "ack"
+//	  fingerprint { id = "input.body.id" }
 //	}
+//
+// When `use = "dedupe.<name>"` is present, the block becomes a reference to
+// a top-level reusable dedupe block (see parseNamedDedupeBlock). All other
+// fields are optional in that case and act as attribute-level overrides on
+// top of the named base; runtime resolves the merge.
 func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfig, error) {
+	return parseDedupeBody(block, ctx, false)
+}
+
+// parseNamedDedupeBlock parses a top-level `dedupe "<name>" { ... }` block.
+// All fields are required because there is no base to merge against. The
+// resulting DedupeConfig is registered in Configuration.NamedDedupes and
+// can be referenced from flow-level dedupe blocks via `use = "dedupe.<name>"`.
+func parseNamedDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("dedupe block requires a name label when declared at top level")
+	}
+	dedupe, err := parseDedupeBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	dedupe.Name = block.Labels[0]
+	return dedupe, nil
+}
+
+// parseDedupeBody is the shared implementation used by inline and named
+// dedupe blocks. When strict is true (named top-level), all the structural
+// requirements (cache, key, fingerprint block) are enforced. When strict is
+// false (inline), they are optional so the block can act as a pure reference
+// (`use = "dedupe.foo"`) or a partial override on top of one.
+func parseDedupeBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.DedupeConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
-			{Name: "cache", Required: true},
-			{Name: "key", Required: true},
+			{Name: "use"},
+			{Name: "cache"},
+			{Name: "key"},
 			{Name: "ttl"},
 			{Name: "on_duplicate"},
 		},
@@ -1273,8 +1305,14 @@ func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfi
 		return nil, fmt.Errorf("dedupe block content error: %s", diags.Error())
 	}
 
-	dedupe := &flow.DedupeConfig{
-		OnDuplicate: "ack", // sequence_guard-style default
+	dedupe := &flow.DedupeConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("dedupe use error: %s", diags.Error())
+		}
+		dedupe.Use = parseRefName("dedupe", val.AsString())
 	}
 
 	if attr, ok := content.Attributes["cache"]; ok {
@@ -1318,10 +1356,10 @@ func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfi
 		dedupe.OnDuplicate = val.AsString()
 	}
 
-	// Parse the (required) fingerprint block — named CEL expressions, same
-	// shape as a transform block. Each entry contributes to the canonical
-	// projection. The author must list every persisted field; the runtime
-	// cannot infer which fields count.
+	// Parse the fingerprint block — named CEL expressions, same shape as a
+	// transform block. Required in strict mode and when the block stands on
+	// its own; optional when this block is a reference (use != "") because
+	// the named base may already supply it.
 	var fingerprintBlock *hcl.Block
 	for _, b := range content.Blocks {
 		if b.Type == "fingerprint" {
@@ -1331,43 +1369,64 @@ func parseDedupeBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.DedupeConfi
 			fingerprintBlock = b
 		}
 	}
-	if fingerprintBlock == nil {
-		return nil, fmt.Errorf("dedupe block must contain a fingerprint block")
-	}
-
-	fpAttrs, diags := fingerprintBlock.Body.JustAttributes()
-	if diags.HasErrors() {
-		return nil, fmt.Errorf("dedupe fingerprint block error: %s", diags.Error())
-	}
-	if len(fpAttrs) == 0 {
-		return nil, fmt.Errorf("dedupe fingerprint block must define at least one named expression")
-	}
-
-	dedupe.Fingerprint = make(map[string]string, len(fpAttrs))
-	for name, attr := range fpAttrs {
-		val, diags := attr.Expr.Value(ctx)
+	if fingerprintBlock != nil {
+		fpAttrs, diags := fingerprintBlock.Body.JustAttributes()
 		if diags.HasErrors() {
-			// CEL expression — extract raw text to be evaluated at runtime
-			dedupe.Fingerprint[name] = extractExpressionText(attr.Expr)
-			continue
+			return nil, fmt.Errorf("dedupe fingerprint block error: %s", diags.Error())
 		}
-		// Literal values are accepted too: treat them as constant projections
-		dedupe.Fingerprint[name] = val.AsString()
+		if len(fpAttrs) == 0 {
+			return nil, fmt.Errorf("dedupe fingerprint block must define at least one named expression")
+		}
+		dedupe.Fingerprint = make(map[string]string, len(fpAttrs))
+		for name, attr := range fpAttrs {
+			val, diags := attr.Expr.Value(ctx)
+			if diags.HasErrors() {
+				// CEL expression — extract raw text to be evaluated at runtime
+				dedupe.Fingerprint[name] = extractExpressionText(attr.Expr)
+				continue
+			}
+			// Literal values are accepted too: treat them as constant projections
+			dedupe.Fingerprint[name] = val.AsString()
+		}
 	}
 
-	if dedupe.Cache == "" {
-		return nil, fmt.Errorf("dedupe block must specify a cache connector")
+	if strict {
+		if dedupe.Use != "" {
+			return nil, fmt.Errorf("top-level dedupe %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if dedupe.Cache == "" {
+			return nil, fmt.Errorf("dedupe block must specify a cache connector")
+		}
+		if dedupe.Key == "" {
+			return nil, fmt.Errorf("dedupe block must specify a key expression")
+		}
+		if fingerprintBlock == nil {
+			return nil, fmt.Errorf("dedupe block must contain a fingerprint block")
+		}
+	} else if dedupe.Use == "" {
+		// Inline dedupe without `use` must be self-contained (current behavior).
+		if dedupe.Cache == "" {
+			return nil, fmt.Errorf("dedupe block must specify a cache connector (or `use` a named one)")
+		}
+		if dedupe.Key == "" {
+			return nil, fmt.Errorf("dedupe block must specify a key expression (or `use` a named one)")
+		}
+		if fingerprintBlock == nil {
+			return nil, fmt.Errorf("dedupe block must contain a fingerprint block (or `use` a named one)")
+		}
 	}
 
-	if dedupe.Key == "" {
-		return nil, fmt.Errorf("dedupe block must specify a key expression")
-	}
-
-	switch dedupe.OnDuplicate {
-	case "ack", "reject", "requeue":
-		// ok
-	default:
-		return nil, fmt.Errorf("dedupe on_duplicate must be 'ack', 'reject', or 'requeue', got %q", dedupe.OnDuplicate)
+	if dedupe.OnDuplicate != "" {
+		switch dedupe.OnDuplicate {
+		case "ack", "reject", "requeue":
+			// ok
+		default:
+			return nil, fmt.Errorf("dedupe on_duplicate must be 'ack', 'reject', or 'requeue', got %q", dedupe.OnDuplicate)
+		}
+	} else if strict || dedupe.Use == "" {
+		// Default for self-contained blocks (no reference): ack.
+		// Reference-mode blocks leave this empty so the named base wins.
+		dedupe.OnDuplicate = "ack"
 	}
 
 	return dedupe, nil

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -963,8 +963,37 @@ func parseRequireBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.RequireCon
 }
 
 // parseErrorHandlingBlock parses an error_handling block.
+//
+// When `use = "error_handling.<name>"` is present, the block references a
+// top-level reusable error_handling block and every sub-block is an optional
+// override that replaces the corresponding named sub-block wholesale.
 func parseErrorHandlingBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ErrorHandlingConfig, error) {
+	return parseErrorHandlingBody(block, ctx, false)
+}
+
+// parseNamedErrorHandlingBlock parses a top-level
+// `error_handling "<name>" { ... }` block, registered in
+// Configuration.NamedErrorHandlings and referenced via
+// use = "error_handling.<name>".
+func parseNamedErrorHandlingBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ErrorHandlingConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("error_handling block requires a name label when declared at top level")
+	}
+	eh, err := parseErrorHandlingBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	eh.Name = block.Labels[0]
+	return eh, nil
+}
+
+// parseErrorHandlingBody is shared by inline and named error_handling blocks.
+// Strict (named top-level) requires at least one sub-block and forbids `use`.
+func parseErrorHandlingBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.ErrorHandlingConfig, error) {
 	schema := &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "use"},
+		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "retry"},
 			{Type: "fallback"},
@@ -980,6 +1009,14 @@ func parseErrorHandlingBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Erro
 	}
 
 	eh := &flow.ErrorHandlingConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("error_handling use error: %s", diags.Error())
+		}
+		eh.Use = parseRefName("error_handling", val.AsString())
+	}
 
 	for _, nestedBlock := range content.Blocks {
 		switch nestedBlock.Type {
@@ -1013,6 +1050,15 @@ func parseErrorHandlingBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Erro
 				return nil, fmt.Errorf("on_error block error: %w", err)
 			}
 			eh.OnError = handler
+		}
+	}
+
+	if strict {
+		if eh.Use != "" {
+			return nil, fmt.Errorf("top-level error_handling %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if eh.Retry == nil && eh.Fallback == nil && eh.ErrorResponse == nil && eh.OnTimeout == nil && eh.OnError == nil {
+			return nil, fmt.Errorf("top-level error_handling %q must define at least one of retry/fallback/error_response/on_timeout/on_error", block.Labels[0])
 		}
 	}
 
@@ -2485,8 +2531,30 @@ func parseSemaphoreBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*f
 //	  }
 //	}
 func parseCoordinateBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.CoordinateConfig, error) {
+	return parseCoordinateBody(block, ctx, false)
+}
+
+// parseNamedCoordinateBlock parses a top-level `coordinate "<name>" { ... }`
+// block, registered in Configuration.NamedCoordinates and referenced via
+// use = "coordinate.<name>".
+func parseNamedCoordinateBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.CoordinateConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("coordinate block requires a name label when declared at top level")
+	}
+	coord, err := parseCoordinateBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	coord.Name = block.Labels[0]
+	return coord, nil
+}
+
+// parseCoordinateBody is shared by inline and named coordinate blocks. Strict
+// (named top-level) requires a storage block and forbids `use`.
+func parseCoordinateBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.CoordinateConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
+			{Name: "use"},
 			{Name: "timeout"},
 			{Name: "on_timeout"},
 			{Name: "max_retries"},
@@ -2506,6 +2574,14 @@ func parseCoordinateBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Coordin
 	}
 
 	coord := &flow.CoordinateConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("coordinate use error: %s", diags.Error())
+		}
+		coord.Use = parseRefName("coordinate", val.AsString())
+	}
 
 	if attr, ok := content.Attributes["timeout"]; ok {
 		val, diags := attr.Expr.Value(ctx)
@@ -2576,6 +2652,15 @@ func parseCoordinateBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.Coordin
 				return nil, fmt.Errorf("preflight block error: %w", err)
 			}
 			coord.Preflight = preflight
+		}
+	}
+
+	if strict {
+		if coord.Use != "" {
+			return nil, fmt.Errorf("top-level coordinate %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if coord.Storage == nil {
+			return nil, fmt.Errorf("top-level coordinate %q requires a storage block", block.Labels[0])
 		}
 	}
 

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -1050,9 +1050,40 @@ func parseErrorClassHandlerBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.
 }
 
 // parseRetryConfigBlock parses a retry block within error_handling.
+//
+// When `use = "retry.<name>"` is present, the block becomes a reference to a
+// top-level reusable retry block (see parseNamedRetryBlock). All other fields
+// are optional in that case and act as attribute-level overrides on top of
+// the named base; the reference is folded in by ResolveReferences.
 func parseRetryConfigBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.RetryConfig, error) {
+	return parseRetryBody(block, ctx, false)
+}
+
+// parseNamedRetryBlock parses a top-level `retry "<name>" { ... }` block. It
+// must define at least one attempt because there is no base to merge against.
+// The resulting RetryConfig is registered in Configuration.NamedRetries and
+// can be referenced from error_handling.retry blocks via `use = "retry.<name>"`.
+func parseNamedRetryBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.RetryConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("retry block requires a name label when declared at top level")
+	}
+	retry, err := parseRetryBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	retry.Name = block.Labels[0]
+	return retry, nil
+}
+
+// parseRetryBody is the shared implementation used by inline and named retry
+// blocks. When strict is true (named top-level) the block must define at
+// least one attempt and cannot carry a `use`. When strict is false (inline)
+// every field is optional so the block can act as a pure reference
+// (`use = "retry.foo"`) or a partial override on top of one.
+func parseRetryBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.RetryConfig, error) {
 	schema := &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
+			{Name: "use"},
 			{Name: "attempts"},
 			{Name: "delay"},
 			{Name: "max_delay"},
@@ -1066,6 +1097,14 @@ func parseRetryConfigBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.RetryC
 	}
 
 	retry := &flow.RetryConfig{}
+
+	if attr, ok := content.Attributes["use"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("retry use error: %s", diags.Error())
+		}
+		retry.Use = parseRefName("retry", val.AsString())
+	}
 
 	if attr, ok := content.Attributes["attempts"]; ok {
 		val, diags := attr.Expr.Value(ctx)
@@ -1101,6 +1140,15 @@ func parseRetryConfigBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.RetryC
 			return nil, fmt.Errorf("retry backoff error: %s", diags.Error())
 		}
 		retry.Backoff = val.AsString()
+	}
+
+	if strict {
+		if retry.Use != "" {
+			return nil, fmt.Errorf("top-level retry %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if retry.Attempts <= 0 {
+			return nil, fmt.Errorf("top-level retry %q must specify a positive attempts value", block.Labels[0])
+		}
 	}
 
 	return retry, nil

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -211,10 +211,11 @@ func (c *Configuration) ValidateTransactionTargets() error {
 // Returns an error if duplicates are found, with file paths for both definitions.
 func (c *Configuration) ValidateUniqueNames() error {
 	// Check each category using the SourceFiles map which tracks all files per key
-	categories := []struct {
+	type uniqueNameCategory struct {
 		itemType string
 		key      func() []string // returns keys like "connector:name"
-	}{
+	}
+	categories := []uniqueNameCategory{
 		{"connector", func() []string {
 			keys := make([]string, len(c.Connectors))
 			for i, conn := range c.Connectors {
@@ -257,27 +258,15 @@ func (c *Configuration) ValidateUniqueNames() error {
 			}
 			return keys
 		}},
-		{"dedupe", func() []string {
-			keys := make([]string, len(c.NamedDedupes))
-			for i, d := range c.NamedDedupes {
-				keys[i] = "dedupe:" + d.Name
-			}
-			return keys
-		}},
-		{"retry", func() []string {
-			keys := make([]string, len(c.NamedRetries))
-			for i, r := range c.NamedRetries {
-				keys[i] = "retry:" + r.Name
-			}
-			return keys
-		}},
-		{"lock", func() []string {
-			keys := make([]string, len(c.NamedLocks))
-			for i, l := range c.NamedLocks {
-				keys[i] = "lock:" + l.Name
-			}
-			return keys
-		}},
+	}
+
+	// Reusable inline blocks (dedupe, retry, lock, ...) contribute their
+	// uniqueness categories from the registry — no per-kind code here.
+	for _, k := range reusableKinds {
+		k := k
+		categories = append(categories, uniqueNameCategory{k.typeName, func() []string {
+			return k.uniqueKeys(c)
+		}})
 	}
 
 	for _, cat := range categories {
@@ -459,6 +448,15 @@ func (p *HCLParser) ParseFile(ctx context.Context, path string) (*Configuration,
 
 	// Process each block type
 	for _, block := range content.Blocks {
+		// Reusable inline blocks (dedupe, retry, lock, ...) are dispatched
+		// through the registry so this loop never grows per kind.
+		if kind, ok := reusableKindByName[block.Type]; ok {
+			if err := kind.parseRegister(p, block, config, path); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
 		switch block.Type {
 		case "connector":
 			conn, err := parseConnectorBlock(block, p.evalCtx)
@@ -499,30 +497,6 @@ func (p *HCLParser) ParseFile(ctx context.Context, path string) (*Configuration,
 				return nil, fmt.Errorf("cache parse error: %w", err)
 			}
 			config.NamedCaches = append(config.NamedCaches, cache)
-
-		case "dedupe":
-			dedupe, err := parseNamedDedupeBlock(block, p.evalCtx)
-			if err != nil {
-				return nil, fmt.Errorf("dedupe parse error: %w", err)
-			}
-			config.NamedDedupes = append(config.NamedDedupes, dedupe)
-			config.SourceFiles["dedupe:"+dedupe.Name] = append(config.SourceFiles["dedupe:"+dedupe.Name], path)
-
-		case "retry":
-			retry, err := parseNamedRetryBlock(block, p.evalCtx)
-			if err != nil {
-				return nil, fmt.Errorf("retry parse error: %w", err)
-			}
-			config.NamedRetries = append(config.NamedRetries, retry)
-			config.SourceFiles["retry:"+retry.Name] = append(config.SourceFiles["retry:"+retry.Name], path)
-
-		case "lock":
-			lock, err := parseNamedLockBlock(block, p.evalCtx)
-			if err != nil {
-				return nil, fmt.Errorf("lock parse error: %w", err)
-			}
-			config.NamedLocks = append(config.NamedLocks, lock)
-			config.SourceFiles["lock:"+lock.Name] = append(config.SourceFiles["lock:"+lock.Name], path)
 
 		case "aspect":
 			asp, err := parseAspectBlock(block, p.evalCtx)
@@ -601,18 +575,17 @@ func (p *HCLParser) ParseFile(ctx context.Context, path string) (*Configuration,
 	return config, nil
 }
 
-// rootSchema returns the top-level HCL schema.
+// rootSchema returns the top-level HCL schema. The reusable inline blocks
+// (dedupe, retry, lock, ...) are appended from the reusableKinds registry so a
+// new kind needs no edit here.
 func rootSchema() *hcl.BodySchema {
-	return &hcl.BodySchema{
+	schema := &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "connector", LabelNames: []string{"name"}},
 			{Type: "flow", LabelNames: []string{"name"}},
 			{Type: "type", LabelNames: []string{"name"}},
 			{Type: "transform", LabelNames: []string{"name"}},
 			{Type: "cache", LabelNames: []string{"name"}},
-			{Type: "dedupe", LabelNames: []string{"name"}},
-			{Type: "retry", LabelNames: []string{"name"}},
-			{Type: "lock", LabelNames: []string{"name"}},
 			{Type: "aspect", LabelNames: []string{"name"}},
 			{Type: "validator", LabelNames: []string{"name"}},
 			{Type: "functions", LabelNames: []string{"name"}},
@@ -625,6 +598,13 @@ func rootSchema() *hcl.BodySchema {
 			{Type: "security"},
 		},
 	}
+	for _, k := range reusableKinds {
+		schema.Blocks = append(schema.Blocks, hcl.BlockHeaderSchema{
+			Type:       k.typeName,
+			LabelNames: []string{"name"},
+		})
+	}
+	return schema
 }
 
 // parseServiceBlock parses a service block.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -62,6 +62,10 @@ type Configuration struct {
 	// error_handling.retry blocks via `use = "retry.<name>"`.
 	NamedRetries []*flow.RetryConfig
 
+	// NamedLocks are reusable lock configurations. Referenced from
+	// flow-level lock blocks via `use = "lock.<name>"`.
+	NamedLocks []*flow.LockConfig
+
 	// Aspects are cross-cutting concern configurations.
 	Aspects []*aspect.Config
 
@@ -138,6 +142,7 @@ func NewConfiguration() *Configuration {
 		NamedCaches:   make([]*flow.NamedCacheConfig, 0),
 		NamedDedupes:  make([]*flow.DedupeConfig, 0),
 		NamedRetries:  make([]*flow.RetryConfig, 0),
+		NamedLocks:    make([]*flow.LockConfig, 0),
 		Aspects:       make([]*aspect.Config, 0),
 		Validators:    make([]*validator.Config, 0),
 		Functions:     make([]*functions.Config, 0),
@@ -157,6 +162,7 @@ func (c *Configuration) Merge(other *Configuration) {
 	c.NamedCaches = append(c.NamedCaches, other.NamedCaches...)
 	c.NamedDedupes = append(c.NamedDedupes, other.NamedDedupes...)
 	c.NamedRetries = append(c.NamedRetries, other.NamedRetries...)
+	c.NamedLocks = append(c.NamedLocks, other.NamedLocks...)
 	c.Aspects = append(c.Aspects, other.Aspects...)
 	c.Validators = append(c.Validators, other.Validators...)
 	c.Functions = append(c.Functions, other.Functions...)
@@ -262,6 +268,13 @@ func (c *Configuration) ValidateUniqueNames() error {
 			keys := make([]string, len(c.NamedRetries))
 			for i, r := range c.NamedRetries {
 				keys[i] = "retry:" + r.Name
+			}
+			return keys
+		}},
+		{"lock", func() []string {
+			keys := make([]string, len(c.NamedLocks))
+			for i, l := range c.NamedLocks {
+				keys[i] = "lock:" + l.Name
 			}
 			return keys
 		}},
@@ -503,6 +516,14 @@ func (p *HCLParser) ParseFile(ctx context.Context, path string) (*Configuration,
 			config.NamedRetries = append(config.NamedRetries, retry)
 			config.SourceFiles["retry:"+retry.Name] = append(config.SourceFiles["retry:"+retry.Name], path)
 
+		case "lock":
+			lock, err := parseNamedLockBlock(block, p.evalCtx)
+			if err != nil {
+				return nil, fmt.Errorf("lock parse error: %w", err)
+			}
+			config.NamedLocks = append(config.NamedLocks, lock)
+			config.SourceFiles["lock:"+lock.Name] = append(config.SourceFiles["lock:"+lock.Name], path)
+
 		case "aspect":
 			asp, err := parseAspectBlock(block, p.evalCtx)
 			if err != nil {
@@ -591,6 +612,7 @@ func rootSchema() *hcl.BodySchema {
 			{Type: "cache", LabelNames: []string{"name"}},
 			{Type: "dedupe", LabelNames: []string{"name"}},
 			{Type: "retry", LabelNames: []string{"name"}},
+			{Type: "lock", LabelNames: []string{"name"}},
 			{Type: "aspect", LabelNames: []string{"name"}},
 			{Type: "validator", LabelNames: []string{"name"}},
 			{Type: "functions", LabelNames: []string{"name"}},

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -54,6 +54,10 @@ type Configuration struct {
 	// NamedCaches are reusable cache configurations.
 	NamedCaches []*flow.NamedCacheConfig
 
+	// NamedDedupes are reusable dedupe configurations. Referenced from
+	// flow-level dedupe blocks via `use = "dedupe.<name>"`.
+	NamedDedupes []*flow.DedupeConfig
+
 	// Aspects are cross-cutting concern configurations.
 	Aspects []*aspect.Config
 
@@ -128,6 +132,7 @@ func NewConfiguration() *Configuration {
 		Types:         make([]*validate.TypeSchema, 0),
 		Transforms:    make([]*transform.Config, 0),
 		NamedCaches:   make([]*flow.NamedCacheConfig, 0),
+		NamedDedupes:  make([]*flow.DedupeConfig, 0),
 		Aspects:       make([]*aspect.Config, 0),
 		Validators:    make([]*validator.Config, 0),
 		Functions:     make([]*functions.Config, 0),
@@ -145,6 +150,7 @@ func (c *Configuration) Merge(other *Configuration) {
 	c.Types = append(c.Types, other.Types...)
 	c.Transforms = append(c.Transforms, other.Transforms...)
 	c.NamedCaches = append(c.NamedCaches, other.NamedCaches...)
+	c.NamedDedupes = append(c.NamedDedupes, other.NamedDedupes...)
 	c.Aspects = append(c.Aspects, other.Aspects...)
 	c.Validators = append(c.Validators, other.Validators...)
 	c.Functions = append(c.Functions, other.Functions...)
@@ -236,6 +242,13 @@ func (c *Configuration) ValidateUniqueNames() error {
 			keys := make([]string, len(c.Validators))
 			for i, v := range c.Validators {
 				keys[i] = "validator:" + v.Name
+			}
+			return keys
+		}},
+		{"dedupe", func() []string {
+			keys := make([]string, len(c.NamedDedupes))
+			for i, d := range c.NamedDedupes {
+				keys[i] = "dedupe:" + d.Name
 			}
 			return keys
 		}},
@@ -387,6 +400,14 @@ func (p *HCLParser) Parse(ctx context.Context, configDir string) (*Configuration
 		return nil, err
 	}
 
+	// Resolve reusable-block references (e.g. flow.dedupe.use → named dedupe).
+	// Validation of the reference (target exists) and the merge happen in one
+	// pass; after this, runtime sees fully self-contained blocks regardless
+	// of whether they were declared inline or referenced.
+	if err := config.ResolveReferences(); err != nil {
+		return nil, err
+	}
+
 	// Validate that transaction writes target a database connector
 	if err := config.ValidateTransactionTargets(); err != nil {
 		return nil, err
@@ -452,6 +473,14 @@ func (p *HCLParser) ParseFile(ctx context.Context, path string) (*Configuration,
 				return nil, fmt.Errorf("cache parse error: %w", err)
 			}
 			config.NamedCaches = append(config.NamedCaches, cache)
+
+		case "dedupe":
+			dedupe, err := parseNamedDedupeBlock(block, p.evalCtx)
+			if err != nil {
+				return nil, fmt.Errorf("dedupe parse error: %w", err)
+			}
+			config.NamedDedupes = append(config.NamedDedupes, dedupe)
+			config.SourceFiles["dedupe:"+dedupe.Name] = append(config.SourceFiles["dedupe:"+dedupe.Name], path)
 
 		case "aspect":
 			asp, err := parseAspectBlock(block, p.evalCtx)
@@ -539,6 +568,7 @@ func rootSchema() *hcl.BodySchema {
 			{Type: "type", LabelNames: []string{"name"}},
 			{Type: "transform", LabelNames: []string{"name"}},
 			{Type: "cache", LabelNames: []string{"name"}},
+			{Type: "dedupe", LabelNames: []string{"name"}},
 			{Type: "aspect", LabelNames: []string{"name"}},
 			{Type: "validator", LabelNames: []string{"name"}},
 			{Type: "functions", LabelNames: []string{"name"}},

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -75,6 +75,19 @@ type Configuration struct {
 	// `use = "sequence_guard.<name>"`.
 	NamedSequenceGuards []*flow.SequenceGuardConfig
 
+	// NamedCoordinates are reusable coordinate configurations. Referenced
+	// from flow-level coordinate blocks via `use = "coordinate.<name>"`.
+	NamedCoordinates []*flow.CoordinateConfig
+
+	// NamedTransactions are reusable transaction configurations. Referenced
+	// from `to { transaction { use = "transaction.<name>" } }`.
+	NamedTransactions []*flow.TransactionConfig
+
+	// NamedErrorHandlings are reusable error_handling configurations.
+	// Referenced from flow-level error_handling blocks via
+	// `use = "error_handling.<name>"`.
+	NamedErrorHandlings []*flow.ErrorHandlingConfig
+
 	// Aspects are cross-cutting concern configurations.
 	Aspects []*aspect.Config
 
@@ -154,6 +167,9 @@ func NewConfiguration() *Configuration {
 		NamedLocks:          make([]*flow.LockConfig, 0),
 		NamedSemaphores:     make([]*flow.SemaphoreConfig, 0),
 		NamedSequenceGuards: make([]*flow.SequenceGuardConfig, 0),
+		NamedCoordinates:    make([]*flow.CoordinateConfig, 0),
+		NamedTransactions:   make([]*flow.TransactionConfig, 0),
+		NamedErrorHandlings: make([]*flow.ErrorHandlingConfig, 0),
 		Aspects:             make([]*aspect.Config, 0),
 		Validators:          make([]*validator.Config, 0),
 		Functions:           make([]*functions.Config, 0),
@@ -176,6 +192,9 @@ func (c *Configuration) Merge(other *Configuration) {
 	c.NamedLocks = append(c.NamedLocks, other.NamedLocks...)
 	c.NamedSemaphores = append(c.NamedSemaphores, other.NamedSemaphores...)
 	c.NamedSequenceGuards = append(c.NamedSequenceGuards, other.NamedSequenceGuards...)
+	c.NamedCoordinates = append(c.NamedCoordinates, other.NamedCoordinates...)
+	c.NamedTransactions = append(c.NamedTransactions, other.NamedTransactions...)
+	c.NamedErrorHandlings = append(c.NamedErrorHandlings, other.NamedErrorHandlings...)
 	c.Aspects = append(c.Aspects, other.Aspects...)
 	c.Validators = append(c.Validators, other.Validators...)
 	c.Functions = append(c.Functions, other.Functions...)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -66,6 +66,15 @@ type Configuration struct {
 	// flow-level lock blocks via `use = "lock.<name>"`.
 	NamedLocks []*flow.LockConfig
 
+	// NamedSemaphores are reusable semaphore configurations. Referenced from
+	// flow-level semaphore blocks via `use = "semaphore.<name>"`.
+	NamedSemaphores []*flow.SemaphoreConfig
+
+	// NamedSequenceGuards are reusable sequence_guard configurations.
+	// Referenced from flow-level sequence_guard blocks via
+	// `use = "sequence_guard.<name>"`.
+	NamedSequenceGuards []*flow.SequenceGuardConfig
+
 	// Aspects are cross-cutting concern configurations.
 	Aspects []*aspect.Config
 
@@ -135,21 +144,23 @@ type RateLimitConfig struct {
 // NewConfiguration creates an empty configuration.
 func NewConfiguration() *Configuration {
 	return &Configuration{
-		Connectors:    make([]*connector.Config, 0),
-		Flows:         make([]*flow.Config, 0),
-		Types:         make([]*validate.TypeSchema, 0),
-		Transforms:    make([]*transform.Config, 0),
-		NamedCaches:   make([]*flow.NamedCacheConfig, 0),
-		NamedDedupes:  make([]*flow.DedupeConfig, 0),
-		NamedRetries:  make([]*flow.RetryConfig, 0),
-		NamedLocks:    make([]*flow.LockConfig, 0),
-		Aspects:       make([]*aspect.Config, 0),
-		Validators:    make([]*validator.Config, 0),
-		Functions:     make([]*functions.Config, 0),
-		Plugins:       make([]*plugin.PluginDeclaration, 0),
-		Sagas:         make([]*saga.Config, 0),
-		StateMachines: make([]*statemachine.Config, 0),
-		SourceFiles:   make(map[string][]string),
+		Connectors:          make([]*connector.Config, 0),
+		Flows:               make([]*flow.Config, 0),
+		Types:               make([]*validate.TypeSchema, 0),
+		Transforms:          make([]*transform.Config, 0),
+		NamedCaches:         make([]*flow.NamedCacheConfig, 0),
+		NamedDedupes:        make([]*flow.DedupeConfig, 0),
+		NamedRetries:        make([]*flow.RetryConfig, 0),
+		NamedLocks:          make([]*flow.LockConfig, 0),
+		NamedSemaphores:     make([]*flow.SemaphoreConfig, 0),
+		NamedSequenceGuards: make([]*flow.SequenceGuardConfig, 0),
+		Aspects:             make([]*aspect.Config, 0),
+		Validators:          make([]*validator.Config, 0),
+		Functions:           make([]*functions.Config, 0),
+		Plugins:             make([]*plugin.PluginDeclaration, 0),
+		Sagas:               make([]*saga.Config, 0),
+		StateMachines:       make([]*statemachine.Config, 0),
+		SourceFiles:         make(map[string][]string),
 	}
 }
 
@@ -163,6 +174,8 @@ func (c *Configuration) Merge(other *Configuration) {
 	c.NamedDedupes = append(c.NamedDedupes, other.NamedDedupes...)
 	c.NamedRetries = append(c.NamedRetries, other.NamedRetries...)
 	c.NamedLocks = append(c.NamedLocks, other.NamedLocks...)
+	c.NamedSemaphores = append(c.NamedSemaphores, other.NamedSemaphores...)
+	c.NamedSequenceGuards = append(c.NamedSequenceGuards, other.NamedSequenceGuards...)
 	c.Aspects = append(c.Aspects, other.Aspects...)
 	c.Validators = append(c.Validators, other.Validators...)
 	c.Functions = append(c.Functions, other.Functions...)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -88,6 +88,14 @@ type Configuration struct {
 	// `use = "error_handling.<name>"`.
 	NamedErrorHandlings []*flow.ErrorHandlingConfig
 
+	// NamedAccepts are reusable accept gates. Referenced from flow-level
+	// accept blocks via `use = "accept.<name>"`.
+	NamedAccepts []*flow.AcceptConfig
+
+	// NamedResponses are reusable response mappings. Referenced from
+	// flow-level response blocks via `use = "response.<name>"`.
+	NamedResponses []*flow.ResponseConfig
+
 	// Aspects are cross-cutting concern configurations.
 	Aspects []*aspect.Config
 
@@ -170,6 +178,8 @@ func NewConfiguration() *Configuration {
 		NamedCoordinates:    make([]*flow.CoordinateConfig, 0),
 		NamedTransactions:   make([]*flow.TransactionConfig, 0),
 		NamedErrorHandlings: make([]*flow.ErrorHandlingConfig, 0),
+		NamedAccepts:        make([]*flow.AcceptConfig, 0),
+		NamedResponses:      make([]*flow.ResponseConfig, 0),
 		Aspects:             make([]*aspect.Config, 0),
 		Validators:          make([]*validator.Config, 0),
 		Functions:           make([]*functions.Config, 0),
@@ -195,6 +205,8 @@ func (c *Configuration) Merge(other *Configuration) {
 	c.NamedCoordinates = append(c.NamedCoordinates, other.NamedCoordinates...)
 	c.NamedTransactions = append(c.NamedTransactions, other.NamedTransactions...)
 	c.NamedErrorHandlings = append(c.NamedErrorHandlings, other.NamedErrorHandlings...)
+	c.NamedAccepts = append(c.NamedAccepts, other.NamedAccepts...)
+	c.NamedResponses = append(c.NamedResponses, other.NamedResponses...)
 	c.Aspects = append(c.Aspects, other.Aspects...)
 	c.Validators = append(c.Validators, other.Validators...)
 	c.Functions = append(c.Functions, other.Functions...)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -58,6 +58,10 @@ type Configuration struct {
 	// flow-level dedupe blocks via `use = "dedupe.<name>"`.
 	NamedDedupes []*flow.DedupeConfig
 
+	// NamedRetries are reusable retry configurations. Referenced from
+	// error_handling.retry blocks via `use = "retry.<name>"`.
+	NamedRetries []*flow.RetryConfig
+
 	// Aspects are cross-cutting concern configurations.
 	Aspects []*aspect.Config
 
@@ -133,6 +137,7 @@ func NewConfiguration() *Configuration {
 		Transforms:    make([]*transform.Config, 0),
 		NamedCaches:   make([]*flow.NamedCacheConfig, 0),
 		NamedDedupes:  make([]*flow.DedupeConfig, 0),
+		NamedRetries:  make([]*flow.RetryConfig, 0),
 		Aspects:       make([]*aspect.Config, 0),
 		Validators:    make([]*validator.Config, 0),
 		Functions:     make([]*functions.Config, 0),
@@ -151,6 +156,7 @@ func (c *Configuration) Merge(other *Configuration) {
 	c.Transforms = append(c.Transforms, other.Transforms...)
 	c.NamedCaches = append(c.NamedCaches, other.NamedCaches...)
 	c.NamedDedupes = append(c.NamedDedupes, other.NamedDedupes...)
+	c.NamedRetries = append(c.NamedRetries, other.NamedRetries...)
 	c.Aspects = append(c.Aspects, other.Aspects...)
 	c.Validators = append(c.Validators, other.Validators...)
 	c.Functions = append(c.Functions, other.Functions...)
@@ -249,6 +255,13 @@ func (c *Configuration) ValidateUniqueNames() error {
 			keys := make([]string, len(c.NamedDedupes))
 			for i, d := range c.NamedDedupes {
 				keys[i] = "dedupe:" + d.Name
+			}
+			return keys
+		}},
+		{"retry", func() []string {
+			keys := make([]string, len(c.NamedRetries))
+			for i, r := range c.NamedRetries {
+				keys[i] = "retry:" + r.Name
 			}
 			return keys
 		}},
@@ -482,6 +495,14 @@ func (p *HCLParser) ParseFile(ctx context.Context, path string) (*Configuration,
 			config.NamedDedupes = append(config.NamedDedupes, dedupe)
 			config.SourceFiles["dedupe:"+dedupe.Name] = append(config.SourceFiles["dedupe:"+dedupe.Name], path)
 
+		case "retry":
+			retry, err := parseNamedRetryBlock(block, p.evalCtx)
+			if err != nil {
+				return nil, fmt.Errorf("retry parse error: %w", err)
+			}
+			config.NamedRetries = append(config.NamedRetries, retry)
+			config.SourceFiles["retry:"+retry.Name] = append(config.SourceFiles["retry:"+retry.Name], path)
+
 		case "aspect":
 			asp, err := parseAspectBlock(block, p.evalCtx)
 			if err != nil {
@@ -569,6 +590,7 @@ func rootSchema() *hcl.BodySchema {
 			{Type: "transform", LabelNames: []string{"name"}},
 			{Type: "cache", LabelNames: []string{"name"}},
 			{Type: "dedupe", LabelNames: []string{"name"}},
+			{Type: "retry", LabelNames: []string{"name"}},
 			{Type: "aspect", LabelNames: []string{"name"}},
 			{Type: "validator", LabelNames: []string{"name"}},
 			{Type: "functions", LabelNames: []string{"name"}},

--- a/internal/parser/reference.go
+++ b/internal/parser/reference.go
@@ -1,0 +1,11 @@
+package parser
+
+import "strings"
+
+// parseRefName strips the "<kind>." prefix from a reference string used in
+// reusable-block references like `use = "dedupe.standard"` or
+// `cache = "cache.products"`. If the prefix is absent the input is returned
+// unchanged so callers can keep accepting bare names for backward compatibility.
+func parseRefName(kind, ref string) string {
+	return strings.TrimPrefix(ref, kind+".")
+}

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -256,6 +256,22 @@ func mergeErrorHandling(base, inline *flow.ErrorHandlingConfig) *flow.ErrorHandl
 	return &merged
 }
 
+// mergeAccept overlays an inline accept block on top of the named base.
+// Scalars (when, on_reject) override when non-empty.
+func mergeAccept(base, inline *flow.AcceptConfig) *flow.AcceptConfig {
+	merged := *base
+	merged.Name = ""
+	merged.Use = inline.Use
+
+	if inline.When != "" {
+		merged.When = inline.When
+	}
+	if inline.OnReject != "" {
+		merged.OnReject = inline.OnReject
+	}
+	return &merged
+}
+
 // mergeSequenceGuard overlays an inline sequence_guard block on top of the
 // named base. Scalars override when non-empty; the storage sub-block is
 // replaced wholesale.

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -178,6 +178,84 @@ func mergeSemaphore(base, inline *flow.SemaphoreConfig) *flow.SemaphoreConfig {
 	return &merged
 }
 
+// mergeCoordinate overlays an inline coordinate block on top of the named
+// base. Scalars override when non-zero; each sub-block (storage/wait/signal/
+// preflight) is replaced wholesale when the inline block defines it.
+func mergeCoordinate(base, inline *flow.CoordinateConfig) *flow.CoordinateConfig {
+	merged := *base
+	merged.Name = ""
+	merged.Use = inline.Use
+
+	if inline.Timeout != "" {
+		merged.Timeout = inline.Timeout
+	}
+	if inline.OnTimeout != "" {
+		merged.OnTimeout = inline.OnTimeout
+	}
+	if inline.MaxRetries != 0 {
+		merged.MaxRetries = inline.MaxRetries
+	}
+	if inline.MaxConcurrentWaits != 0 {
+		merged.MaxConcurrentWaits = inline.MaxConcurrentWaits
+	}
+	if inline.Storage != nil {
+		merged.Storage = inline.Storage
+	}
+	if inline.Wait != nil {
+		merged.Wait = inline.Wait
+	}
+	if inline.Signal != nil {
+		merged.Signal = inline.Signal
+	}
+	if inline.Preflight != nil {
+		merged.Preflight = inline.Preflight
+	}
+	return &merged
+}
+
+// mergeTransaction overlays an inline transaction reference on top of the named
+// base. A transaction has no scalar fields to overlay: if the referencing block
+// lists its own statements they replace the named base's wholesale, otherwise
+// the base's statements are used as-is.
+func mergeTransaction(base, inline *flow.TransactionConfig) *flow.TransactionConfig {
+	merged := *base
+	merged.Name = ""
+	merged.Use = inline.Use
+
+	if len(inline.Statements) > 0 {
+		merged.Statements = inline.Statements
+	}
+	return &merged
+}
+
+// mergeErrorHandling overlays an inline error_handling block on top of the
+// named base. Every member is a sub-block, so each is replaced wholesale when
+// the inline block defines it. A retry pulled in here that itself carries a
+// `use` is resolved by the retry pass, which runs after this one (see the
+// reusableKinds registry ordering).
+func mergeErrorHandling(base, inline *flow.ErrorHandlingConfig) *flow.ErrorHandlingConfig {
+	merged := *base
+	merged.Name = ""
+	merged.Use = inline.Use
+
+	if inline.Retry != nil {
+		merged.Retry = inline.Retry
+	}
+	if inline.Fallback != nil {
+		merged.Fallback = inline.Fallback
+	}
+	if inline.ErrorResponse != nil {
+		merged.ErrorResponse = inline.ErrorResponse
+	}
+	if inline.OnTimeout != nil {
+		merged.OnTimeout = inline.OnTimeout
+	}
+	if inline.OnError != nil {
+		merged.OnError = inline.OnError
+	}
+	return &merged
+}
+
 // mergeSequenceGuard overlays an inline sequence_guard block on top of the
 // named base. Scalars override when non-empty; the storage sub-block is
 // replaced wholesale.

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -27,6 +27,7 @@ import (
 // result because the second pass finds an empty `Use` (cleared after merge).
 func (c *Configuration) ResolveReferences() error {
 	namedDedupes := indexByName(c.NamedDedupes, func(d *flow.DedupeConfig) string { return d.Name })
+	namedRetries := indexByName(c.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
 
 	for _, f := range c.Flows {
 		if f.Dedupe != nil && f.Dedupe.Use != "" {
@@ -35,6 +36,13 @@ func (c *Configuration) ResolveReferences() error {
 				return fmt.Errorf("flow %q: %w", f.Name, err)
 			}
 			f.Dedupe = merged
+		}
+		if f.ErrorHandling != nil && f.ErrorHandling.Retry != nil && f.ErrorHandling.Retry.Use != "" {
+			merged, err := resolveRetry(f.ErrorHandling.Retry, namedRetries)
+			if err != nil {
+				return fmt.Errorf("flow %q: %w", f.Name, err)
+			}
+			f.ErrorHandling.Retry = merged
 		}
 	}
 	return nil
@@ -97,6 +105,35 @@ func resolveDedupe(inline *flow.DedupeConfig, named map[string]*flow.DedupeConfi
 		for k, v := range inline.Fingerprint {
 			merged.Fingerprint[k] = v
 		}
+	}
+	return &merged, nil
+}
+
+// resolveRetry overlays an inline retry block (with `use` set) on top of the
+// named base it references. Inline non-zero attributes win, attribute by
+// attribute; unset inline fields inherit from the named base. Returns the
+// merged config or an error if the reference does not exist.
+func resolveRetry(inline *flow.RetryConfig, named map[string]*flow.RetryConfig) (*flow.RetryConfig, error) {
+	base, ok := named[inline.Use]
+	if !ok {
+		return nil, fmt.Errorf("retry references unknown name %q (available: %s)", inline.Use, availableNames(named))
+	}
+
+	merged := *base
+	merged.Name = ""        // inline blocks have no name
+	merged.Use = inline.Use // preserve the reference for tracing/debugging
+
+	if inline.Attempts != 0 {
+		merged.Attempts = inline.Attempts
+	}
+	if inline.Delay != "" {
+		merged.Delay = inline.Delay
+	}
+	if inline.MaxDelay != "" {
+		merged.MaxDelay = inline.MaxDelay
+	}
+	if inline.Backoff != "" {
+		merged.Backoff = inline.Backoff
 	}
 	return &merged, nil
 }

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -23,34 +23,21 @@ import (
 //     never has to know whether a block came from a named reference or
 //     was written inline — Config.Dedupe etc. are always complete.
 //
-// Mutates the receiver in place. Idempotent: running twice yields the same
-// result because the second pass finds an empty `Use` (cleared after merge).
+// The set of reusable kinds lives in the reusableKinds registry; this loop is
+// generic over them. Each kind builds its name index once (in newResolver),
+// not per flow. Mutates the receiver in place. Idempotent: a second pass finds
+// an empty `Use` on the already-folded blocks and is a no-op.
 func (c *Configuration) ResolveReferences() error {
-	namedDedupes := indexByName(c.NamedDedupes, func(d *flow.DedupeConfig) string { return d.Name })
-	namedRetries := indexByName(c.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
-	namedLocks := indexByName(c.NamedLocks, func(l *flow.LockConfig) string { return l.Name })
+	resolvers := make([]func(*flow.Config) error, len(reusableKinds))
+	for i, k := range reusableKinds {
+		resolvers[i] = k.newResolver(c)
+	}
 
 	for _, f := range c.Flows {
-		if f.Dedupe != nil && f.Dedupe.Use != "" {
-			merged, err := resolveDedupe(f.Dedupe, namedDedupes)
-			if err != nil {
+		for _, resolve := range resolvers {
+			if err := resolve(f); err != nil {
 				return fmt.Errorf("flow %q: %w", f.Name, err)
 			}
-			f.Dedupe = merged
-		}
-		if f.ErrorHandling != nil && f.ErrorHandling.Retry != nil && f.ErrorHandling.Retry.Use != "" {
-			merged, err := resolveRetry(f.ErrorHandling.Retry, namedRetries)
-			if err != nil {
-				return fmt.Errorf("flow %q: %w", f.Name, err)
-			}
-			f.ErrorHandling.Retry = merged
-		}
-		if f.Lock != nil && f.Lock.Use != "" {
-			merged, err := resolveLock(f.Lock, namedLocks)
-			if err != nil {
-				return fmt.Errorf("flow %q: %w", f.Name, err)
-			}
-			f.Lock = merged
 		}
 	}
 	return nil
@@ -80,15 +67,10 @@ func availableNames[T any](m map[string]*T) string {
 	return strings.Join(names, ", ")
 }
 
-// resolveDedupe overlays an inline dedupe block (with `use` set) on top of
-// the named base it references. Returns the merged config or an error if
-// the reference does not exist.
-func resolveDedupe(inline *flow.DedupeConfig, named map[string]*flow.DedupeConfig) (*flow.DedupeConfig, error) {
-	base, ok := named[inline.Use]
-	if !ok {
-		return nil, fmt.Errorf("dedupe references unknown name %q (available: %s)", inline.Use, availableNames(named))
-	}
-
+// mergeDedupe overlays an inline dedupe block (with `use` set) on top of the
+// named base it references. Scalars override when non-empty; the fingerprint
+// map is merged key by key (inline wins per key, named-only keys preserved).
+func mergeDedupe(base, inline *flow.DedupeConfig) *flow.DedupeConfig {
 	merged := *base
 	merged.Name = ""        // inline blocks have no name
 	merged.Use = inline.Use // preserve the reference for tracing/debugging
@@ -114,22 +96,15 @@ func resolveDedupe(inline *flow.DedupeConfig, named map[string]*flow.DedupeConfi
 			merged.Fingerprint[k] = v
 		}
 	}
-	return &merged, nil
+	return &merged
 }
 
-// resolveRetry overlays an inline retry block (with `use` set) on top of the
-// named base it references. Inline non-zero attributes win, attribute by
-// attribute; unset inline fields inherit from the named base. Returns the
-// merged config or an error if the reference does not exist.
-func resolveRetry(inline *flow.RetryConfig, named map[string]*flow.RetryConfig) (*flow.RetryConfig, error) {
-	base, ok := named[inline.Use]
-	if !ok {
-		return nil, fmt.Errorf("retry references unknown name %q (available: %s)", inline.Use, availableNames(named))
-	}
-
+// mergeRetry overlays an inline retry block on top of the named base it
+// references. Inline non-zero attributes win; unset inline fields inherit.
+func mergeRetry(base, inline *flow.RetryConfig) *flow.RetryConfig {
 	merged := *base
-	merged.Name = ""        // inline blocks have no name
-	merged.Use = inline.Use // preserve the reference for tracing/debugging
+	merged.Name = ""
+	merged.Use = inline.Use
 
 	if inline.Attempts != 0 {
 		merged.Attempts = inline.Attempts
@@ -143,28 +118,22 @@ func resolveRetry(inline *flow.RetryConfig, named map[string]*flow.RetryConfig) 
 	if inline.Backoff != "" {
 		merged.Backoff = inline.Backoff
 	}
-	return &merged, nil
+	return &merged
 }
 
-// resolveLock overlays an inline lock block (with `use` set) on top of the
-// named base it references. String attributes override when non-empty. The
-// storage sub-block is replaced wholesale when the inline block defines one
-// (no deep merge — see the v2.6 plan: sub-blocks replace, attributes overlay).
+// mergeLock overlays an inline lock block on top of the named base it
+// references. String attributes override when non-empty. The storage sub-block
+// is replaced wholesale when the inline block defines one (no deep merge — see
+// the v2.6 plan: sub-blocks replace, attributes overlay).
 //
 // Caveat for `wait`: a bool cannot distinguish "unset" from "false", so an
 // inline `wait = true` overrides the base but an inline `wait = false` (or an
 // omitted wait) inherits the base value. To force no-wait against a base that
-// waits, define a separate named lock or inline the block fully. (The upcoming
-// table-driven refactor can resolve this generically via presence tracking.)
-func resolveLock(inline *flow.LockConfig, named map[string]*flow.LockConfig) (*flow.LockConfig, error) {
-	base, ok := named[inline.Use]
-	if !ok {
-		return nil, fmt.Errorf("lock references unknown name %q (available: %s)", inline.Use, availableNames(named))
-	}
-
+// waits, define a separate named lock or inline the block fully.
+func mergeLock(base, inline *flow.LockConfig) *flow.LockConfig {
 	merged := *base
-	merged.Name = ""        // inline blocks have no name
-	merged.Use = inline.Use // preserve the reference for tracing/debugging
+	merged.Name = ""
+	merged.Use = inline.Use
 
 	if inline.Key != "" {
 		merged.Key = inline.Key
@@ -181,5 +150,5 @@ func resolveLock(inline *flow.LockConfig, named map[string]*flow.LockConfig) (*f
 	if inline.Storage != nil {
 		merged.Storage = inline.Storage
 	}
-	return &merged, nil
+	return &merged
 }

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -1,0 +1,102 @@
+package parser
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+// ResolveReferences walks every flow and folds reusable-block references
+// (e.g. `dedupe { use = "dedupe.standard"; ttl = "1h" }`) into a single
+// self-contained block per flow. It does two things in one pass:
+//
+//  1. **Validation.** Every `use` value must name a registered top-level
+//     block of the matching kind. A typo here would otherwise survive parse
+//     and only blow up when the flow is dispatched at runtime — too late.
+//     The error message lists the available names to make typos obvious.
+//
+//  2. **Merge.** The named block is taken as the base, the inline block's
+//     non-zero attributes overlay it. Map-typed fields (e.g. dedupe's
+//     fingerprint) are merged key by key. After this pass, the runtime
+//     never has to know whether a block came from a named reference or
+//     was written inline — Config.Dedupe etc. are always complete.
+//
+// Mutates the receiver in place. Idempotent: running twice yields the same
+// result because the second pass finds an empty `Use` (cleared after merge).
+func (c *Configuration) ResolveReferences() error {
+	namedDedupes := indexByName(c.NamedDedupes, func(d *flow.DedupeConfig) string { return d.Name })
+
+	for _, f := range c.Flows {
+		if f.Dedupe != nil && f.Dedupe.Use != "" {
+			merged, err := resolveDedupe(f.Dedupe, namedDedupes)
+			if err != nil {
+				return fmt.Errorf("flow %q: %w", f.Name, err)
+			}
+			f.Dedupe = merged
+		}
+	}
+	return nil
+}
+
+// indexByName builds a name → entry map from a slice. The key function lets
+// callers reuse the helper across different Named* types without reflection.
+func indexByName[T any](items []*T, name func(*T) string) map[string]*T {
+	out := make(map[string]*T, len(items))
+	for _, item := range items {
+		out[name(item)] = item
+	}
+	return out
+}
+
+// availableNames returns a sorted, comma-joined list of map keys for use in
+// "did you mean" style error messages.
+func availableNames[T any](m map[string]*T) string {
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return "(none defined)"
+	}
+	return strings.Join(names, ", ")
+}
+
+// resolveDedupe overlays an inline dedupe block (with `use` set) on top of
+// the named base it references. Returns the merged config or an error if
+// the reference does not exist.
+func resolveDedupe(inline *flow.DedupeConfig, named map[string]*flow.DedupeConfig) (*flow.DedupeConfig, error) {
+	base, ok := named[inline.Use]
+	if !ok {
+		return nil, fmt.Errorf("dedupe references unknown name %q (available: %s)", inline.Use, availableNames(named))
+	}
+
+	merged := *base
+	merged.Name = ""        // inline blocks have no name
+	merged.Use = inline.Use // preserve the reference for tracing/debugging
+
+	if inline.Cache != "" {
+		merged.Cache = inline.Cache
+	}
+	if inline.Key != "" {
+		merged.Key = inline.Key
+	}
+	if inline.TTL != "" {
+		merged.TTL = inline.TTL
+	}
+	if inline.OnDuplicate != "" {
+		merged.OnDuplicate = inline.OnDuplicate
+	}
+	if len(inline.Fingerprint) > 0 {
+		merged.Fingerprint = make(map[string]string, len(base.Fingerprint)+len(inline.Fingerprint))
+		for k, v := range base.Fingerprint {
+			merged.Fingerprint[k] = v
+		}
+		for k, v := range inline.Fingerprint {
+			merged.Fingerprint[k] = v
+		}
+	}
+	return &merged, nil
+}

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -28,6 +28,7 @@ import (
 func (c *Configuration) ResolveReferences() error {
 	namedDedupes := indexByName(c.NamedDedupes, func(d *flow.DedupeConfig) string { return d.Name })
 	namedRetries := indexByName(c.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
+	namedLocks := indexByName(c.NamedLocks, func(l *flow.LockConfig) string { return l.Name })
 
 	for _, f := range c.Flows {
 		if f.Dedupe != nil && f.Dedupe.Use != "" {
@@ -43,6 +44,13 @@ func (c *Configuration) ResolveReferences() error {
 				return fmt.Errorf("flow %q: %w", f.Name, err)
 			}
 			f.ErrorHandling.Retry = merged
+		}
+		if f.Lock != nil && f.Lock.Use != "" {
+			merged, err := resolveLock(f.Lock, namedLocks)
+			if err != nil {
+				return fmt.Errorf("flow %q: %w", f.Name, err)
+			}
+			f.Lock = merged
 		}
 	}
 	return nil
@@ -134,6 +142,44 @@ func resolveRetry(inline *flow.RetryConfig, named map[string]*flow.RetryConfig) 
 	}
 	if inline.Backoff != "" {
 		merged.Backoff = inline.Backoff
+	}
+	return &merged, nil
+}
+
+// resolveLock overlays an inline lock block (with `use` set) on top of the
+// named base it references. String attributes override when non-empty. The
+// storage sub-block is replaced wholesale when the inline block defines one
+// (no deep merge — see the v2.6 plan: sub-blocks replace, attributes overlay).
+//
+// Caveat for `wait`: a bool cannot distinguish "unset" from "false", so an
+// inline `wait = true` overrides the base but an inline `wait = false` (or an
+// omitted wait) inherits the base value. To force no-wait against a base that
+// waits, define a separate named lock or inline the block fully. (The upcoming
+// table-driven refactor can resolve this generically via presence tracking.)
+func resolveLock(inline *flow.LockConfig, named map[string]*flow.LockConfig) (*flow.LockConfig, error) {
+	base, ok := named[inline.Use]
+	if !ok {
+		return nil, fmt.Errorf("lock references unknown name %q (available: %s)", inline.Use, availableNames(named))
+	}
+
+	merged := *base
+	merged.Name = ""        // inline blocks have no name
+	merged.Use = inline.Use // preserve the reference for tracing/debugging
+
+	if inline.Key != "" {
+		merged.Key = inline.Key
+	}
+	if inline.Timeout != "" {
+		merged.Timeout = inline.Timeout
+	}
+	if inline.Retry != "" {
+		merged.Retry = inline.Retry
+	}
+	if inline.Wait {
+		merged.Wait = true
+	}
+	if inline.Storage != nil {
+		merged.Storage = inline.Storage
 	}
 	return &merged, nil
 }

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -152,3 +152,54 @@ func mergeLock(base, inline *flow.LockConfig) *flow.LockConfig {
 	}
 	return &merged
 }
+
+// mergeSemaphore overlays an inline semaphore block on top of the named base.
+// Scalars override when non-zero; the storage sub-block is replaced wholesale.
+func mergeSemaphore(base, inline *flow.SemaphoreConfig) *flow.SemaphoreConfig {
+	merged := *base
+	merged.Name = ""
+	merged.Use = inline.Use
+
+	if inline.Key != "" {
+		merged.Key = inline.Key
+	}
+	if inline.MaxPermits != 0 {
+		merged.MaxPermits = inline.MaxPermits
+	}
+	if inline.Timeout != "" {
+		merged.Timeout = inline.Timeout
+	}
+	if inline.Lease != "" {
+		merged.Lease = inline.Lease
+	}
+	if inline.Storage != nil {
+		merged.Storage = inline.Storage
+	}
+	return &merged
+}
+
+// mergeSequenceGuard overlays an inline sequence_guard block on top of the
+// named base. Scalars override when non-empty; the storage sub-block is
+// replaced wholesale.
+func mergeSequenceGuard(base, inline *flow.SequenceGuardConfig) *flow.SequenceGuardConfig {
+	merged := *base
+	merged.Name = ""
+	merged.Use = inline.Use
+
+	if inline.Key != "" {
+		merged.Key = inline.Key
+	}
+	if inline.Sequence != "" {
+		merged.Sequence = inline.Sequence
+	}
+	if inline.OnOlder != "" {
+		merged.OnOlder = inline.OnOlder
+	}
+	if inline.TTL != "" {
+		merged.TTL = inline.TTL
+	}
+	if inline.Storage != nil {
+		merged.Storage = inline.Storage
+	}
+	return &merged
+}

--- a/internal/parser/reusable.go
+++ b/internal/parser/reusable.go
@@ -264,6 +264,78 @@ var reusableKinds = []reusableKind{
 		},
 	},
 	{
+		typeName: "accept",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			a, err := parseNamedAcceptBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("accept parse error: %w", err)
+			}
+			cfg.NamedAccepts = append(cfg.NamedAccepts, a)
+			cfg.recordSource("accept", a.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("accept", cfg.NamedAccepts, func(a *flow.AcceptConfig) string { return a.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedAccepts, func(a *flow.AcceptConfig) string { return a.Name })
+			return func(f *flow.Config) error {
+				if f.Accept == nil || f.Accept.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("accept", f.Accept.Use, f.Accept, idx, mergeAccept)
+				if err != nil {
+					return err
+				}
+				f.Accept = merged
+				return nil
+			}
+		},
+	},
+	{
+		// response is special: the named form is a *ResponseConfig, but a flow's
+		// inline response is a bare map (Flow.Config.Response) with the reference
+		// carried in the ResponseUse marker. So the resolver is bespoke — it
+		// folds the named mappings under the flow's inline overrides — rather
+		// than going through resolveRef.
+		typeName: "response",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			r, err := parseNamedResponseBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("response parse error: %w", err)
+			}
+			cfg.NamedResponses = append(cfg.NamedResponses, r)
+			cfg.recordSource("response", r.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("response", cfg.NamedResponses, func(r *flow.ResponseConfig) string { return r.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedResponses, func(r *flow.ResponseConfig) string { return r.Name })
+			return func(f *flow.Config) error {
+				if f.ResponseUse == "" {
+					return nil
+				}
+				base, ok := idx[f.ResponseUse]
+				if !ok {
+					return fmt.Errorf("response references unknown name %q (available: %s)", f.ResponseUse, availableNames(idx))
+				}
+				// Named mappings form the base; the flow's inline entries (if
+				// any) override key by key, same as a transform reference.
+				merged := make(map[string]string, len(base.Mappings)+len(f.Response))
+				for k, v := range base.Mappings {
+					merged[k] = v
+				}
+				for k, v := range f.Response {
+					merged[k] = v
+				}
+				f.Response = merged
+				return nil
+			}
+		},
+	},
+	{
 		// retry is intentionally LAST — see the ordering note above. A retry
 		// materialized onto a flow by the error_handling pass (carrying its
 		// own `use`) is folded here.

--- a/internal/parser/reusable.go
+++ b/internal/parser/reusable.go
@@ -40,8 +40,12 @@ type reusableKind struct {
 	newResolver func(cfg *Configuration) func(f *flow.Config) error
 }
 
-// reusableKinds is the registry. Order only affects the deterministic order of
-// rootSchema entries and validation passes; it has no semantic effect.
+// reusableKinds is the registry. Order is mostly cosmetic (it sets the order of
+// rootSchema entries and validation passes), with ONE semantic constraint:
+// error_handling must come before retry. A reused error_handling can pull in a
+// retry that itself carries `use = "retry.<name>"`; ResolveReferences materializes
+// the error_handling first so the later retry pass sees and folds that retry.
+// Hence retry is intentionally last.
 var reusableKinds = []reusableKind{
 	{
 		typeName: "dedupe",
@@ -68,35 +72,6 @@ var reusableKinds = []reusableKind{
 					return err
 				}
 				f.Dedupe = merged
-				return nil
-			}
-		},
-	},
-	{
-		typeName: "retry",
-		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
-			r, err := parseNamedRetryBlock(block, p.evalCtx)
-			if err != nil {
-				return fmt.Errorf("retry parse error: %w", err)
-			}
-			cfg.NamedRetries = append(cfg.NamedRetries, r)
-			cfg.recordSource("retry", r.Name, path)
-			return nil
-		},
-		uniqueKeys: func(cfg *Configuration) []string {
-			return nameKeys("retry", cfg.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
-		},
-		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
-			idx := indexByName(cfg.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
-			return func(f *flow.Config) error {
-				if f.ErrorHandling == nil || f.ErrorHandling.Retry == nil || f.ErrorHandling.Retry.Use == "" {
-					return nil
-				}
-				merged, err := resolveRef("retry", f.ErrorHandling.Retry.Use, f.ErrorHandling.Retry, idx, mergeRetry)
-				if err != nil {
-					return err
-				}
-				f.ErrorHandling.Retry = merged
 				return nil
 			}
 		},
@@ -184,6 +159,138 @@ var reusableKinds = []reusableKind{
 					return err
 				}
 				f.SequenceGuard = merged
+				return nil
+			}
+		},
+	},
+	{
+		typeName: "coordinate",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			c, err := parseNamedCoordinateBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("coordinate parse error: %w", err)
+			}
+			cfg.NamedCoordinates = append(cfg.NamedCoordinates, c)
+			cfg.recordSource("coordinate", c.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("coordinate", cfg.NamedCoordinates, func(c *flow.CoordinateConfig) string { return c.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedCoordinates, func(c *flow.CoordinateConfig) string { return c.Name })
+			return func(f *flow.Config) error {
+				if f.Coordinate == nil || f.Coordinate.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("coordinate", f.Coordinate.Use, f.Coordinate, idx, mergeCoordinate)
+				if err != nil {
+					return err
+				}
+				f.Coordinate = merged
+				return nil
+			}
+		},
+	},
+	{
+		typeName: "transaction",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			tx, err := parseNamedTransactionBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("transaction parse error: %w", err)
+			}
+			cfg.NamedTransactions = append(cfg.NamedTransactions, tx)
+			cfg.recordSource("transaction", tx.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("transaction", cfg.NamedTransactions, func(tx *flow.TransactionConfig) string { return tx.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedTransactions, func(tx *flow.TransactionConfig) string { return tx.Name })
+			resolveTo := func(to *flow.ToConfig) error {
+				if to == nil || to.Transaction == nil || to.Transaction.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("transaction", to.Transaction.Use, to.Transaction, idx, mergeTransaction)
+				if err != nil {
+					return err
+				}
+				to.Transaction = merged
+				return nil
+			}
+			return func(f *flow.Config) error {
+				// Transactions can live in the single `to` and in every
+				// fan-out `to` (MultiTo); resolve them all.
+				if err := resolveTo(f.To); err != nil {
+					return err
+				}
+				for _, to := range f.MultiTo {
+					if err := resolveTo(to); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+		},
+	},
+	{
+		typeName: "error_handling",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			eh, err := parseNamedErrorHandlingBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("error_handling parse error: %w", err)
+			}
+			cfg.NamedErrorHandlings = append(cfg.NamedErrorHandlings, eh)
+			cfg.recordSource("error_handling", eh.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("error_handling", cfg.NamedErrorHandlings, func(eh *flow.ErrorHandlingConfig) string { return eh.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedErrorHandlings, func(eh *flow.ErrorHandlingConfig) string { return eh.Name })
+			return func(f *flow.Config) error {
+				if f.ErrorHandling == nil || f.ErrorHandling.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("error_handling", f.ErrorHandling.Use, f.ErrorHandling, idx, mergeErrorHandling)
+				if err != nil {
+					return err
+				}
+				f.ErrorHandling = merged
+				return nil
+			}
+		},
+	},
+	{
+		// retry is intentionally LAST — see the ordering note above. A retry
+		// materialized onto a flow by the error_handling pass (carrying its
+		// own `use`) is folded here.
+		typeName: "retry",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			r, err := parseNamedRetryBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("retry parse error: %w", err)
+			}
+			cfg.NamedRetries = append(cfg.NamedRetries, r)
+			cfg.recordSource("retry", r.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("retry", cfg.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
+			return func(f *flow.Config) error {
+				if f.ErrorHandling == nil || f.ErrorHandling.Retry == nil || f.ErrorHandling.Retry.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("retry", f.ErrorHandling.Retry.Use, f.ErrorHandling.Retry, idx, mergeRetry)
+				if err != nil {
+					return err
+				}
+				f.ErrorHandling.Retry = merged
 				return nil
 			}
 		},

--- a/internal/parser/reusable.go
+++ b/internal/parser/reusable.go
@@ -130,6 +130,64 @@ var reusableKinds = []reusableKind{
 			}
 		},
 	},
+	{
+		typeName: "semaphore",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			s, err := parseNamedSemaphoreBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("semaphore parse error: %w", err)
+			}
+			cfg.NamedSemaphores = append(cfg.NamedSemaphores, s)
+			cfg.recordSource("semaphore", s.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("semaphore", cfg.NamedSemaphores, func(s *flow.SemaphoreConfig) string { return s.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedSemaphores, func(s *flow.SemaphoreConfig) string { return s.Name })
+			return func(f *flow.Config) error {
+				if f.Semaphore == nil || f.Semaphore.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("semaphore", f.Semaphore.Use, f.Semaphore, idx, mergeSemaphore)
+				if err != nil {
+					return err
+				}
+				f.Semaphore = merged
+				return nil
+			}
+		},
+	},
+	{
+		typeName: "sequence_guard",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			sg, err := parseNamedSequenceGuardBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("sequence_guard parse error: %w", err)
+			}
+			cfg.NamedSequenceGuards = append(cfg.NamedSequenceGuards, sg)
+			cfg.recordSource("sequence_guard", sg.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("sequence_guard", cfg.NamedSequenceGuards, func(sg *flow.SequenceGuardConfig) string { return sg.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedSequenceGuards, func(sg *flow.SequenceGuardConfig) string { return sg.Name })
+			return func(f *flow.Config) error {
+				if f.SequenceGuard == nil || f.SequenceGuard.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("sequence_guard", f.SequenceGuard.Use, f.SequenceGuard, idx, mergeSequenceGuard)
+				if err != nil {
+					return err
+				}
+				f.SequenceGuard = merged
+				return nil
+			}
+		},
+	},
 }
 
 // reusableKindByName indexes the registry by HCL block type for O(1) dispatch

--- a/internal/parser/reusable.go
+++ b/internal/parser/reusable.go
@@ -1,0 +1,173 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+// reusableKind describes one nameable + referenceable inline block (dedupe,
+// retry, lock, ...). A single entry drives every cross-cutting concern so the
+// generic plumbing never has to grow per kind:
+//
+//   - rootSchema registers `<typeName> "<name>" {}` as a top-level block.
+//   - ParseFile dispatches a top-level block of this type to parseRegister.
+//   - ValidateUniqueNames feeds uniqueKeys into its duplicate-name check.
+//   - ResolveReferences runs newResolver against every flow.
+//
+// Adding a new reusable block is then: embed flow.Reusable in its *Config, add
+// the typed slice to Configuration (+ NewConfiguration + Merge), and append one
+// entry here backed by a parseNamed*/merge* pair. No edits to the loops.
+type reusableKind struct {
+	// typeName is the HCL block type and the `use = "<typeName>.<name>"`
+	// namespace (also the prefix used for SourceFiles and uniqueness keys).
+	typeName string
+
+	// parseRegister parses a top-level `<typeName> "<name>" { ... }` block,
+	// appends it to the matching Configuration slice, and records its source
+	// file for duplicate-name diagnostics.
+	parseRegister func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error
+
+	// uniqueKeys returns the "<typeName>:<name>" keys for the registered
+	// blocks of this kind, consumed by ValidateUniqueNames.
+	uniqueKeys func(cfg *Configuration) []string
+
+	// newResolver builds a per-flow resolver. The index over named blocks is
+	// built once (here, not per flow); the returned closure folds a flow's
+	// reference of this kind into a self-contained block, or is a no-op when
+	// the flow does not reference this kind.
+	newResolver func(cfg *Configuration) func(f *flow.Config) error
+}
+
+// reusableKinds is the registry. Order only affects the deterministic order of
+// rootSchema entries and validation passes; it has no semantic effect.
+var reusableKinds = []reusableKind{
+	{
+		typeName: "dedupe",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			d, err := parseNamedDedupeBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("dedupe parse error: %w", err)
+			}
+			cfg.NamedDedupes = append(cfg.NamedDedupes, d)
+			cfg.recordSource("dedupe", d.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("dedupe", cfg.NamedDedupes, func(d *flow.DedupeConfig) string { return d.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedDedupes, func(d *flow.DedupeConfig) string { return d.Name })
+			return func(f *flow.Config) error {
+				if f.Dedupe == nil || f.Dedupe.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("dedupe", f.Dedupe.Use, f.Dedupe, idx, mergeDedupe)
+				if err != nil {
+					return err
+				}
+				f.Dedupe = merged
+				return nil
+			}
+		},
+	},
+	{
+		typeName: "retry",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			r, err := parseNamedRetryBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("retry parse error: %w", err)
+			}
+			cfg.NamedRetries = append(cfg.NamedRetries, r)
+			cfg.recordSource("retry", r.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("retry", cfg.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedRetries, func(r *flow.RetryConfig) string { return r.Name })
+			return func(f *flow.Config) error {
+				if f.ErrorHandling == nil || f.ErrorHandling.Retry == nil || f.ErrorHandling.Retry.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("retry", f.ErrorHandling.Retry.Use, f.ErrorHandling.Retry, idx, mergeRetry)
+				if err != nil {
+					return err
+				}
+				f.ErrorHandling.Retry = merged
+				return nil
+			}
+		},
+	},
+	{
+		typeName: "lock",
+		parseRegister: func(p *HCLParser, block *hcl.Block, cfg *Configuration, path string) error {
+			l, err := parseNamedLockBlock(block, p.evalCtx)
+			if err != nil {
+				return fmt.Errorf("lock parse error: %w", err)
+			}
+			cfg.NamedLocks = append(cfg.NamedLocks, l)
+			cfg.recordSource("lock", l.Name, path)
+			return nil
+		},
+		uniqueKeys: func(cfg *Configuration) []string {
+			return nameKeys("lock", cfg.NamedLocks, func(l *flow.LockConfig) string { return l.Name })
+		},
+		newResolver: func(cfg *Configuration) func(f *flow.Config) error {
+			idx := indexByName(cfg.NamedLocks, func(l *flow.LockConfig) string { return l.Name })
+			return func(f *flow.Config) error {
+				if f.Lock == nil || f.Lock.Use == "" {
+					return nil
+				}
+				merged, err := resolveRef("lock", f.Lock.Use, f.Lock, idx, mergeLock)
+				if err != nil {
+					return err
+				}
+				f.Lock = merged
+				return nil
+			}
+		},
+	},
+}
+
+// reusableKindByName indexes the registry by HCL block type for O(1) dispatch
+// in ParseFile. Built once at init; depends on reusableKinds being initialized
+// first, which Go guarantees by package-var dependency order.
+var reusableKindByName = func() map[string]reusableKind {
+	m := make(map[string]reusableKind, len(reusableKinds))
+	for _, k := range reusableKinds {
+		m[k.typeName] = k
+	}
+	return m
+}()
+
+// resolveRef looks up the named base an inline block references and folds the
+// inline overrides on top of it via the kind-specific merge function. The
+// lookup + "did you mean" error is shared; only merge differs per kind.
+func resolveRef[T any](kind, use string, inline *T, named map[string]*T, merge func(base, inline *T) *T) (*T, error) {
+	base, ok := named[use]
+	if !ok {
+		return nil, fmt.Errorf("%s references unknown name %q (available: %s)", kind, use, availableNames(named))
+	}
+	return merge(base, inline), nil
+}
+
+// nameKeys builds the "<kind>:<name>" uniqueness keys for a slice of named
+// blocks. The name accessor lets one helper serve every kind without
+// reflection.
+func nameKeys[T any](kind string, items []*T, name func(*T) string) []string {
+	keys := make([]string, len(items))
+	for i, it := range items {
+		keys[i] = kind + ":" + name(it)
+	}
+	return keys
+}
+
+// recordSource appends a source file under the "<kind>:<name>" key used by
+// ValidateUniqueNames to report where each definition lives.
+func (c *Configuration) recordSource(kind, name, path string) {
+	key := kind + ":" + name
+	c.SourceFiles[key] = append(c.SourceFiles[key], path)
+}

--- a/internal/parser/reusable_category_b_test.go
+++ b/internal/parser/reusable_category_b_test.go
@@ -1,0 +1,377 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// Category B: blocks with sub-blocks (coordinate, transaction, error_handling).
+// All added through the reusableKinds registry. Override is attribute-level for
+// scalars and wholesale for sub-blocks (no deep merge), matching the v2.6 plan.
+
+// --- coordinate ---
+
+func TestNamedCoordinateResolvesAndOverrides(t *testing.T) {
+	hcl := `
+coordinate "ordering" {
+  storage {
+    driver = "redis"
+    url    = "redis://base:6379"
+  }
+  timeout     = "60s"
+  on_timeout  = "fail"
+  max_retries = 3
+  wait {
+    when = "input.type == 'child'"
+    for  = "'parent:' + input.parent_id"
+  }
+}
+
+flow "resolves" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  coordinate {
+    use = "coordinate.ordering"
+  }
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  coordinate {
+    use        = "coordinate.ordering"
+    timeout    = "10s"
+    storage {
+      driver = "memory"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+
+	r := findFlow(t, cfg, "resolves").Coordinate
+	if r.Timeout != "60s" || r.OnTimeout != "fail" || r.MaxRetries != 3 {
+		t.Errorf("resolved coordinate should inherit base scalars: %+v", r)
+	}
+	if r.Wait == nil || r.Wait.When != "input.type == 'child'" {
+		t.Errorf("resolved coordinate should inherit base wait: %+v", r.Wait)
+	}
+	if r.Storage == nil || r.Storage.URL != "redis://base:6379" {
+		t.Errorf("resolved coordinate should inherit base storage: %+v", r.Storage)
+	}
+
+	ov := findFlow(t, cfg, "overrides").Coordinate
+	if ov.Timeout != "10s" {
+		t.Errorf("timeout override: want 10s, got %q", ov.Timeout)
+	}
+	// Untouched scalar inherits.
+	if ov.OnTimeout != "fail" || ov.MaxRetries != 3 {
+		t.Errorf("untouched coordinate scalars should inherit: %+v", ov)
+	}
+	// Storage replaced wholesale: base URL must not leak.
+	if ov.Storage == nil || ov.Storage.Driver != "memory" || ov.Storage.URL != "" {
+		t.Errorf("storage should be replaced wholesale: %+v", ov.Storage)
+	}
+	// Wait sub-block not overridden inline → inherited from base.
+	if ov.Wait == nil || ov.Wait.When == "" {
+		t.Errorf("wait should inherit from base when not overridden: %+v", ov.Wait)
+	}
+}
+
+func TestNamedCoordinateMissingStorageFails(t *testing.T) {
+	hcl := `
+coordinate "broken" {
+  timeout = "30s"
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "storage") {
+		t.Errorf("expected storage error for named coordinate; got: %v", err)
+	}
+}
+
+func TestFlowCoordinateUnknownNameFails(t *testing.T) {
+	hcl := `
+coordinate "ordering" {
+  storage {
+    driver = "memory"
+  }
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  coordinate {
+    use = "coordinate.orderingg"
+  }
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "orderingg") || !strings.Contains(err.Error(), "ordering") {
+		t.Errorf("expected unknown-name error listing available; got: %v", err)
+	}
+}
+
+// --- transaction ---
+
+func TestNamedTransactionResolves(t *testing.T) {
+	hcl := `
+connector "db" {
+  type   = "database"
+  driver = "sqlite"
+  path   = "./t.db"
+}
+
+transaction "persist_order" {
+  exec {
+    query   = "INSERT INTO orders (sku) VALUES (:sku)"
+    params  = { sku = "input.sku" }
+    capture = "order_id"
+  }
+  exec {
+    query  = "INSERT INTO order_log (order_id) VALUES (:oid)"
+    params = { oid = "captured.order_id" }
+  }
+}
+
+flow "save" {
+  from {
+    connector = "x"
+    operation = "POST /orders"
+  }
+  to {
+    connector = "db"
+    transaction {
+      use = "transaction.persist_order"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	tx := findFlow(t, cfg, "save").To.Transaction
+	if tx == nil {
+		t.Fatal("transaction should not be nil after resolve")
+	}
+	if len(tx.Statements) != 2 {
+		t.Fatalf("expected 2 statements pulled from named transaction, got %d", len(tx.Statements))
+	}
+	if tx.Statements[0].Exec == nil || !strings.Contains(tx.Statements[0].Exec.Query, "INSERT INTO orders") {
+		t.Errorf("first statement not resolved from named base: %+v", tx.Statements[0])
+	}
+	if tx.Use != "persist_order" {
+		t.Errorf("Use should be preserved for tracing: got %q", tx.Use)
+	}
+}
+
+func TestNamedTransactionEmptyFails(t *testing.T) {
+	hcl := `
+transaction "empty" {
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "at least one exec or each") {
+		t.Errorf("expected empty-transaction error; got: %v", err)
+	}
+}
+
+func TestFlowTransactionUnknownNameFails(t *testing.T) {
+	hcl := `
+connector "db" {
+  type   = "database"
+  driver = "sqlite"
+  path   = "./t.db"
+}
+
+transaction "persist" {
+  exec {
+    query  = "INSERT INTO t (a) VALUES (:a)"
+    params = { a = "input.a" }
+  }
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "POST /t"
+  }
+  to {
+    connector = "db"
+    transaction {
+      use = "transaction.persistt"
+    }
+  }
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "persistt") || !strings.Contains(err.Error(), "persist") {
+		t.Errorf("expected unknown-name error listing available; got: %v", err)
+	}
+}
+
+// --- error_handling ---
+
+func TestNamedErrorHandlingResolvesAndOverrides(t *testing.T) {
+	hcl := `
+error_handling "standard" {
+  retry {
+    attempts = 3
+    delay    = "1s"
+    backoff  = "exponential"
+  }
+  on_timeout {
+    action = "ack"
+  }
+}
+
+flow "resolves" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    use = "error_handling.standard"
+  }
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    use = "error_handling.standard"
+    retry {
+      attempts = 5
+      backoff  = "linear"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+
+	r := findFlow(t, cfg, "resolves").ErrorHandling
+	if r.Retry == nil || r.Retry.Attempts != 3 || r.Retry.Backoff != "exponential" {
+		t.Errorf("resolved error_handling should inherit base retry: %+v", r.Retry)
+	}
+	if r.OnTimeout == nil || r.OnTimeout.Action != "ack" {
+		t.Errorf("resolved error_handling should inherit base on_timeout: %+v", r.OnTimeout)
+	}
+
+	ov := findFlow(t, cfg, "overrides").ErrorHandling
+	// retry sub-block replaced wholesale by inline.
+	if ov.Retry == nil || ov.Retry.Attempts != 5 || ov.Retry.Backoff != "linear" {
+		t.Errorf("retry should be replaced wholesale by inline: %+v", ov.Retry)
+	}
+	// on_timeout not overridden → inherited from base.
+	if ov.OnTimeout == nil || ov.OnTimeout.Action != "ack" {
+		t.Errorf("on_timeout should inherit from base when not overridden: %+v", ov.OnTimeout)
+	}
+}
+
+// TestNamedErrorHandlingWithNestedRetryUse is the cross-cutting case: a named
+// error_handling whose retry itself references a named retry. The error_handling
+// pass materializes the retry onto the flow, then the retry pass (which runs
+// after) folds the retry reference. Proves the registry ordering constraint.
+func TestNamedErrorHandlingWithNestedRetryUse(t *testing.T) {
+	hcl := `
+retry "aggressive" {
+  attempts  = 7
+  delay     = "2s"
+  max_delay = "1m"
+  backoff   = "exponential"
+}
+
+error_handling "standard" {
+  retry {
+    use = "retry.aggressive"
+  }
+}
+
+flow "uses_both" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    use = "error_handling.standard"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	r := findFlow(t, cfg, "uses_both").ErrorHandling.Retry
+	if r == nil {
+		t.Fatal("retry should be present after resolving error_handling + nested retry")
+	}
+	if r.Attempts != 7 || r.Delay != "2s" || r.MaxDelay != "1m" || r.Backoff != "exponential" {
+		t.Errorf("nested retry reference not resolved from named retry: %+v", r)
+	}
+}
+
+func TestNamedErrorHandlingEmptyFails(t *testing.T) {
+	hcl := `
+error_handling "empty" {
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("expected non-empty error for named error_handling; got: %v", err)
+	}
+}
+
+func TestFlowErrorHandlingUnknownNameFails(t *testing.T) {
+	hcl := `
+error_handling "standard" {
+  retry {
+    attempts = 3
+  }
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    use = "error_handling.standardd"
+  }
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "standardd") || !strings.Contains(err.Error(), "standard") {
+		t.Errorf("expected unknown-name error listing available; got: %v", err)
+	}
+}

--- a/internal/parser/reusable_category_c_test.go
+++ b/internal/parser/reusable_category_c_test.go
@@ -1,0 +1,270 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// Category C: mapping-style blocks. `accept` fits the registry pattern; named
+// `response` is a *ResponseConfig while a flow's inline response stays a bare
+// map (the reference is carried by the ResponseUse marker), so its resolver is
+// bespoke. error_response is intentionally NOT independently reusable — it is
+// covered by reusing the whole error_handling block (which holds a single
+// error_response).
+
+// --- accept ---
+
+func TestNamedAcceptResolvesAndOverrides(t *testing.T) {
+	hcl := `
+accept "is_mine" {
+  when      = "input.body.type == 'order'"
+  on_reject = "reject"
+}
+
+flow "resolves" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  accept {
+    use = "accept.is_mine"
+  }
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  accept {
+    use       = "accept.is_mine"
+    on_reject = "requeue"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+
+	r := findFlow(t, cfg, "resolves").Accept
+	if r.When != "input.body.type == 'order'" || r.OnReject != "reject" {
+		t.Errorf("resolved accept should inherit base: %+v", r)
+	}
+	if r.Use != "is_mine" {
+		t.Errorf("Use should be preserved for tracing: got %q", r.Use)
+	}
+
+	ov := findFlow(t, cfg, "overrides").Accept
+	if ov.OnReject != "requeue" {
+		t.Errorf("on_reject override: want requeue, got %q", ov.OnReject)
+	}
+	// when not overridden → inherits base.
+	if ov.When != "input.body.type == 'order'" {
+		t.Errorf("when should inherit base: got %q", ov.When)
+	}
+}
+
+func TestNamedAcceptMissingWhenFails(t *testing.T) {
+	hcl := `
+accept "broken" {
+  on_reject = "ack"
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "when") {
+		t.Errorf("expected when error for named accept; got: %v", err)
+	}
+}
+
+func TestFlowAcceptUnknownNameFails(t *testing.T) {
+	hcl := `
+accept "is_mine" {
+  when = "true"
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  accept {
+    use = "accept.is_minee"
+  }
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "is_minee") || !strings.Contains(err.Error(), "is_mine") {
+		t.Errorf("expected unknown-name error listing available; got: %v", err)
+	}
+}
+
+func TestInlineAcceptWithoutUseStillSelfContained(t *testing.T) {
+	hcl := `
+flow "still_inline" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  accept {
+    when = "input.ok"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	a := cfg.Flows[0].Accept
+	if a.When != "input.ok" {
+		t.Errorf("inline accept lost when: %+v", a)
+	}
+	if a.OnReject != "ack" {
+		t.Errorf("inline accept default on_reject: want ack, got %q", a.OnReject)
+	}
+	if a.Use != "" {
+		t.Errorf("inline-only accept should have empty Use, got %q", a.Use)
+	}
+}
+
+// --- response ---
+
+func TestNamedResponseResolvesAndOverrides(t *testing.T) {
+	hcl := `
+response "envelope" {
+  id     = "output.id"
+  status = "'ok'"
+  ts     = "output.created_at"
+}
+
+flow "resolves" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  response {
+    use = "response.envelope"
+  }
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  response {
+    use    = "response.envelope"
+    status = "'created'"
+    extra  = "output.extra"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+
+	r := findFlow(t, cfg, "resolves").Response
+	if len(r) != 3 || r["id"] != "output.id" || r["status"] != "'ok'" || r["ts"] != "output.created_at" {
+		t.Errorf("resolved response should equal named base mappings: %+v", r)
+	}
+	if findFlow(t, cfg, "resolves").ResponseUse != "envelope" {
+		t.Errorf("ResponseUse marker should be preserved for tracing")
+	}
+
+	ov := findFlow(t, cfg, "overrides").Response
+	// status overridden, id/ts inherited, extra added (4 keys, no "use" leak).
+	if len(ov) != 4 {
+		t.Errorf("merged response should have 4 keys, got %d: %+v", len(ov), ov)
+	}
+	if ov["status"] != "'created'" {
+		t.Errorf("status override: want 'created', got %q", ov["status"])
+	}
+	if ov["id"] != "output.id" || ov["ts"] != "output.created_at" {
+		t.Errorf("untouched response keys should inherit base: %+v", ov)
+	}
+	if ov["extra"] != "output.extra" {
+		t.Errorf("inline-only response key should be added: %+v", ov)
+	}
+	if _, leaked := ov["use"]; leaked {
+		t.Errorf("the `use` key must not leak into the response map: %+v", ov)
+	}
+}
+
+func TestNamedResponseEmptyFails(t *testing.T) {
+	hcl := `
+response "empty" {
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "at least one field") {
+		t.Errorf("expected empty-response error; got: %v", err)
+	}
+}
+
+func TestFlowResponseUnknownNameFails(t *testing.T) {
+	hcl := `
+response "envelope" {
+  id = "output.id"
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  response {
+    use = "response.envelopee"
+  }
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "envelopee") || !strings.Contains(err.Error(), "envelope") {
+		t.Errorf("expected unknown-name error listing available; got: %v", err)
+	}
+}
+
+func TestInlineResponseWithoutUseStillWorks(t *testing.T) {
+	hcl := `
+flow "still_inline" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  response {
+    result = "step.results"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	f := cfg.Flows[0]
+	if f.Response["result"] != "step.results" {
+		t.Errorf("inline response lost mapping: %+v", f.Response)
+	}
+	if f.ResponseUse != "" {
+		t.Errorf("inline-only response should have empty ResponseUse, got %q", f.ResponseUse)
+	}
+}

--- a/internal/parser/reusable_dedupe_test.go
+++ b/internal/parser/reusable_dedupe_test.go
@@ -1,0 +1,309 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNamedDedupeTopLevel verifies that a `dedupe "<name>" { ... }` block at
+// top level is parsed and registered under NamedDedupes.
+func TestNamedDedupeTopLevel(t *testing.T) {
+	hcl := `
+dedupe "standard" {
+  cache         = "memory_cache"
+  key           = "input.id"
+  ttl           = "1h"
+  on_duplicate  = "ack"
+  fingerprint {
+    id = "input.id"
+  }
+}
+`
+	cfg := mustParse(t, hcl)
+
+	if len(cfg.NamedDedupes) != 1 {
+		t.Fatalf("expected 1 named dedupe, got %d", len(cfg.NamedDedupes))
+	}
+	d := cfg.NamedDedupes[0]
+	if d.Name != "standard" {
+		t.Errorf("name: want %q, got %q", "standard", d.Name)
+	}
+	if d.Cache != "memory_cache" {
+		t.Errorf("cache: want %q, got %q", "memory_cache", d.Cache)
+	}
+	if d.Key != "input.id" {
+		t.Errorf("key: want %q, got %q", "input.id", d.Key)
+	}
+	if d.TTL != "1h" {
+		t.Errorf("ttl: want %q, got %q", "1h", d.TTL)
+	}
+	if d.OnDuplicate != "ack" {
+		t.Errorf("on_duplicate: want %q, got %q", "ack", d.OnDuplicate)
+	}
+	if d.Fingerprint["id"] != "input.id" {
+		t.Errorf("fingerprint[id]: want %q, got %q", "input.id", d.Fingerprint["id"])
+	}
+}
+
+// TestFlowDedupeUseResolvesToNamed verifies that a flow's dedupe with
+// `use = "dedupe.<name>"` and no other fields ends up fully populated from
+// the named block after parse.
+func TestFlowDedupeUseResolvesToNamed(t *testing.T) {
+	hcl := `
+dedupe "standard" {
+  cache         = "memory_cache"
+  key           = "input.id"
+  ttl           = "1h"
+  on_duplicate  = "ack"
+  fingerprint {
+    id   = "input.id"
+    name = "input.name"
+  }
+}
+
+flow "uses_named" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  dedupe {
+    use = "dedupe.standard"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	f := cfg.Flows[0]
+	if f.Dedupe == nil {
+		t.Fatal("flow.Dedupe should not be nil after resolve")
+	}
+	if f.Dedupe.Cache != "memory_cache" {
+		t.Errorf("cache: want %q, got %q", "memory_cache", f.Dedupe.Cache)
+	}
+	if f.Dedupe.Key != "input.id" {
+		t.Errorf("key: want %q, got %q", "input.id", f.Dedupe.Key)
+	}
+	if f.Dedupe.TTL != "1h" {
+		t.Errorf("ttl: want %q, got %q", "1h", f.Dedupe.TTL)
+	}
+	if f.Dedupe.OnDuplicate != "ack" {
+		t.Errorf("on_duplicate: want %q, got %q", "ack", f.Dedupe.OnDuplicate)
+	}
+	if len(f.Dedupe.Fingerprint) != 2 {
+		t.Errorf("fingerprint: want 2 entries, got %d", len(f.Dedupe.Fingerprint))
+	}
+	if f.Dedupe.Use != "standard" {
+		t.Errorf("Use should be preserved for tracing: want %q, got %q", "standard", f.Dedupe.Use)
+	}
+}
+
+// TestFlowDedupeInlineOverridesNamed verifies attribute-level override: inline
+// non-zero values win over the named base, but unset inline fields inherit
+// from the base. Fingerprint map is merged key-by-key (inline wins per key,
+// named-only keys are preserved).
+func TestFlowDedupeInlineOverridesNamed(t *testing.T) {
+	hcl := `
+dedupe "standard" {
+  cache         = "memory_cache"
+  key           = "input.id"
+  ttl           = "1h"
+  on_duplicate  = "ack"
+  fingerprint {
+    id   = "input.id"
+    name = "input.name"
+  }
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  dedupe {
+    use          = "dedupe.standard"
+    ttl          = "24h"
+    on_duplicate = "reject"
+    fingerprint {
+      name  = "input.upper_name"
+      email = "input.email"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	d := cfg.Flows[0].Dedupe
+
+	// Base attributes carry over untouched.
+	if d.Cache != "memory_cache" {
+		t.Errorf("cache: want %q, got %q (should inherit from base)", "memory_cache", d.Cache)
+	}
+	if d.Key != "input.id" {
+		t.Errorf("key: want %q, got %q (should inherit from base)", "input.id", d.Key)
+	}
+	// Overridden attributes use the inline value.
+	if d.TTL != "24h" {
+		t.Errorf("ttl: want %q (override), got %q", "24h", d.TTL)
+	}
+	if d.OnDuplicate != "reject" {
+		t.Errorf("on_duplicate: want %q (override), got %q", "reject", d.OnDuplicate)
+	}
+	// Fingerprint merges: id (base only) preserved, name (both) wins inline,
+	// email (inline only) added.
+	if d.Fingerprint["id"] != "input.id" {
+		t.Errorf("fingerprint[id]: want %q (preserved from base), got %q", "input.id", d.Fingerprint["id"])
+	}
+	if d.Fingerprint["name"] != "input.upper_name" {
+		t.Errorf("fingerprint[name]: want %q (inline wins), got %q", "input.upper_name", d.Fingerprint["name"])
+	}
+	if d.Fingerprint["email"] != "input.email" {
+		t.Errorf("fingerprint[email]: want %q (inline-only), got %q", "input.email", d.Fingerprint["email"])
+	}
+}
+
+// TestFlowDedupeUseUnknownNameFails verifies that referencing a non-existent
+// named dedupe fails at parse time with a helpful message listing the
+// available names — not at runtime when the flow first dispatches.
+func TestFlowDedupeUseUnknownNameFails(t *testing.T) {
+	hcl := `
+dedupe "standard" {
+  cache = "memory_cache"
+  key   = "input.id"
+  fingerprint { id = "input.id" }
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  dedupe {
+    use = "dedupe.standar"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected parse error for unknown dedupe reference")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "standar") || !strings.Contains(msg, "standard") {
+		t.Errorf("error should mention the typo and list the available name; got: %s", msg)
+	}
+}
+
+// TestInlineDedupeWithoutUseStillSelfContained verifies that the existing
+// inline-only behavior (no `use`) is unchanged: a self-contained dedupe
+// must still specify cache/key/fingerprint or fail clearly.
+func TestInlineDedupeWithoutUseStillSelfContained(t *testing.T) {
+	hcl := `
+flow "still_inline" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  dedupe {
+    cache = "memory_cache"
+    key   = "input.id"
+    fingerprint { id = "input.id" }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	d := cfg.Flows[0].Dedupe
+	if d.Cache != "memory_cache" || d.Key != "input.id" || d.Fingerprint["id"] != "input.id" {
+		t.Errorf("inline dedupe lost fields: %+v", d)
+	}
+	if d.Use != "" {
+		t.Errorf("inline-only dedupe should have empty Use, got %q", d.Use)
+	}
+	if d.OnDuplicate != "ack" {
+		t.Errorf("inline-only dedupe default OnDuplicate: want %q, got %q", "ack", d.OnDuplicate)
+	}
+}
+
+// TestInlineDedupeMissingCacheFailsClearly keeps the v2.5 error UX: an
+// inline dedupe without a `use` and without `cache` must still fail with a
+// helpful message, not silently end up half-configured.
+func TestInlineDedupeMissingCacheFailsClearly(t *testing.T) {
+	hcl := `
+flow "broken" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  dedupe {
+    key = "input.id"
+    fingerprint { id = "input.id" }
+  }
+}
+`
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected error for inline dedupe without cache")
+	}
+	if !strings.Contains(err.Error(), "cache") {
+		t.Errorf("error should mention the missing cache attribute; got: %s", err.Error())
+	}
+}
+
+// mustParse parses a single-file config from a string and returns it. Used
+// for tests that only need to exercise top-level blocks (no flow refs).
+func mustParse(t *testing.T, hcl string) *Configuration {
+	t.Helper()
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := NewHCLParser().ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return cfg
+}
+
+// mustParseDir parses a config through the full Parse() pipeline (including
+// ValidateUniqueNames + ResolveReferences) so flow-level refs to named
+// blocks get resolved. Use whenever the test asserts post-resolve state.
+func mustParseDir(t *testing.T, hcl string) *Configuration {
+	t.Helper()
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return cfg
+}

--- a/internal/parser/reusable_lock_test.go
+++ b/internal/parser/reusable_lock_test.go
@@ -1,0 +1,267 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNamedLockTopLevel verifies that a `lock "<name>" { ... }` block at top
+// level is parsed and registered under NamedLocks.
+func TestNamedLockTopLevel(t *testing.T) {
+	hcl := `
+lock "user_mutex" {
+  storage {
+    driver = "redis"
+    url    = "redis://localhost:6379"
+  }
+  key     = "'user:' + input.id"
+  timeout = "30s"
+  wait    = true
+  retry   = "100ms"
+}
+`
+	cfg := mustParse(t, hcl)
+
+	if len(cfg.NamedLocks) != 1 {
+		t.Fatalf("expected 1 named lock, got %d", len(cfg.NamedLocks))
+	}
+	l := cfg.NamedLocks[0]
+	if l.Name != "user_mutex" {
+		t.Errorf("name: want %q, got %q", "user_mutex", l.Name)
+	}
+	if l.Key != "'user:' + input.id" {
+		t.Errorf("key: want %q, got %q", "'user:' + input.id", l.Key)
+	}
+	if l.Timeout != "30s" {
+		t.Errorf("timeout: want %q, got %q", "30s", l.Timeout)
+	}
+	if !l.Wait {
+		t.Errorf("wait: want true, got false")
+	}
+	if l.Retry != "100ms" {
+		t.Errorf("retry: want %q, got %q", "100ms", l.Retry)
+	}
+	if l.Storage == nil || l.Storage.Driver != "redis" || l.Storage.URL != "redis://localhost:6379" {
+		t.Errorf("storage not parsed correctly: %+v", l.Storage)
+	}
+}
+
+// TestFlowLockUseResolvesToNamed verifies that a flow's lock with
+// `use = "lock.<name>"` and no other fields ends up fully populated from the
+// named block after parse, including the storage sub-block.
+func TestFlowLockUseResolvesToNamed(t *testing.T) {
+	hcl := `
+lock "user_mutex" {
+  storage {
+    driver = "redis"
+    url    = "redis://localhost:6379"
+  }
+  key     = "'user:' + input.id"
+  timeout = "30s"
+  wait    = true
+  retry   = "100ms"
+}
+
+flow "uses_named" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  lock {
+    use = "lock.user_mutex"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	l := cfg.Flows[0].Lock
+	if l == nil {
+		t.Fatal("flow.Lock should not be nil after resolve")
+	}
+	if l.Key != "'user:' + input.id" {
+		t.Errorf("key: want %q, got %q", "'user:' + input.id", l.Key)
+	}
+	if l.Timeout != "30s" {
+		t.Errorf("timeout: want %q, got %q", "30s", l.Timeout)
+	}
+	if !l.Wait {
+		t.Errorf("wait: want true (from base), got false")
+	}
+	if l.Retry != "100ms" {
+		t.Errorf("retry: want %q, got %q", "100ms", l.Retry)
+	}
+	if l.Storage == nil || l.Storage.Driver != "redis" {
+		t.Errorf("storage should inherit from base: %+v", l.Storage)
+	}
+	if l.Use != "user_mutex" {
+		t.Errorf("Use should be preserved for tracing: want %q, got %q", "user_mutex", l.Use)
+	}
+}
+
+// TestFlowLockInlineOverridesNamed verifies attribute-level override: inline
+// non-zero scalar values win, and an inline storage block replaces the named
+// base's storage block wholesale.
+func TestFlowLockInlineOverridesNamed(t *testing.T) {
+	hcl := `
+lock "user_mutex" {
+  storage {
+    driver = "redis"
+    url    = "redis://base:6379"
+  }
+  key     = "'user:' + input.id"
+  timeout = "30s"
+  retry   = "100ms"
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  lock {
+    use     = "lock.user_mutex"
+    key     = "'order:' + input.order_id"
+    timeout = "5s"
+    storage {
+      driver = "memory"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	l := cfg.Flows[0].Lock
+
+	// Overridden scalars use the inline value.
+	if l.Key != "'order:' + input.order_id" {
+		t.Errorf("key: want override, got %q", l.Key)
+	}
+	if l.Timeout != "5s" {
+		t.Errorf("timeout: want %q (override), got %q", "5s", l.Timeout)
+	}
+	// Untouched scalar inherits from base.
+	if l.Retry != "100ms" {
+		t.Errorf("retry: want %q (inherit from base), got %q", "100ms", l.Retry)
+	}
+	// Storage sub-block is replaced wholesale, not deep-merged: the base URL
+	// must NOT survive when the inline storage omits it.
+	if l.Storage == nil || l.Storage.Driver != "memory" {
+		t.Errorf("storage driver: want %q (inline replace), got %+v", "memory", l.Storage)
+	}
+	if l.Storage.URL != "" {
+		t.Errorf("storage URL should not leak from base after wholesale replace, got %q", l.Storage.URL)
+	}
+}
+
+// TestFlowLockUseUnknownNameFails verifies that referencing a non-existent
+// named lock fails at parse time with a helpful message listing the available
+// names.
+func TestFlowLockUseUnknownNameFails(t *testing.T) {
+	hcl := `
+lock "user_mutex" {
+  key = "'user:' + input.id"
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  lock {
+    use = "lock.user_mutexx"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected parse error for unknown lock reference")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "user_mutexx") || !strings.Contains(msg, "user_mutex") {
+		t.Errorf("error should mention the typo and list the available name; got: %s", msg)
+	}
+}
+
+// TestInlineLockWithoutUseStillSelfContained verifies that the existing
+// inline-only behavior (no `use`) is unchanged.
+func TestInlineLockWithoutUseStillSelfContained(t *testing.T) {
+	hcl := `
+flow "still_inline" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  lock {
+    storage {
+      driver = "memory"
+    }
+    key     = "'user:' + input.id"
+    timeout = "10s"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	l := cfg.Flows[0].Lock
+	if l.Key != "'user:' + input.id" || l.Timeout != "10s" {
+		t.Errorf("inline lock lost fields: %+v", l)
+	}
+	if l.Storage == nil || l.Storage.Driver != "memory" {
+		t.Errorf("inline lock storage missing: %+v", l.Storage)
+	}
+	if l.Use != "" {
+		t.Errorf("inline-only lock should have empty Use, got %q", l.Use)
+	}
+}
+
+// TestInlineLockMissingKeyFailsClearly keeps the existing error UX: an inline
+// lock without a `use` and without a `key` must still fail with a helpful
+// message, not silently end up half-configured.
+func TestInlineLockMissingKeyFailsClearly(t *testing.T) {
+	hcl := `
+flow "broken" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  lock {
+    timeout = "10s"
+  }
+}
+`
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected error for inline lock without key")
+	}
+	if !strings.Contains(err.Error(), "key") {
+		t.Errorf("error should mention the missing key; got: %s", err.Error())
+	}
+}

--- a/internal/parser/reusable_retry_test.go
+++ b/internal/parser/reusable_retry_test.go
@@ -1,0 +1,237 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNamedRetryTopLevel verifies that a `retry "<name>" { ... }` block at top
+// level is parsed and registered under NamedRetries.
+func TestNamedRetryTopLevel(t *testing.T) {
+	hcl := `
+retry "aggressive" {
+  attempts  = 5
+  delay     = "1s"
+  max_delay = "30s"
+  backoff   = "exponential"
+}
+`
+	cfg := mustParse(t, hcl)
+
+	if len(cfg.NamedRetries) != 1 {
+		t.Fatalf("expected 1 named retry, got %d", len(cfg.NamedRetries))
+	}
+	r := cfg.NamedRetries[0]
+	if r.Name != "aggressive" {
+		t.Errorf("name: want %q, got %q", "aggressive", r.Name)
+	}
+	if r.Attempts != 5 {
+		t.Errorf("attempts: want %d, got %d", 5, r.Attempts)
+	}
+	if r.Delay != "1s" {
+		t.Errorf("delay: want %q, got %q", "1s", r.Delay)
+	}
+	if r.MaxDelay != "30s" {
+		t.Errorf("max_delay: want %q, got %q", "30s", r.MaxDelay)
+	}
+	if r.Backoff != "exponential" {
+		t.Errorf("backoff: want %q, got %q", "exponential", r.Backoff)
+	}
+}
+
+// TestFlowRetryUseResolvesToNamed verifies that an error_handling.retry block
+// with `use = "retry.<name>"` and no other fields ends up fully populated from
+// the named block after parse.
+func TestFlowRetryUseResolvesToNamed(t *testing.T) {
+	hcl := `
+retry "aggressive" {
+  attempts  = 5
+  delay     = "1s"
+  max_delay = "30s"
+  backoff   = "exponential"
+}
+
+flow "uses_named" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    retry {
+      use = "retry.aggressive"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	f := cfg.Flows[0]
+	if f.ErrorHandling == nil || f.ErrorHandling.Retry == nil {
+		t.Fatal("flow.ErrorHandling.Retry should not be nil after resolve")
+	}
+	r := f.ErrorHandling.Retry
+	if r.Attempts != 5 {
+		t.Errorf("attempts: want %d, got %d", 5, r.Attempts)
+	}
+	if r.Delay != "1s" {
+		t.Errorf("delay: want %q, got %q", "1s", r.Delay)
+	}
+	if r.MaxDelay != "30s" {
+		t.Errorf("max_delay: want %q, got %q", "30s", r.MaxDelay)
+	}
+	if r.Backoff != "exponential" {
+		t.Errorf("backoff: want %q, got %q", "exponential", r.Backoff)
+	}
+	if r.Use != "aggressive" {
+		t.Errorf("Use should be preserved for tracing: want %q, got %q", "aggressive", r.Use)
+	}
+}
+
+// TestFlowRetryInlineOverridesNamed verifies attribute-level override: inline
+// non-zero values win over the named base, but unset inline fields inherit
+// from the base.
+func TestFlowRetryInlineOverridesNamed(t *testing.T) {
+	hcl := `
+retry "aggressive" {
+  attempts  = 5
+  delay     = "1s"
+  max_delay = "30s"
+  backoff   = "exponential"
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    retry {
+      use      = "retry.aggressive"
+      attempts = 2
+      backoff  = "linear"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	r := cfg.Flows[0].ErrorHandling.Retry
+
+	// Overridden attributes use the inline value.
+	if r.Attempts != 2 {
+		t.Errorf("attempts: want %d (override), got %d", 2, r.Attempts)
+	}
+	if r.Backoff != "linear" {
+		t.Errorf("backoff: want %q (override), got %q", "linear", r.Backoff)
+	}
+	// Untouched attributes carry over from the base.
+	if r.Delay != "1s" {
+		t.Errorf("delay: want %q (inherit from base), got %q", "1s", r.Delay)
+	}
+	if r.MaxDelay != "30s" {
+		t.Errorf("max_delay: want %q (inherit from base), got %q", "30s", r.MaxDelay)
+	}
+}
+
+// TestFlowRetryUseUnknownNameFails verifies that referencing a non-existent
+// named retry fails at parse time with a helpful message listing the available
+// names — not at runtime when the flow first dispatches.
+func TestFlowRetryUseUnknownNameFails(t *testing.T) {
+	hcl := `
+retry "aggressive" {
+  attempts = 5
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    retry {
+      use = "retry.agressive"
+    }
+  }
+}
+`
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected parse error for unknown retry reference")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "agressive") || !strings.Contains(msg, "aggressive") {
+		t.Errorf("error should mention the typo and list the available name; got: %s", msg)
+	}
+}
+
+// TestInlineRetryWithoutUseStillSelfContained verifies that the existing
+// inline-only behavior (no `use`) is unchanged: an inline retry inside
+// error_handling keeps its fields and has an empty Use.
+func TestInlineRetryWithoutUseStillSelfContained(t *testing.T) {
+	hcl := `
+flow "still_inline" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  error_handling {
+    retry {
+      attempts  = 3
+      delay     = "500ms"
+      backoff   = "constant"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	r := cfg.Flows[0].ErrorHandling.Retry
+	if r.Attempts != 3 || r.Delay != "500ms" || r.Backoff != "constant" {
+		t.Errorf("inline retry lost fields: %+v", r)
+	}
+	if r.Use != "" {
+		t.Errorf("inline-only retry should have empty Use, got %q", r.Use)
+	}
+}
+
+// TestNamedRetryMissingAttemptsFailsClearly verifies that a top-level retry
+// with no positive attempts fails clearly — a named retry that retries nothing
+// is almost certainly a mistake, and we catch it at parse time.
+func TestNamedRetryMissingAttemptsFailsClearly(t *testing.T) {
+	hcl := `
+retry "broken" {
+  delay = "1s"
+}
+`
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected error for named retry without attempts")
+	}
+	if !strings.Contains(err.Error(), "attempts") {
+		t.Errorf("error should mention the missing attempts; got: %s", err.Error())
+	}
+}

--- a/internal/parser/reusable_semaphore_seqguard_test.go
+++ b/internal/parser/reusable_semaphore_seqguard_test.go
@@ -1,0 +1,318 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+// These two kinds were added through the reusableKinds registry alone (no
+// edits to rootSchema / ParseFile / ValidateUniqueNames / ResolveReferences),
+// so the tests double as proof that the table-driven abstraction holds.
+
+// --- semaphore ---
+
+func TestNamedSemaphoreTopLevel(t *testing.T) {
+	hcl := `
+semaphore "external_api" {
+  storage {
+    driver = "memory"
+  }
+  key         = "'external_api'"
+  max_permits = 5
+  timeout     = "30s"
+  lease       = "60s"
+}
+`
+	cfg := mustParse(t, hcl)
+	if len(cfg.NamedSemaphores) != 1 {
+		t.Fatalf("expected 1 named semaphore, got %d", len(cfg.NamedSemaphores))
+	}
+	s := cfg.NamedSemaphores[0]
+	if s.Name != "external_api" || s.Key != "'external_api'" || s.MaxPermits != 5 || s.Timeout != "30s" || s.Lease != "60s" {
+		t.Errorf("named semaphore parsed wrong: %+v", s)
+	}
+}
+
+func TestFlowSemaphoreUseResolvesAndOverrides(t *testing.T) {
+	hcl := `
+semaphore "external_api" {
+  storage {
+    driver = "redis"
+    url    = "redis://base:6379"
+  }
+  key         = "'external_api'"
+  max_permits = 5
+  timeout     = "30s"
+}
+
+flow "resolves" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  semaphore {
+    use = "semaphore.external_api"
+  }
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  semaphore {
+    use         = "semaphore.external_api"
+    max_permits = 10
+    storage {
+      driver = "memory"
+    }
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+
+	resolved := findFlow(t, cfg, "resolves").Semaphore
+	if resolved.MaxPermits != 5 || resolved.Key != "'external_api'" || resolved.Timeout != "30s" {
+		t.Errorf("resolved semaphore should inherit base: %+v", resolved)
+	}
+	if resolved.Storage == nil || resolved.Storage.URL != "redis://base:6379" {
+		t.Errorf("resolved semaphore should inherit base storage: %+v", resolved.Storage)
+	}
+
+	ov := findFlow(t, cfg, "overrides").Semaphore
+	if ov.MaxPermits != 10 {
+		t.Errorf("max_permits override: want 10, got %d", ov.MaxPermits)
+	}
+	// Storage replaced wholesale: base URL must not leak.
+	if ov.Storage == nil || ov.Storage.Driver != "memory" || ov.Storage.URL != "" {
+		t.Errorf("storage should be replaced wholesale: %+v", ov.Storage)
+	}
+}
+
+func TestFlowSemaphoreUnknownNameFails(t *testing.T) {
+	hcl := `
+semaphore "external_api" {
+  storage {
+    driver = "memory"
+  }
+  key         = "'x'"
+  max_permits = 1
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  semaphore {
+    use = "semaphore.external_apii"
+  }
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "external_apii") || !strings.Contains(err.Error(), "external_api") {
+		t.Errorf("expected unknown-name error listing available; got: %v", err)
+	}
+}
+
+func TestNamedSemaphoreMissingMaxPermitsFails(t *testing.T) {
+	hcl := `
+semaphore "broken" {
+  storage {
+    driver = "memory"
+  }
+  key = "'x'"
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "max_permits") {
+		t.Errorf("expected max_permits error; got: %v", err)
+	}
+}
+
+// --- sequence_guard ---
+
+func TestNamedSequenceGuardTopLevel(t *testing.T) {
+	hcl := `
+sequence_guard "sku_seq" {
+  storage {
+    driver = "memory"
+  }
+  key      = "'sku:' + input.sku"
+  sequence = "input.jobId"
+  on_older = "ack"
+  ttl      = "30d"
+}
+`
+	cfg := mustParse(t, hcl)
+	if len(cfg.NamedSequenceGuards) != 1 {
+		t.Fatalf("expected 1 named sequence_guard, got %d", len(cfg.NamedSequenceGuards))
+	}
+	sg := cfg.NamedSequenceGuards[0]
+	if sg.Name != "sku_seq" || sg.Key != "'sku:' + input.sku" || sg.Sequence != "input.jobId" || sg.OnOlder != "ack" || sg.TTL != "30d" {
+		t.Errorf("named sequence_guard parsed wrong: %+v", sg)
+	}
+}
+
+func TestFlowSequenceGuardUseResolvesAndOverrides(t *testing.T) {
+	hcl := `
+sequence_guard "sku_seq" {
+  storage {
+    driver = "redis"
+    url    = "redis://base:6379"
+  }
+  key      = "'sku:' + input.sku"
+  sequence = "input.jobId"
+  on_older = "ack"
+  ttl      = "30d"
+}
+
+flow "resolves" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  sequence_guard {
+    use = "sequence_guard.sku_seq"
+  }
+}
+
+flow "overrides" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  sequence_guard {
+    use      = "sequence_guard.sku_seq"
+    on_older = "reject"
+    ttl      = "7d"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+
+	r := findFlow(t, cfg, "resolves").SequenceGuard
+	if r.Key != "'sku:' + input.sku" || r.Sequence != "input.jobId" || r.OnOlder != "ack" || r.TTL != "30d" {
+		t.Errorf("resolved sequence_guard should inherit base: %+v", r)
+	}
+	if r.Storage == nil || r.Storage.URL != "redis://base:6379" {
+		t.Errorf("resolved sequence_guard should inherit base storage: %+v", r.Storage)
+	}
+
+	ov := findFlow(t, cfg, "overrides").SequenceGuard
+	if ov.OnOlder != "reject" || ov.TTL != "7d" {
+		t.Errorf("override failed: %+v", ov)
+	}
+	// Untouched fields inherit.
+	if ov.Key != "'sku:' + input.sku" || ov.Sequence != "input.jobId" {
+		t.Errorf("untouched fields should inherit base: %+v", ov)
+	}
+}
+
+func TestFlowSequenceGuardUnknownNameFails(t *testing.T) {
+	hcl := `
+sequence_guard "sku_seq" {
+  storage {
+    driver = "memory"
+  }
+  key      = "'x'"
+  sequence = "input.n"
+}
+
+flow "typo" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  sequence_guard {
+    use = "sequence_guard.sku_seqq"
+  }
+}
+`
+	err := parseDirErr(t, hcl)
+	if err == nil || !strings.Contains(err.Error(), "sku_seqq") || !strings.Contains(err.Error(), "sku_seq") {
+		t.Errorf("expected unknown-name error listing available; got: %v", err)
+	}
+}
+
+func TestInlineSequenceGuardWithoutUseStillSelfContained(t *testing.T) {
+	hcl := `
+flow "still_inline" {
+  from {
+    connector = "x"
+    operation = "y"
+  }
+  to {
+    connector = "x"
+    target    = "y"
+  }
+  sequence_guard {
+    storage {
+      driver = "memory"
+    }
+    key      = "'sku:' + input.sku"
+    sequence = "input.jobId"
+  }
+}
+`
+	cfg := mustParseDir(t, hcl)
+	sg := cfg.Flows[0].SequenceGuard
+	if sg.Key == "" || sg.Sequence == "" || sg.Storage == nil {
+		t.Errorf("inline sequence_guard lost fields: %+v", sg)
+	}
+	if sg.Use != "" {
+		t.Errorf("inline-only sequence_guard should have empty Use, got %q", sg.Use)
+	}
+}
+
+// --- helpers ---
+
+func findFlow(t *testing.T, cfg *Configuration, name string) *flow.Config {
+	t.Helper()
+	for _, f := range cfg.Flows {
+		if f.Name == name {
+			return f
+		}
+	}
+	t.Fatalf("flow %q not found", name)
+	return nil
+}
+
+func parseDirErr(t *testing.T, hcl string) error {
+	t.Helper()
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	return err
+}

--- a/internal/parser/transaction.go
+++ b/internal/parser/transaction.go
@@ -14,15 +14,77 @@ import (
 // it iterates the native hclsyntax body's Blocks directly rather than going
 // through a schema, which would not preserve textual order across a
 // heterogeneous exec/each mix.
+//
+// When the block carries `use = "transaction.<name>"` it references a top-level
+// reusable transaction; statements become optional (a reference with no
+// statements pulls in the named base; statements, if present, replace it
+// wholesale — resolved by ResolveReferences).
 func parseTransactionBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.TransactionConfig, error) {
+	return parseTransactionBody(block, ctx, false)
+}
+
+// parseNamedTransactionBlock parses a top-level `transaction "<name>" { ... }`
+// block, registered in Configuration.NamedTransactions and referenced from a
+// `to` block via use = "transaction.<name>".
+func parseNamedTransactionBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.TransactionConfig, error) {
+	if len(block.Labels) < 1 {
+		return nil, fmt.Errorf("transaction block requires a name label when declared at top level")
+	}
+	tx, err := parseTransactionBody(block, ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	tx.Name = block.Labels[0]
+	return tx, nil
+}
+
+// parseTransactionBody is shared by inline and named transaction blocks. Strict
+// (named top-level) requires at least one statement and forbids `use`. Inline
+// blocks require a statement only when they are not a reference.
+func parseTransactionBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow.TransactionConfig, error) {
+	use, err := parseTxUse(block.Body, ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	stmts, err := parseTxStatements(block.Body, ctx)
 	if err != nil {
 		return nil, err
 	}
-	if len(stmts) == 0 {
-		return nil, fmt.Errorf("transaction block must contain at least one exec or each")
+
+	if strict {
+		if use != "" {
+			return nil, fmt.Errorf("top-level transaction %q cannot use `use` — that's for inline references", block.Labels[0])
+		}
+		if len(stmts) == 0 {
+			return nil, fmt.Errorf("top-level transaction %q must contain at least one exec or each", block.Labels[0])
+		}
+	} else if use == "" && len(stmts) == 0 {
+		return nil, fmt.Errorf("transaction block must contain at least one exec or each (or `use` a named one)")
 	}
-	return &flow.TransactionConfig{Statements: stmts}, nil
+
+	tx := &flow.TransactionConfig{Statements: stmts}
+	tx.Use = use
+	return tx, nil
+}
+
+// parseTxUse reads an optional `use` attribute from a transaction body. The
+// body is iterated as native hclsyntax (same as the statements) so the
+// attribute can coexist with the ordered exec/each blocks.
+func parseTxUse(body hcl.Body, ctx *hcl.EvalContext) (string, error) {
+	syntaxBody, ok := body.(*hclsyntax.Body)
+	if !ok {
+		return "", nil
+	}
+	attr, ok := syntaxBody.Attributes["use"]
+	if !ok {
+		return "", nil
+	}
+	val, diags := attr.Expr.Value(ctx)
+	if diags.HasErrors() {
+		return "", fmt.Errorf("transaction use error: %s", diags.Error())
+	}
+	return parseRefName("transaction", val.AsString()), nil
 }
 
 // parseTxStatements reads the ordered exec/each children of a transaction (or

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -121,6 +121,9 @@ func TransactionSchema() Block {
 	return Block{
 		Type: "transaction",
 		Doc:  "Multi-statement, iterative write run atomically in one DB transaction (database connectors only). Mutually exclusive with query/target/operation/envelope.",
+		Attrs: []Attr{
+			{Name: "use", Doc: "Reference a named transaction block (use = \"transaction.<name>\"); inline statements replace it wholesale", Type: TypeString, Ref: RefTransaction},
+		},
 		Children: []Block{
 			TxExecSchema(),
 			TxEachSchema(),
@@ -157,7 +160,8 @@ func AcceptSchema() Block {
 		Type: "accept",
 		Doc:  "Business-level gate after filter, before transform. Determines if this flow should process the message.",
 		Attrs: []Attr{
-			{Name: "when", Doc: "CEL expression — must return true to proceed", Type: TypeString, Required: true},
+			{Name: "use", Doc: "Reference a named accept block (use = \"accept.<name>\"); other attrs override it", Type: TypeString, Ref: RefAccept},
+			{Name: "when", Doc: "CEL expression — must return true to proceed", Type: TypeString},
 			{Name: "on_reject", Doc: "What to do when condition is false", Type: TypeString, Values: []string{"ack", "reject", "requeue"}},
 		},
 	}
@@ -198,6 +202,9 @@ func ResponseBlockSchema() Block {
 		Type: "response",
 		Doc:  "Transform output AFTER destination write. Available variables: input, output.",
 		Open: true, // attributes are CEL field mappings
+		Attrs: []Attr{
+			{Name: "use", Doc: "Reference a named response block (use = \"response.<name>\"); inline field mappings override it key by key", Type: TypeString, Ref: RefResponse},
+		},
 	}
 }
 
@@ -245,7 +252,8 @@ func LockSchema() Block {
 		Type: "lock",
 		Doc:  "Mutex lock for this flow",
 		Attrs: []Attr{
-			{Name: "key", Doc: "CEL expression for the lock key", Type: TypeString, Required: true},
+			{Name: "use", Doc: "Reference a named lock block (use = \"lock.<name>\"); other attrs override it", Type: TypeString, Ref: RefLock},
+			{Name: "key", Doc: "CEL expression for the lock key", Type: TypeString},
 			{Name: "timeout", Doc: "Max time to hold the lock", Type: TypeDuration},
 			{Name: "wait", Doc: "Wait for lock or fail immediately", Type: TypeBool},
 			{Name: "retry", Doc: "Retry interval", Type: TypeDuration},
@@ -261,8 +269,9 @@ func SemaphoreSchema() Block {
 		Type: "semaphore",
 		Doc:  "Concurrency limiter for this flow",
 		Attrs: []Attr{
-			{Name: "key", Doc: "CEL expression for the semaphore key", Type: TypeString, Required: true},
-			{Name: "max_permits", Doc: "Maximum concurrent permits", Type: TypeNumber, Required: true},
+			{Name: "use", Doc: "Reference a named semaphore block (use = \"semaphore.<name>\"); other attrs override it", Type: TypeString, Ref: RefSemaphore},
+			{Name: "key", Doc: "CEL expression for the semaphore key", Type: TypeString},
+			{Name: "max_permits", Doc: "Maximum concurrent permits", Type: TypeNumber},
 			{Name: "timeout", Doc: "Max time to wait for a permit", Type: TypeDuration},
 			{Name: "lease", Doc: "Max time to hold a permit", Type: TypeDuration},
 		},
@@ -277,6 +286,7 @@ func CoordinateSchema() Block {
 		Type: "coordinate",
 		Doc:  "Signal/wait coordination between flows",
 		Attrs: []Attr{
+			{Name: "use", Doc: "Reference a named coordinate block (use = \"coordinate.<name>\"); other attrs override it", Type: TypeString, Ref: RefCoordinate},
 			{Name: "timeout", Doc: "Max time to wait", Type: TypeDuration},
 			{Name: "on_timeout", Doc: "Behavior on timeout", Type: TypeString, Values: []string{"fail", "retry", "skip", "pass"}},
 			{Name: "max_retries", Doc: "Max retries when on_timeout is retry", Type: TypeNumber},
@@ -307,8 +317,9 @@ func SequenceGuardSchema() Block {
 		Type: "sequence_guard",
 		Doc:  "Monotonic sequence dedup — rejects messages whose sequence is not strictly greater than the last one stored for the same key. Compose with lock for atomicity.",
 		Attrs: []Attr{
-			{Name: "key", Doc: "CEL expression for the per-resource key (e.g. 'sku:' + input.body.sku)", Type: TypeString, Required: true},
-			{Name: "sequence", Doc: "CEL expression yielding a monotonic numeric sequence (e.g. input.body.jobId)", Type: TypeString, Required: true},
+			{Name: "use", Doc: "Reference a named sequence_guard block (use = \"sequence_guard.<name>\"); other attrs override it", Type: TypeString, Ref: RefSequenceGuard},
+			{Name: "key", Doc: "CEL expression for the per-resource key (e.g. 'sku:' + input.body.sku)", Type: TypeString},
+			{Name: "sequence", Doc: "CEL expression yielding a monotonic numeric sequence (e.g. input.body.jobId)", Type: TypeString},
 			{Name: "on_older", Doc: "What to do when current sequence is not strictly greater than stored", Type: TypeString, Values: []string{"ack", "reject", "requeue"}},
 			{Name: "ttl", Doc: "How long to retain stored sequences after the last update (e.g. 30d)", Type: TypeDuration},
 		},
@@ -360,8 +371,12 @@ func ErrorHandlingSchema() Block {
 	return Block{
 		Type: "error_handling",
 		Doc:  "Error handling with retry, fallback, and custom responses",
+		Attrs: []Attr{
+			{Name: "use", Doc: "Reference a named error_handling block (use = \"error_handling.<name>\"); sub-blocks override it wholesale", Type: TypeString, Ref: RefErrorHandling},
+		},
 		Children: []Block{
 			{Type: "retry", Doc: "Automatic retry on failure", Attrs: []Attr{
+				{Name: "use", Doc: "Reference a named retry block (use = \"retry.<name>\"); other attrs override it", Type: TypeString, Ref: RefRetry},
 				{Name: "attempts", Doc: "Maximum retry attempts", Type: TypeNumber},
 				{Name: "delay", Doc: "Initial delay between retries", Type: TypeDuration},
 				{Name: "max_delay", Doc: "Maximum delay (exponential backoff cap)", Type: TypeDuration},
@@ -390,8 +405,9 @@ func DedupeSchema() Block {
 		Type: "dedupe",
 		Doc:  "Content-based, biphasic deduplication. Compares a canonical fingerprint of a named projection of the message against the previously-stored fingerprint for the same key; on match, drops without invoking `to`. Stores the new fingerprint only after `to` succeeds.",
 		Attrs: []Attr{
-			{Name: "cache", Doc: "Cache-typed connector used to store fingerprints", Type: TypeString, Required: true, Ref: RefConnector},
-			{Name: "key", Doc: "CEL expression for the per-resource fingerprint key (evaluated against input.*)", Type: TypeString, Required: true},
+			{Name: "use", Doc: "Reference a named dedupe block (use = \"dedupe.<name>\"); other attrs override it", Type: TypeString, Ref: RefDedupe},
+			{Name: "cache", Doc: "Cache-typed connector used to store fingerprints", Type: TypeString, Ref: RefConnector},
+			{Name: "key", Doc: "CEL expression for the per-resource fingerprint key (evaluated against input.*)", Type: TypeString},
 			{Name: "ttl", Doc: "How long to keep stored fingerprints after the last update", Type: TypeDuration},
 			{Name: "on_duplicate", Doc: "Behavior on fingerprint match", Type: TypeString, Values: []string{"ack", "reject", "requeue"}},
 		},

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -32,6 +32,17 @@ const (
 	RefValidator
 	RefFlow
 	RefStateMachine
+	// Reusable inline-block references (v2.6): use = "<kind>.<name>".
+	RefDedupe
+	RefRetry
+	RefLock
+	RefSemaphore
+	RefSequenceGuard
+	RefCoordinate
+	RefTransaction
+	RefErrorHandling
+	RefAccept
+	RefResponse
 )
 
 // Attr describes a single attribute in a block.

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -58,8 +58,16 @@ func TestAcceptSchema(t *testing.T) {
 	if when == nil {
 		t.Fatal("accept missing 'when' attribute")
 	}
-	if !when.Required {
-		t.Error("accept.when should be required")
+	// As of v2.6 `when` is no longer schema-required: a reference form
+	// (use = "accept.<name>") inherits it from the named base. The
+	// parser still enforces `when` for self-contained accept blocks.
+	if when.Required {
+		t.Error("accept.when should not be schema-required (use-references inherit it)")
+	}
+
+	use := accept.GetAttr("use")
+	if use == nil || use.Ref != RefAccept {
+		t.Errorf("accept should expose a 'use' attribute referencing RefAccept, got %+v", use)
 	}
 
 	onReject := accept.GetAttr("on_reject")
@@ -237,6 +245,6 @@ type mockProvider struct {
 	connSchema Block
 }
 
-func (m *mockProvider) ConnectorSchema() Block   { return m.connSchema }
-func (m *mockProvider) SourceSchema() *Block      { return nil }
-func (m *mockProvider) TargetSchema() *Block      { return nil }
+func (m *mockProvider) ConnectorSchema() Block { return m.connSchema }
+func (m *mockProvider) SourceSchema() *Block   { return nil }
+func (m *mockProvider) TargetSchema() *Block   { return nil }

--- a/tests/integration/config/flows/reusable-blocks.mycel
+++ b/tests/integration/config/flows/reusable-blocks.mycel
@@ -1,0 +1,180 @@
+# Flows that consume the reusable named blocks via use = "<kind>.<name>".
+# See reusable/blocks.mycel for the definitions and test-reusable-blocks.sh
+# for the assertions.
+
+# --- dedupe (behavioural: duplicates dropped) ---
+flow "ru_dedupe_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/dedupe"
+  }
+  transform {
+    sku   = "input.sku"
+    price = "input.price"
+  }
+  dedupe {
+    use = "dedupe.ru_dedupe"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-dedupe-target"
+    operation = "POST"
+  }
+}
+
+# --- accept (behavioural: gate by region) ---
+flow "ru_accept_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/accept"
+  }
+  accept {
+    use = "accept.ru_accept"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-accept-target"
+    operation = "POST"
+  }
+}
+
+# --- response (behavioural: caller body shaped by named response) ---
+flow "ru_response_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/response"
+  }
+  response {
+    use = "response.ru_response"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-response-target"
+    operation = "POST"
+  }
+}
+
+# --- sequence_guard (behavioural: older sequence dropped) ---
+flow "ru_seq_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/seq"
+  }
+  sequence_guard {
+    use = "sequence_guard.ru_seq"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-seq-target"
+    operation = "POST"
+  }
+}
+
+# --- transaction (behavioural: row inserted via mysql) ---
+# Transactions are supported on mysql/sqlite (not postgres), so this writes to
+# the mysql connector.
+flow "ru_tx_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/tx"
+  }
+  to {
+    connector = "mysql"
+    transaction {
+      use = "transaction.ru_tx"
+    }
+  }
+}
+
+flow "ru_tx_read" {
+  from {
+    connector = "api"
+    operation = "GET /test/ru/tx/results"
+  }
+  to {
+    connector = "mysql"
+    target    = "ru_tx_results"
+  }
+}
+
+# --- error_handling (resolution + execution; nested retry.use) ---
+flow "ru_eh_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/eh"
+  }
+  error_handling {
+    use = "error_handling.ru_eh"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-eh-target"
+    operation = "POST"
+  }
+}
+
+# --- retry (direct reuse inside an inline error_handling) ---
+flow "ru_retry_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/retry"
+  }
+  error_handling {
+    retry {
+      use = "retry.ru_retry"
+    }
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-retry-target"
+    operation = "POST"
+  }
+}
+
+# --- lock (resolution + execution) ---
+flow "ru_lock_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/lock"
+  }
+  lock {
+    use = "lock.ru_lock"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-lock-target"
+    operation = "POST"
+  }
+}
+
+# --- semaphore (resolution + execution) ---
+flow "ru_sem_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/sem"
+  }
+  semaphore {
+    use = "semaphore.ru_sem"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-sem-target"
+    operation = "POST"
+  }
+}
+
+# --- coordinate (resolution + execution; signal-only) ---
+flow "ru_coord_flow" {
+  from {
+    connector = "api"
+    operation = "POST /test/ru/coord"
+  }
+  coordinate {
+    use = "coordinate.ru_coord"
+  }
+  to {
+    connector = "external_api"
+    target    = "/ru-coord-target"
+    operation = "POST"
+  }
+}

--- a/tests/integration/config/reusable/blocks.mycel
+++ b/tests/integration/config/reusable/blocks.mycel
@@ -1,0 +1,97 @@
+# Reusable inline blocks — one named definition per kind (v2.6.0).
+#
+# Each block here is referenced from a flow in flows/reusable-blocks.mycel via
+# use = "<kind>.<name>". Because the parser resolves every reference at config
+# load, the integration container simply STARTING with this file proves that
+# all ten kinds resolve end-to-end in the real binary; the bash test then
+# asserts the runtime behaviour for the cleanly-observable ones.
+
+# --- Category A (flat) ---
+
+dedupe "ru_dedupe" {
+  cache        = "dedupe_cache"
+  key          = "'ru:' + input.sku"
+  ttl          = "30d"
+  on_duplicate = "ack"
+  fingerprint {
+    sku   = "output.sku"
+    price = "output.price"
+  }
+}
+
+retry "ru_retry" {
+  attempts = 3
+  delay    = "100ms"
+  backoff  = "constant"
+}
+
+lock "ru_lock" {
+  storage {
+    driver = "memory"
+  }
+  key     = "'ru-lock:' + input.id"
+  timeout = "5s"
+}
+
+semaphore "ru_sem" {
+  storage {
+    driver = "memory"
+  }
+  key         = "'ru-sem'"
+  max_permits = 2
+  timeout     = "5s"
+}
+
+sequence_guard "ru_seq" {
+  storage {
+    driver = "memory"
+  }
+  key      = "'ru-seq:' + input.id"
+  sequence = "input.seq"
+  on_older = "ack"
+}
+
+# --- Category B (sub-blocks) ---
+
+coordinate "ru_coord" {
+  storage {
+    driver = "memory"
+  }
+  timeout = "2s"
+  signal {
+    when = "true"
+    emit = "'ru:' + input.id + ':done'"
+    ttl  = "30s"
+  }
+}
+
+transaction "ru_tx" {
+  exec {
+    query  = "INSERT INTO ru_tx_results (name) VALUES (:name)"
+    params = { name = "input.name" }
+  }
+}
+
+# error_handling whose retry itself references a named retry — proves the
+# nested-reference ordering (error_handling resolves before retry) in the
+# real binary.
+error_handling "ru_eh" {
+  retry {
+    use = "retry.ru_retry"
+  }
+  on_timeout {
+    action = "ack"
+  }
+}
+
+# --- Category C (mapping) ---
+
+accept "ru_accept" {
+  when      = "input.region == 'us-east'"
+  on_reject = "ack"
+}
+
+response "ru_response" {
+  ok     = "true"
+  source = "'reusable'"
+}

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -155,6 +155,7 @@ else
     scripts/test-new-features.sh
     scripts/test-fanout.sh
     scripts/test-dedupe.sh
+    scripts/test-reusable-blocks.sh
   )
 fi
 
@@ -225,7 +226,7 @@ else
       rate-limit)
         SOLO_FILES+=("$test_file")
         ;;
-      http-client|notifications|dedupe)
+      http-client|notifications|dedupe|reusable-blocks)
         MOCK_FILES+=("$test_file")
         ;;
       *)

--- a/tests/integration/scripts/test-reusable-blocks.sh
+++ b/tests/integration/scripts/test-reusable-blocks.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Test: reusable inline blocks (v2.6.0) end-to-end through the real binary.
+#
+# The integration container loads reusable/blocks.mycel (one named block per
+# kind) and flows/reusable-blocks.mycel (flows referencing them via use=).
+# Because the parser resolves every `use` at config load, the container being
+# up at all already proves all ten references resolve in the real binary. This
+# script then asserts the runtime BEHAVIOUR for the cleanly-observable kinds
+# (dedupe / accept / response / sequence_guard / transaction) and that the
+# remaining kinds (retry / error_handling / lock / semaphore / coordinate)
+# actually execute the flow that reuses them.
+#
+# This suite is registered in run.sh's sequential "mock" phase (alongside
+# dedupe / notifications / http-client) so it never runs concurrently with
+# another suite that calls the global mock_clear. Each flow also writes to a
+# UNIQUE mock path and mock_requests filters by path, so the per-path counts
+# are doubly robust.
+source "$(dirname "$0")/lib.sh"
+
+echo "=== Reusable inline blocks (use = \"<kind>.<name>\") ==="
+
+# Clean baseline — safe here because this suite runs in the sequential phase.
+mock_clear
+
+# --- dedupe: named dedupe drops duplicate content -------------------------
+# Two identical POSTs + one with a changed price → mock should see 2 (the
+# second of the identical pair is deduped; the price change is a new
+# fingerprint).
+http_status POST "$BASE/test/ru/dedupe" '{"sku":"Z","price":1}' > /dev/null
+http_status POST "$BASE/test/ru/dedupe" '{"sku":"Z","price":1}' > /dev/null
+http_status POST "$BASE/test/ru/dedupe" '{"sku":"Z","price":2}' > /dev/null
+sleep 1
+n=$(mock_requests "/ru-dedupe-target" | jq 'length' 2>/dev/null)
+assert_status "dedupe reuse: 2 of 3 reach downstream (duplicate dropped)" "2" "$n"
+
+# --- accept: named gate lets us-east through, drops eu-west ---------------
+http_status POST "$BASE/test/ru/accept" '{"region":"us-east"}' > /dev/null
+http_status POST "$BASE/test/ru/accept" '{"region":"eu-west"}' > /dev/null
+sleep 1
+n=$(mock_requests "/ru-accept-target" | jq 'length' 2>/dev/null)
+assert_status "accept reuse: only the accepted region reaches downstream" "1" "$n"
+
+# --- response: caller body is shaped by the named response mapping --------
+body=$(http_body POST "$BASE/test/ru/response" '{"anything":1}')
+assert_contains "response reuse: caller body carries named mapping (source)" "reusable" "$body"
+assert_contains "response reuse: caller body carries named mapping (ok)" '"ok"' "$body"
+
+# --- sequence_guard: the reused guard is wired and the flow executes ------
+# Resolution + execution proof (like lock/semaphore/coordinate below): a POST
+# through a flow that reuses the named sequence_guard returns 200, so the named
+# block resolved and the runtime accepted the merged config. (A value-ordering
+# behavioural assertion is intentionally omitted here — sequence value CEL
+# resolution over a plain REST source is a separate sync-eval concern,
+# orthogonal to whether the block is reused.)
+status=$(http_status POST "$BASE/test/ru/seq" '{"id":"a","seq":5}')
+assert_status "sequence_guard reuse: flow returns 200" "200" "$status"
+
+# --- transaction: named transaction inserts a row via mysql ---------------
+status=$(http_status POST "$BASE/test/ru/tx" '{"name":"alpha"}')
+assert_status "transaction reuse: POST runs the named transaction (200)" "200" "$status"
+sleep 1
+rows=$(http_body GET "$BASE/test/ru/tx/results")
+assert_contains "transaction reuse: row was inserted by the named transaction" "alpha" "$rows"
+
+# --- error_handling (with nested retry.use): flow executes ----------------
+status=$(http_status POST "$BASE/test/ru/eh" '{"id":"e1"}')
+assert_status "error_handling reuse (+ nested retry.use): flow returns 200" "200" "$status"
+sleep 1
+n=$(mock_requests "/ru-eh-target" | jq 'length' 2>/dev/null)
+assert_status "error_handling reuse: downstream reached once" "1" "$n"
+
+# --- retry (direct reuse inside inline error_handling): flow executes -----
+status=$(http_status POST "$BASE/test/ru/retry" '{"id":"r1"}')
+assert_status "retry reuse: flow returns 200" "200" "$status"
+
+# --- lock: flow executes under the reused lock ----------------------------
+status=$(http_status POST "$BASE/test/ru/lock" '{"id":"l1"}')
+assert_status "lock reuse: flow returns 200" "200" "$status"
+
+# --- semaphore: flow executes under the reused semaphore ------------------
+status=$(http_status POST "$BASE/test/ru/sem" '{"id":"s1"}')
+assert_status "semaphore reuse: flow returns 200" "200" "$status"
+
+# --- coordinate: signal-only flow executes under the reused coordinator ---
+status=$(http_status POST "$BASE/test/ru/coord" '{"id":"c1"}')
+assert_status "coordinate reuse: flow returns 200" "200" "$status"
+
+report

--- a/tests/integration/seed/mysql-init.sql
+++ b/tests/integration/seed/mysql-init.sql
@@ -5,3 +5,12 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Target for the reusable-blocks transaction test (use = "transaction.ru_tx").
+-- Transactions are supported on mysql/sqlite (not postgres), so the test
+-- writes here.
+CREATE TABLE IF NOT EXISTS ru_tx_results (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## What

Makes every inline block nameable + referenceable, the same way `transform` and `cache` already were. Declare a block **once** at the top level with a name, then reference it from any flow with `use = "<kind>.<name>"`, with optional attribute-level overrides.

Framed in the docs as the **recommended** way to write configs — named vs anonymous blocks, like named vs anonymous functions. Inline stays fine for genuine one-offs.

```hcl
dedupe "standard" {
  cache = "fingerprints"
  key   = "'item:' + input.id"
  ttl   = "30d"
  fingerprint { id = "output.id"  price = "output.price" }
}

flow "ingest_orders" {
  dedupe {
    use = "dedupe.standard"
    key = "'order:' + input.id"   # override just the key; cache/ttl/fingerprint inherited
  }
}
```

## Scope — all ten inline blocks

| Category | Kinds |
|---|---|
| Flat | `dedupe`, `retry`, `lock`, `semaphore`, `sequence_guard` |
| Sub-block | `coordinate`, `transaction`, `error_handling` |
| Mapping | `accept`, `response` |

`error_response` / `on_timeout` / `on_error` are intentionally **not** independently nameable — an `error_handling` holds a single one of each, so reusing the whole named `error_handling` already covers them.

## Merge rules

- **Scalars** override when set; otherwise inherit the base.
- **Maps** (dedupe `fingerprint`, `response` mappings) merge key by key.
- **Sub-blocks** (lock `storage`, error_handling `retry`, …) are replaced wholesale (no deep merge).
- A named `error_handling` may itself reference a named `retry` (resolved outer-first).

## Implementation

- A table-driven `reusableKinds` registry (`internal/parser/reusable.go`) drives the top-level parse dispatch, name-uniqueness validation, and reference resolution — each kind contributes only its parse/merge functions. Built incrementally: dedupe → retry → lock proved the pattern, then refactored to the registry, then semaphore/sequence_guard/coordinate/transaction/error_handling/accept/response added through it.
- References are folded into self-contained blocks by a new `ResolveReferences` pass at **parse time**. **The runtime is unchanged** — `Config.Dedupe` etc. are always complete by the time a flow registers. A `use` pointing at a missing name fails `mycel validate` with the list of available names, never at runtime.
- `pkg/schema`: `use` attribute on every reusable block schema (IDE autocomplete) + new `RefKind` constants (go-to-definition).

## Backward compatibility

Strictly additive. Every existing inline block (written without `use`) behaves exactly as before. Names live in a per-kind namespace. Version bumped 2.5.0 → **2.6.0** (minor).

## Testing

- Unit: ~60 new parser tests (6+ per kind: top-level naming, full reference resolution, attribute/sub-block override, typo error, inline self-containment). `go test ./...` + `go vet` green.
- Examples: new runnable `examples/reusable-blocks/`; all 57 example configs validate.
- **Integration: 146 passed / 0 failed.** New `test-reusable-blocks.sh` proves reuse of all ten kinds end-to-end in the real binary — behavioural for dedupe / accept / response / transaction; resolution+execution for sequence_guard / error_handling (incl. nested `retry.use`) / retry / lock / semaphore / coordinate. No regressions to existing suites.

## Docs

`docs/core-concepts/reusable-blocks.md` (full matrix + merge semantics + when-to-name guidance), README entry, CHANGELOG v2.6.0.

## Note

`sequence_guard` value-ordering is asserted only as resolution+execution in integration: `evaluateSyncKey`/`evaluateSyncSequence` resolve against a nil transformer on a plain REST source (key stays literal, sequence → 0). Pre-existing and orthogonal to reuse — flagged for a separate look.