### PR TITLE
chore: add GitHub Sponsors funding option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,5 @@
 # GitHub Funding configuration.
 # Surfaces a "Sponsor" button on the repo page and an entry in the right
 # sidebar. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: matutetandil
 buy_me_a_coffee: matutetandil

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Variants and integration patterns beyond the individual features above:
 
 If you find this project useful, consider supporting its development:
 
+<a href="https://github.com/sponsors/matutetandil" target="_blank"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-db61a2?logo=githubsponsors&logoColor=white&style=for-the-badge" alt="GitHub Sponsors" height="42"></a>
+&nbsp;
 <a href="https://buymeacoffee.com/matutetandil" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="200"></a>
 
 ## Contributing


### PR DESCRIPTION
## Summary
- Add `github: matutetandil` to `.github/FUNDING.yml` so the repo shows the **Sponsor** button and a sidebar entry.
- Add a GitHub Sponsors badge in the README Support section, next to the existing Buy Me A Coffee button.

## Notes
- Doc/config only — no code changes.
- The Sponsor button appears once the GitHub Sponsors profile is active and published.