### PR TITLE
docs(examples): refresh stale examples to match implemented features

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -23,7 +23,7 @@ auth {
   }
 
   users {
-    connector = connector.postgres
+    connector = "postgres"
     table     = "users"
   }
 }
@@ -239,7 +239,7 @@ oidc "auth0" {
 
 ```hcl
 users {
-  connector = connector.postgres
+  connector = "postgres"
   table     = "users"
 
   # Field mappings (if different from defaults)
@@ -276,7 +276,7 @@ storage {
 ```hcl
 audit {
   enabled   = true
-  connector = connector.postgres
+  connector = "postgres"
   table     = "auth_audit_log"
   events    = [
     "login",

--- a/examples/aspects/README.md
+++ b/examples/aspects/README.md
@@ -56,10 +56,10 @@ sqlite3 audit_logs.db "SELECT * FROM audit_logs"
 
 ## Files
 
-- `config.hcl` - Service configuration
-- `connectors.hcl` - Database and cache connectors
-- `flows.hcl` - API flows (CRUD operations)
-- `aspects.hcl` - Cross-cutting concerns
+- `config.mycel` - Service configuration
+- `connectors.mycel` - Database and cache connectors
+- `flows.mycel` - API flows (CRUD operations)
+- `aspects.mycel` - Cross-cutting concerns
 
 ## Aspect Configuration Reference
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -261,7 +261,7 @@ CREATE INDEX idx_linked_provider ON linked_accounts(provider, provider_id);
 
 ### Enterprise OIDC (Okta, Azure AD, Auth0)
 
-Configure your identity provider and add to config.hcl:
+Configure your identity provider and add to config.mycel:
 
 ```hcl
 oidc "okta" {

--- a/examples/auth/config.mycel
+++ b/examples/auth/config.mycel
@@ -1,13 +1,16 @@
 # Authentication Service Example
-# This example demonstrates a complete authentication microservice using Mycel
-# NOTE: The auth block is a planned feature - this is a reference implementation
+#
+# A complete authentication microservice defined entirely in HCL — no code.
+# It exposes register/login/refresh/logout, password hashing (argon2id),
+# brute-force protection, sessions, MFA (TOTP + WebAuthn) and optional
+# social login. See README.md for the full endpoint list and curl examples.
 
 service {
   name    = "auth-service"
   version = "1.0.0"
 }
 
-# Database for user storage
+# Database for user storage and audit log
 connector "postgres" {
   type     = "database"
   driver   = "postgres"
@@ -18,7 +21,7 @@ connector "postgres" {
   password = env("DB_PASSWORD", "postgres")
 }
 
-# REST API connector (exposes auth endpoints)
+# REST API connector — the auth endpoints are mounted here
 connector "api" {
   type = "rest"
   port = 8080
@@ -30,24 +33,110 @@ connector "api" {
   }
 }
 
-# NOTE: The auth block below is a planned feature (Phase 5.1)
-# It is commented out until full implementation is complete
+# Authentication system.
 #
-# auth {
-#   preset = "standard"
-#
-#   users {
-#     connector = "postgres"
-#     table     = "users"
-#   }
-#
-#   jwt {
-#     secret           = env("JWT_SECRET", "change-this-in-production")
-#     access_lifetime  = "1h"
-#     refresh_lifetime = "7d"
-#   }
-#
-#   endpoints {
-#     prefix = "/auth"
-#   }
-# }
+# `preset` picks a security baseline (strict | standard | relaxed | development);
+# every block below overrides only the parts you care about. Anything omitted
+# falls back to the preset's defaults.
+auth {
+  preset = "standard"
+
+  # Where users (and the audit log) live. Omit this block to use the
+  # built-in in-memory stores, handy for local experimentation.
+  users {
+    connector = "postgres"
+    table     = "users"
+  }
+
+  # JWT signing. Use a strong secret in production (env, not a literal).
+  jwt {
+    secret           = env("JWT_SECRET", "change-this-in-production")
+    algorithm        = "HS256"
+    access_lifetime  = "1h"
+    refresh_lifetime = "7d"
+    issuer           = "auth-service"
+    rotation         = true
+  }
+
+  # Password policy. Hashing is always argon2id.
+  password {
+    min_length     = 8
+    require_upper  = true
+    require_lower  = true
+    require_number = true
+    history        = 5
+  }
+
+  # Multi-factor authentication. Optional for users under the `standard`
+  # preset; set `required = "true"` to force enrolment.
+  mfa {
+    required = "optional"
+    methods  = ["totp", "webauthn"]
+
+    totp {
+      issuer = "auth-service"
+      digits = 6
+      period = 30
+    }
+
+    webauthn {
+      rp_name = "Auth Service"
+      rp_id   = "localhost"
+      origins = ["http://localhost:8080"]
+    }
+
+    recovery {
+      enabled    = true
+      code_count = 10
+    }
+  }
+
+  # Account protection.
+  security {
+    brute_force {
+      enabled      = true
+      max_attempts = 5
+      window       = "15m"
+      lockout_time = "30m"
+      track_by     = "ip+user"
+    }
+
+    replay_protection {
+      enabled = true
+      window  = "5m"
+    }
+  }
+
+  # Session lifetimes.
+  sessions {
+    idle_timeout     = "30m"
+    absolute_timeout = "24h"
+  }
+
+  # Optional social login. Providers stay inert until their client
+  # credentials are supplied via environment variables.
+  social {
+    google {
+      client_id     = env("GOOGLE_CLIENT_ID", "")
+      client_secret = env("GOOGLE_CLIENT_SECRET", "")
+      scopes        = ["openid", "email", "profile"]
+    }
+
+    github {
+      client_id     = env("GITHUB_CLIENT_ID", "")
+      client_secret = env("GITHUB_CLIENT_SECRET", "")
+      scopes        = ["user:email"]
+    }
+  }
+
+  # Persist authentication events for auditing.
+  audit {
+    enabled   = true
+    connector = "postgres"
+  }
+
+  # All endpoints are served under this prefix (e.g. POST /auth/login).
+  endpoints {
+    prefix = "/auth"
+  }
+}

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -85,14 +85,14 @@ Expected response (validation error):
 
 ```
 basic/
-├── config.hcl              # Service name and version
+├── config.mycel              # Service name and version
 ├── connectors/
-│   ├── api.hcl             # REST API configuration
-│   └── database.hcl        # SQLite database connection
+│   ├── api.mycel             # REST API configuration
+│   └── database.mycel        # SQLite database connection
 ├── flows/
-│   └── users.hcl           # User CRUD operations
+│   └── users.mycel           # User CRUD operations
 ├── types/
-│   └── user.hcl            # User input validation schema
+│   └── user.mycel            # User input validation schema
 ├── data/
 │   └── app.db              # SQLite database file (created automatically)
 └── setup.sql               # Initial database schema
@@ -100,7 +100,7 @@ basic/
 
 ## Configuration Explained
 
-### Service (`config.hcl`)
+### Service (`config.mycel`)
 
 ```hcl
 service {
@@ -109,7 +109,7 @@ service {
 }
 ```
 
-### REST API (`connectors/api.hcl`)
+### REST API (`connectors/api.mycel`)
 
 ```hcl
 connector "api" {
@@ -123,7 +123,7 @@ connector "api" {
 }
 ```
 
-### Database (`connectors/database.hcl`)
+### Database (`connectors/database.mycel`)
 
 ```hcl
 connector "sqlite" {
@@ -133,7 +133,7 @@ connector "sqlite" {
 }
 ```
 
-### Flows (`flows/users.hcl`)
+### Flows (`flows/users.mycel`)
 
 ```hcl
 # GET /users - List all users
@@ -191,7 +191,7 @@ mkdir -p examples/basic/data
 
 ### "Port 3000 already in use"
 
-Another service is using port 3000. Either stop it or change the port in `connectors/api.hcl`:
+Another service is using port 3000. Either stop it or change the port in `connectors/api.mycel`:
 
 ```hcl
 connector "api" {

--- a/examples/cache/README.md
+++ b/examples/cache/README.md
@@ -16,10 +16,10 @@ This example demonstrates caching with Mycel using both in-memory and Redis cach
 
 | File | Description |
 |------|-------------|
-| `config.hcl` | Service configuration |
-| `connectors.hcl` | REST API, SQLite, and Cache connectors |
-| `caches.hcl` | Named cache definitions (reusable) |
-| `flows.hcl` | Flow definitions with various caching patterns |
+| `config.mycel` | Service configuration |
+| `connectors.mycel` | REST API, SQLite, and Cache connectors |
+| `caches.mycel` | Named cache definitions (reusable) |
+| `flows.mycel` | Flow definitions with various caching patterns |
 
 ## Quick Start
 
@@ -60,14 +60,14 @@ flow "get_product" {
 Define once, use everywhere:
 
 ```hcl
-# In caches.hcl
+# In caches.mycel
 cache "products" {
   storage = "memory_cache"
   ttl     = "10m"
   prefix  = "products"
 }
 
-# In flows.hcl
+# In flows.mycel
 flow "get_product" {
   from { ... }
   to   { ... }
@@ -156,7 +156,7 @@ cache {
 
 For production deployments, use Redis for distributed caching:
 
-1. Uncomment the Redis connector in `connectors.hcl`:
+1. Uncomment the Redis connector in `connectors.mycel`:
 
 ```hcl
 connector "redis_cache" {

--- a/examples/enrich/README.md
+++ b/examples/enrich/README.md
@@ -12,10 +12,10 @@ Data enrichment allows you to:
 
 ## Files
 
-- `config.hcl` - Service configuration
-- `connectors.hcl` - Connector definitions (REST API, database, external services)
-- `flows.hcl` - Flow definitions with enrichments
-- `transforms.hcl` - Reusable transforms with built-in enrichments
+- `config.mycel` - Service configuration
+- `connectors.mycel` - Connector definitions (REST API, database, external services)
+- `flows.mycel` - Flow definitions with enrichments
+- `transforms.mycel` - Reusable transforms that read enriched data
 
 ## How It Works
 
@@ -89,19 +89,15 @@ flow "get_product_full" {
 }
 ```
 
-### Reusable Transforms with Enrichment
+### Reusable Transforms over Enriched Data
 
-Put enrichments inside named transforms to reuse them:
+`enrich` blocks live in the flow. A named transform stays a pure set of
+field mappings, but it can read whatever the flow enriched through the
+`enriched.*` namespace — so the mapping logic is reusable across flows:
 
 ```hcl
-# transforms.hcl
+# transforms.mycel
 transform "with_pricing" {
-  enrich "pricing" {
-    connector = "pricing_service"
-    operation = "getPrice"
-    params { product_id = "input.id" }
-  }
-
   id       = "input.id"
   name     = "input.name"
   price    = "enriched.pricing.price"
@@ -109,11 +105,17 @@ transform "with_pricing" {
 }
 ```
 
-Then use in any flow:
+Pair it with a flow-level `enrich` block that produces `enriched.pricing`:
 
 ```hcl
 flow "get_product" {
   from { ... }
+
+  enrich "pricing" {
+    connector = "pricing_service"
+    operation = "getPrice"
+    params { product_id = "input.id" }
+  }
 
   transform {
     use = "transform.with_pricing"

--- a/examples/enrich/flows.mycel
+++ b/examples/enrich/flows.mycel
@@ -1,7 +1,6 @@
 # Flow configurations
-# NOTE: enrich blocks are a planned feature (not yet implemented)
 
-# Example: Get product
+# Plain flow, no enrichment
 flow "get_product" {
   from {
     connector = "api"
@@ -19,17 +18,92 @@ flow "get_product" {
   }
 }
 
-# Example: Get product with transform
-flow "get_product_with_transform" {
+# Flow-level enrichment: fetch the price from an external pricing
+# microservice and expose it through `enriched.pricing` in the transform.
+flow "get_product_with_price" {
+  from {
+    connector = "api"
+    operation = "GET /products/:id/price"
+  }
+
+  enrich "pricing" {
+    connector = "pricing_service"
+    operation = "getPrice"
+    params {
+      product_id = "input.id"
+    }
+  }
+
+  transform {
+    id       = "input.id"
+    name     = "input.name"
+    price    = "enriched.pricing.price"
+    currency = "enriched.pricing.currency"
+  }
+
+  to {
+    connector = "products_db"
+    operation = "products"
+  }
+}
+
+# Multiple enrichments from independent services in a single flow.
+flow "get_product_full" {
+  from {
+    connector = "api"
+    operation = "GET /products/:id/full"
+  }
+
+  enrich "pricing" {
+    connector = "pricing_service"
+    operation = "getPrice"
+    params {
+      product_id = "input.id"
+    }
+  }
+
+  enrich "inventory" {
+    connector = "inventory_service"
+    operation = "GET /stock"
+    params {
+      sku = "input.sku"
+    }
+  }
+
+  transform {
+    id              = "input.id"
+    name            = "input.name"
+    price           = "enriched.pricing.price"
+    stock_available = "enriched.inventory.available"
+    in_stock        = "enriched.inventory.available > 0"
+  }
+
+  to {
+    connector = "products_db"
+    operation = "products"
+  }
+}
+
+# Flow-level enrich paired with a reusable named transform that reads the
+# enriched data (see `transform "with_pricing"` in transforms.mycel).
+flow "get_product_reusable" {
   from {
     connector = "api"
     operation = "GET /products/:id/v2"
   }
 
-  transform {
-    use = "transform.normalize_product"
+  enrich "pricing" {
+    connector = "pricing_service"
+    operation = "getPrice"
+    params {
+      product_id = "input.id"
+    }
+  }
 
-    # Additional inline mappings
+  transform {
+    use = "transform.with_pricing"
+
+    # Additional inline mappings merge on top of the reusable transform
     fetched_at = "now()"
   }
 

--- a/examples/enrich/transforms.mycel
+++ b/examples/enrich/transforms.mycel
@@ -1,11 +1,23 @@
 # Reusable transforms
-# NOTE: enrich blocks are a planned feature (not yet implemented)
+#
+# Note: named (top-level) transforms hold field mappings only. Enrichment
+# lives in the flow itself via `enrich` blocks (see flows.mycel) — a named
+# transform then reads the results through the `enriched.*` namespace.
 
 # Simple transform without enrichment
 transform "normalize_product" {
   id       = "input.id"
   name     = "upper(input.name)"
   sku      = "input.sku"
+}
+
+# Transform that reads enriched data produced by a flow-level enrich block.
+# Pair it with `enrich "pricing" { ... }` in the flow that uses it.
+transform "with_pricing" {
+  id       = "input.id"
+  name     = "input.name"
+  price    = "enriched.pricing.price"
+  currency = "enriched.pricing.currency"
 }
 
 # Transform with calculated fields

--- a/examples/error-handling/README.md
+++ b/examples/error-handling/README.md
@@ -28,7 +28,7 @@ docker run \
 
 ## Error Handling Layers
 
-### 1. Retry with Exponential Backoff + DLQ (`flows/retry.hcl`)
+### 1. Retry with Exponential Backoff + DLQ (`flows/retry.mycel`)
 
 ```hcl
 error_handling {
@@ -49,7 +49,7 @@ error_handling {
 
 If `POST /orders` fails, Mycel retries 5 times (1s, 2s, 4s, 8s, 16s capped at 30s). After exhaustion, the message goes to RabbitMQ `dead_letters` exchange with the original payload and error details.
 
-### 2. Custom Error Responses (`flows/custom_errors.hcl`)
+### 2. Custom Error Responses (`flows/custom_errors.mycel`)
 
 ```hcl
 error_handling {
@@ -66,7 +66,7 @@ error_handling {
 
 Returns structured error responses with specific HTTP status codes instead of generic 500 errors.
 
-### 3. Step-Level Error Handling (`flows/skip_steps.hcl`)
+### 3. Step-Level Error Handling (`flows/skip_steps.mycel`)
 
 ```hcl
 step "customer" {
@@ -87,7 +87,7 @@ step "shipping" {
 
 Three modes: `fail` (abort flow), `skip` (continue without data), `default` (use fallback values).
 
-### 4. Circuit Breaker (`aspects/circuit_breaker.hcl`)
+### 4. Circuit Breaker (`aspects/circuit_breaker.mycel`)
 
 ```hcl
 aspect "db_circuit_breaker" {
@@ -104,7 +104,7 @@ aspect "db_circuit_breaker" {
 
 After 5 consecutive failures, the circuit opens and requests fail fast for 30s. After timeout, allows 1 request through; if it succeeds 2 times, the circuit closes.
 
-### 5. Rate Limiting (`config.hcl`)
+### 5. Rate Limiting (`config.mycel`)
 
 ```hcl
 service {
@@ -123,19 +123,19 @@ Token bucket rate limiting per client IP. Returns `429 Too Many Requests` with `
 
 ```
 error-handling/
-├── config.hcl                     # Service config with rate limiting
+├── config.mycel                     # Service config with rate limiting
 ├── connectors/
-│   ├── api.hcl                    # REST API on port 3000
-│   ├── database.hcl               # PostgreSQL connection
-│   └── queue.hcl                  # RabbitMQ for DLQ
+│   ├── api.mycel                    # REST API on port 3000
+│   ├── database.mycel               # PostgreSQL connection
+│   └── queue.mycel                  # RabbitMQ for DLQ
 ├── flows/
-│   ├── retry.hcl                  # Retry + backoff + DLQ
-│   ├── custom_errors.hcl          # Custom HTTP error responses
-│   └── skip_steps.hcl             # Step-level skip/default
+│   ├── retry.mycel                  # Retry + backoff + DLQ
+│   ├── custom_errors.mycel          # Custom HTTP error responses
+│   └── skip_steps.mycel             # Step-level skip/default
 ├── types/
-│   └── order.hcl                  # Order validation schema
+│   └── order.mycel                  # Order validation schema
 ├── aspects/
-│   └── circuit_breaker.hcl        # Circuit breaker for all flows
+│   └── circuit_breaker.mycel        # Circuit breaker for all flows
 └── README.md
 ```
 

--- a/examples/files/README.md
+++ b/examples/files/README.md
@@ -11,8 +11,8 @@ This example demonstrates local file system operations.
 
 ## Files
 
-- `config.hcl` - Connectors configuration
-- `flows.hcl` - File operation flows
+- `config.mycel` - Connectors configuration
+- `flows.mycel` - File operation flows
 
 ## Usage
 

--- a/examples/format/README.md
+++ b/examples/format/README.md
@@ -139,15 +139,15 @@ Expected response (JSON, enriched with legacy XML data):
 
 ```
 format/
-├── config.hcl              # Service name and version
+├── config.mycel              # Service name and version
 ├── connectors/
-│   ├── api.hcl             # REST API (default JSON)
-│   ├── database.hcl        # SQLite database
-│   └── soap_api.hcl        # External SOAP client (format = "xml")
+│   ├── api.mycel             # REST API (default JSON)
+│   ├── database.mycel        # SQLite database
+│   └── soap_api.mycel        # External SOAP client (format = "xml")
 ├── flows/
-│   ├── json_crud.hcl       # Standard JSON CRUD
-│   ├── xml_endpoint.hcl    # XML endpoints (flow-level format)
-│   └── mixed_format.hcl    # JSON + XML in one flow (step-level format)
+│   ├── json_crud.mycel       # Standard JSON CRUD
+│   ├── xml_endpoint.mycel    # XML endpoints (flow-level format)
+│   └── mixed_format.mycel    # JSON + XML in one flow (step-level format)
 └── README.md
 ```
 

--- a/examples/graphql-federation/README.md
+++ b/examples/graphql-federation/README.md
@@ -6,10 +6,10 @@ This example demonstrates a federated GraphQL subgraph built with Mycel. It show
 
 ```
 graphql-federation/
-├── config.hcl          # Service configuration (product-subgraph)
-├── connectors.hcl      # GraphQL server (federation + subscriptions), SQLite, RabbitMQ
-├── types.hcl           # Product and Review types with federation directives
-├── flows.hcl           # Queries, mutations, entity resolvers, subscriptions
+├── config.mycel          # Service configuration (product-subgraph)
+├── connectors.mycel      # GraphQL server (federation + subscriptions), SQLite, RabbitMQ
+├── types.mycel           # Product and Review types with federation directives
+├── flows.mycel           # Queries, mutations, entity resolvers, subscriptions
 └── README.md           # This file
 ```
 

--- a/examples/graphql-optimization/README.md
+++ b/examples/graphql-optimization/README.md
@@ -282,10 +282,10 @@ For each GraphQL request:
 
 ```
 graphql-optimization/
-├── service.hcl     # Service configuration
-├── connectors.hcl  # GraphQL server + databases
-├── flows.hcl       # Flows with optimization examples
-├── types.hcl       # GraphQL type definitions
+├── service.mycel     # Service configuration
+├── connectors.mycel  # GraphQL server + databases
+├── flows.mycel       # Flows with optimization examples
+├── types.mycel       # GraphQL type definitions
 ├── setup.sql       # Database schema + sample data
 └── README.md       # This file
 ```

--- a/examples/graphql-subscription-client/README.md
+++ b/examples/graphql-subscription-client/README.md
@@ -6,9 +6,9 @@ This example demonstrates Mycel acting as a GraphQL subscription **client** — 
 
 ```
 graphql-subscription-client/
-├── config.hcl          # Service configuration (price-tracker)
-├── connectors.hcl      # GraphQL client with subscriptions, SQLite, REST
-├── flows.hcl           # Subscription handlers + REST API for stored data
+├── config.mycel          # Service configuration (price-tracker)
+├── connectors.mycel      # GraphQL client with subscriptions, SQLite, REST
+├── flows.mycel           # Subscription handlers + REST API for stored data
 └── README.md           # This file
 ```
 

--- a/examples/graphql/README.md
+++ b/examples/graphql/README.md
@@ -11,9 +11,9 @@ Both approaches produce the same result: a fully typed GraphQL API.
 
 ```
 graphql/
-├── config.hcl          # Service configuration
-├── connectors.hcl      # GraphQL server + SQLite database
-├── flows.hcl           # GraphQL operations (Query/Mutation)
+├── config.mycel          # Service configuration
+├── connectors.mycel      # GraphQL server + SQLite database
+├── flows.mycel           # GraphQL operations (Query/Mutation)
 ├── schema.graphql      # SDL schema (for schema-first approach)
 └── README.md           # This file
 ```
@@ -107,7 +107,7 @@ flow "get_users" {
 
 Define your types in HCL files, and Mycel automatically generates the GraphQL schema. Use the `returns` attribute to specify the return type.
 
-### Type Definition (types/user.hcl)
+### Type Definition (types/user.mycel)
 
 ```hcl
 type "User" {

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -12,7 +12,7 @@ This example demonstrates gRPC server and client functionality.
 
 ## Files
 
-- `config.hcl` - Complete configuration with server, client, and flows
+- `config.mycel` - Complete configuration with server, client, and flows
 
 ## Usage
 

--- a/examples/mocks/README.md
+++ b/examples/mocks/README.md
@@ -6,9 +6,9 @@ This example demonstrates how to use Mycel's mock system for testing without ext
 
 ```
 mocks/
-├── config.hcl           # Service config with mocks enabled
-├── connectors.hcl       # REST API + SQLite connectors
-├── flows.hcl            # User CRUD flows
+├── config.mycel           # Service config with mocks enabled
+├── connectors.mycel       # REST API + SQLite connectors
+├── flows.mycel            # User CRUD flows
 ├── mocks/
 │   └── connectors/
 │       └── db/
@@ -52,7 +52,7 @@ Mock files are JSON with two formats:
 ## Running
 
 ```bash
-# With mocks from config.hcl
+# With mocks from config.mycel
 mycel start --config ./examples/mocks
 
 # Override via CLI - mock specific connectors

--- a/examples/mongodb/README.md
+++ b/examples/mongodb/README.md
@@ -12,8 +12,8 @@ This example demonstrates MongoDB NoSQL operations.
 
 ## Files
 
-- `config.hcl` - MongoDB connector configuration
-- `flows.hcl` - CRUD and query flows
+- `config.mycel` - MongoDB connector configuration
+- `flows.mycel` - CRUD and query flows
 
 ## Environment Variables
 

--- a/examples/named-operations/README.md
+++ b/examples/named-operations/README.md
@@ -40,8 +40,8 @@ flow "get_users" {
 
 ```
 named-operations/
-├── connectors.hcl  # Connector definitions with named operations
-├── flows.hcl       # Flows referencing operations by name
+├── connectors.mycel  # Connector definitions with named operations
+├── flows.mycel       # Flows referencing operations by name
 └── README.md       # This file
 ```
 

--- a/examples/notifications/README.md
+++ b/examples/notifications/README.md
@@ -13,11 +13,11 @@ This example demonstrates how to use Mycel's notification connectors to send mes
 
 ## Configuration
 
-Copy `service.example.hcl` to `service.hcl` and fill in your credentials:
+Copy `service.example.mycel` to `service.mycel` and fill in your credentials:
 
 ```bash
-cp service.example.hcl service.hcl
-# Edit service.hcl with your actual credentials
+cp service.example.mycel service.mycel
+# Edit service.mycel with your actual credentials
 ```
 
 ## Running

--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -8,14 +8,14 @@ A Mycel plugin is a directory containing:
 
 ```
 my-plugin/
-├── plugin.hcl          # Plugin manifest (required)
+├── plugin.mycel          # Plugin manifest (required)
 ├── connector.wasm      # WASM connector module (required for connectors)
 └── functions.wasm      # WASM functions module (optional)
 ```
 
-## Plugin Manifest (plugin.hcl)
+## Plugin Manifest (plugin.mycel)
 
-The `plugin.hcl` file describes the plugin and what it provides:
+The `plugin.mycel` file describes the plugin and what it provides:
 
 ```hcl
 plugin {
@@ -59,7 +59,7 @@ provides {
 Declare plugins in your Mycel configuration:
 
 ```hcl
-# plugins.hcl
+# plugins.mycel
 plugin "salesforce" {
   source = "./plugins/salesforce"
 }
@@ -74,7 +74,7 @@ plugin "salesforce" {
 Then use the plugin connector like any built-in connector:
 
 ```hcl
-# connectors/salesforce.hcl
+# connectors/salesforce.mycel
 connector "sf_crm" {
   type = "salesforce"  # Uses the plugin connector type
 
@@ -89,7 +89,7 @@ connector "sf_crm" {
 Use it in flows:
 
 ```hcl
-# flows/get_accounts.hcl
+# flows/get_accounts.mycel
 flow "get_accounts" {
   from {
     connector = "api"

--- a/examples/plugin/plugins.mycel
+++ b/examples/plugin/plugins.mycel
@@ -6,7 +6,7 @@ plugin "example" {
   source = "./plugins/example-plugin"
 }
 
-// Git-hosted plugin (future feature)
+// Git-hosted plugin (supported; the URL below is illustrative)
 // plugin "salesforce" {
 //   source  = "github.com/acme/mycel-salesforce"
 //   version = "~> 1.0"

--- a/examples/plugin/plugins/example-plugin/plugin.mycel
+++ b/examples/plugin/plugins/example-plugin/plugin.mycel
@@ -1,5 +1,8 @@
 // Example Plugin Manifest
-// NOTE: The plugin system is a planned feature
+//
+// The WASM plugin system is implemented (local and git sources). This is an
+// illustrative manifest; actually loading the connector requires a compiled
+// connector.wasm in this directory (see ../../README.md).
 
 plugin "example" {
   source  = "./plugins/example-plugin"

--- a/examples/rate-limit/README.md
+++ b/examples/rate-limit/README.md
@@ -12,8 +12,8 @@ This example demonstrates rate limiting configuration.
 
 ## Files
 
-- `config.hcl` - Service configuration with rate limiting
-- `flows.hcl` - Sample API flows
+- `config.mycel` - Service configuration with rate limiting
+- `flows.mycel` - Sample API flows
 
 ## Usage
 

--- a/examples/s3/README.md
+++ b/examples/s3/README.md
@@ -12,8 +12,8 @@ This example demonstrates S3 and S3-compatible storage (MinIO) operations.
 
 ## Files
 
-- `config.hcl` - S3 and MinIO connector configuration
-- `flows.hcl` - File operation flows
+- `config.mycel` - S3 and MinIO connector configuration
+- `flows.mycel` - File operation flows
 
 ## Environment Variables
 

--- a/examples/saga/README.md
+++ b/examples/saga/README.md
@@ -18,9 +18,9 @@ If any step fails, compensations run **in reverse order**:
 
 | File | Purpose |
 |------|---------|
-| `config.hcl` | Service configuration |
-| `connectors.hcl` | Database and API connectors |
-| `sagas.hcl` | Saga definition with steps and compensations |
+| `config.mycel` | Service configuration |
+| `connectors.mycel` | Database and API connectors |
+| `sagas.mycel` | Saga definition with steps and compensations |
 
 ## Running
 

--- a/examples/scheduled/README.md
+++ b/examples/scheduled/README.md
@@ -56,20 +56,20 @@ curl http://localhost:3000/logs
 
 ```
 scheduled/
-├── config.hcl              # Service name and version
+├── config.mycel              # Service name and version
 ├── connectors/
-│   ├── api.hcl             # REST API on port 3000
-│   └── database.hcl        # SQLite database connection
+│   ├── api.mycel             # REST API on port 3000
+│   └── database.mycel        # SQLite database connection
 ├── flows/
-│   ├── scheduled.hcl       # Three scheduled jobs (cron flows)
-│   └── api.hcl             # REST endpoints to query results
+│   ├── scheduled.mycel       # Three scheduled jobs (cron flows)
+│   └── api.mycel             # REST endpoints to query results
 └── data/
     └── app.db              # SQLite database file (created automatically)
 ```
 
 ## Configuration Explained
 
-### Scheduled Flows (`flows/scheduled.hcl`)
+### Scheduled Flows (`flows/scheduled.mycel`)
 
 The `when` attribute turns a flow into a scheduled job. No `from` block is needed -- the scheduler triggers the flow automatically.
 

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -91,18 +91,18 @@ Expected: bell character (`\u0007`) is stripped; `name` stored as `"AliceBell"`.
 
 ```
 security/
-├── config.hcl              # Service name and version
-├── security.hcl            # Custom security thresholds
+├── config.mycel              # Service name and version
+├── security.mycel            # Custom security thresholds
 ├── connectors/
-│   ├── api.hcl             # REST API on port 3000
-│   └── database.hcl        # SQLite database
+│   ├── api.mycel             # REST API on port 3000
+│   └── database.mycel        # SQLite database
 └── flows/
-    └── users.hcl           # User CRUD (security applies automatically)
+    └── users.mycel           # User CRUD (security applies automatically)
 ```
 
 ## Customizing Thresholds
 
-In `security.hcl`:
+In `security.mycel`:
 
 ```hcl
 security {

--- a/examples/soap/README.md
+++ b/examples/soap/README.md
@@ -105,15 +105,15 @@ Note the differences from SOAP 1.1:
 
 ```
 soap/
-├── config.hcl              # Service name and version
+├── config.mycel              # Service name and version
 ├── connectors/
-│   ├── soap_server.hcl     # SOAP endpoint configuration
-│   └── database.hcl        # SQLite database connection
+│   ├── soap_server.mycel     # SOAP endpoint configuration
+│   └── database.mycel        # SQLite database connection
 ├── flows/
-│   ├── get_user.hcl        # GetUser operation
-│   └── create_user.hcl     # CreateUser operation
+│   ├── get_user.mycel        # GetUser operation
+│   └── create_user.mycel     # CreateUser operation
 ├── types/
-│   └── user.hcl            # User input validation schema
+│   └── user.mycel            # User input validation schema
 ├── data/
 │   └── app.db              # SQLite database file (created automatically)
 └── setup.sql               # Initial database schema

--- a/examples/state-machine/README.md
+++ b/examples/state-machine/README.md
@@ -29,10 +29,10 @@ curl -X POST localhost:3000/orders/1/status \
 
 | File | Purpose |
 |------|---------|
-| `config.hcl` | Service configuration |
-| `connectors.hcl` | REST API and database connectors |
-| `machines.hcl` | State machine definition |
-| `flows.hcl` | Flow that triggers state transitions |
+| `config.mycel` | Service configuration |
+| `connectors.mycel` | REST API and database connectors |
+| `machines.mycel` | State machine definition |
+| `flows.mycel` | Flow that triggers state transitions |
 
 ## Running
 

--- a/examples/sync/flows/scheduled_jobs.mycel
+++ b/examples/sync/flows/scheduled_jobs.mycel
@@ -1,15 +1,15 @@
 # Flow Triggers Example - Scheduled Jobs
-# Run jobs on cron or interval schedules
-# NOTE: Scheduled triggers (when attribute) are a planned feature
+#
+# A flow with a `when` attribute becomes a scheduled job: the scheduler
+# triggers it on a cron expression ("0 3 * * *") or an interval
+# ("@every 5m"), so no `from` block is needed. Locks compose on top to keep
+# overlapping runs (or multiple replicas) from executing the same job twice.
 
-# Daily cleanup
+# Daily cleanup at 3:00 AM
 flow "daily_cleanup" {
-  from {
-    connector = "api"
-    operation = "POST /jobs/cleanup"
-  }
+  when = "0 3 * * *"
 
-  # Prevent concurrent runs with a lock
+  # Prevent concurrent runs across replicas with a distributed lock
   lock {
     storage {
       driver = "redis"
@@ -22,29 +22,23 @@ flow "daily_cleanup" {
 
   to {
     connector = "postgres"
-    operation = "DELETE FROM logs WHERE created_at < now() - interval '30 days'"
+    query     = "DELETE FROM logs WHERE created_at < now() - interval '30 days'"
   }
 }
 
-# Health check endpoint
+# Heartbeat every 5 minutes
 flow "health_ping" {
-  from {
-    connector = "api"
-    operation = "GET /health"
-  }
+  when = "@every 5m"
 
   to {
     connector = "monitoring"
-    operation = "POST /post"
+    target    = "POST /ping"
   }
 }
 
-# Manual stats aggregation trigger
+# Hourly stats aggregation
 flow "aggregate_stats" {
-  from {
-    connector = "api"
-    operation = "POST /jobs/stats"
-  }
+  when = "@every 1h"
 
   lock {
     storage {
@@ -58,6 +52,6 @@ flow "aggregate_stats" {
 
   to {
     connector = "postgres"
-    operation = "INSERT INTO hourly_stats (hour, total_requests) VALUES (now(), 0)"
+    query     = "INSERT INTO hourly_stats (hour, total_requests) VALUES (now(), 0)"
   }
 }

--- a/examples/wasm-functions/README.md
+++ b/examples/wasm-functions/README.md
@@ -227,7 +227,7 @@ cp target/wasm32-unknown-unknown/release/mycel_pricing.wasm ./functions/pricing.
 
 ## Mycel Configuration
 
-### functions.hcl
+### functions.mycel
 
 ```hcl
 functions "pricing" {
@@ -236,7 +236,7 @@ functions "pricing" {
 }
 ```
 
-### flows.hcl
+### flows.mycel
 
 ```hcl
 flow "checkout" {

--- a/examples/wasm-validator/README.md
+++ b/examples/wasm-validator/README.md
@@ -131,7 +131,7 @@ cp target/wasm32-unknown-unknown/release/cuit_validator.wasm ./validators/
 ### 5. Use in Mycel Configuration
 
 ```hcl
-# validators.hcl
+# validators.mycel
 validator "argentina_cuit" {
   type       = "wasm"
   wasm       = "./validators/cuit_validator.wasm"
@@ -139,7 +139,7 @@ validator "argentina_cuit" {
   message    = "Invalid Argentine CUIT"
 }
 
-# types.hcl
+# types.mycel
 type "company" {
   cuit = string { validate = "validator.argentina_cuit" }
 }

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -18,10 +18,10 @@ The entire workflow has a 24-hour timeout. Workflow state is persisted to Postgr
 
 | File | Purpose |
 |------|---------|
-| `config.hcl` | Service config with workflow persistence |
-| `connectors/api.hcl` | REST API on port 3000 |
-| `connectors/database.hcl` | PostgreSQL, shipping API, notifications |
-| `sagas/order_fulfillment.hcl` | Workflow with delay and await steps |
+| `config.mycel` | Service config with workflow persistence |
+| `connectors/api.mycel` | REST API on port 3000 |
+| `connectors/database.mycel` | PostgreSQL, shipping API, notifications |
+| `sagas/order_fulfillment.mycel` | Workflow with delay and await steps |
 
 ## Running
 
@@ -162,7 +162,7 @@ step "wait_for_approval" {
 
 ### Workflow Persistence
 
-Enable in `config.hcl` to persist workflow state across restarts:
+Enable in `config.mycel` to persist workflow state across restarts:
 
 ```hcl
 service {


### PR DESCRIPTION
## Summary

Several examples documented features as "planned" that have actually been implemented for a while, and many READMEs still referenced the old `.hcl` file extension (renamed to `.mycel` in v1.18). This refreshes them and verifies each touched example validates against the binary.

## Changes

- **auth** — replaced the commented-out "planned feature" stub in `examples/auth/config.mycel` with a real, validated `auth` block (preset, jwt, password, mfa, security, sessions, social, audit, endpoints).
- **enrich** — the feature is implemented and executed, but the example never used it. Added flow-level `enrich` blocks (single and multiple) plus a named transform that reads enriched data; dropped the "not implemented" note and corrected the README.
- **sync/scheduled_jobs** — replaced the "planned feature" placeholder with real cron / `@every` `when` triggers, combined with locks.
- **plugin** — corrected notes: the WASM plugin system and git sources are supported; only the registry source remains future.
- **READMEs (28 files)** — updated file references from the old `.hcl` extension to `.mycel`.
- **docs/guides/auth** — fixed connector reference syntax (`connector = "name"`, not `connector = connector.name`, which the binary rejects).

## Left as-is (intentionally)

- `examples/dynamic-api-key` keeps its "planned feature" note: the `auth` `provider` block is parsed but not yet wired into the runtime, so dynamic API-key validation genuinely isn't functional end-to-end.

## Verification

All 78 example directories validate (`mycel validate --config <dir>`). No Go code changed.

## Notes for follow-up (out of scope here)

Two latent issues surfaced while doing this, not addressed in this PR:
- `mfa.enabled` exists on the struct but isn't in the auth MFA parser schema, so MFA can't be enabled purely via config.
- The auth `provider` block is parsed but never read by the runtime.