### PR TITLE
fix(auth): activatable MFA + implement external HTTP identity providers

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -235,6 +235,59 @@ oidc "auth0" {
 }
 ```
 
+### External Identity Providers
+
+A `provider` block validates an incoming credential (typically an API key or
+opaque bearer token) against an external HTTP endpoint at request time, rather
+than against local JWTs or a static list. Use it for dynamic API keys, an
+upstream introspection service, or any "is this token valid, and who is it?"
+backend.
+
+```hcl
+auth {
+  secret = env("AUTH_SECRET")
+
+  provider "api_keys" {
+    type     = "http"                                  # only "http" is supported
+    validate = env("KEYS_VALIDATE_URL")                # URL; supports {token}
+
+    # Headers sent to the validate URL. {token} is replaced with the credential.
+    request = {
+      Authorization = "Bearer {token}"
+    }
+
+    # Response mapping. Each value is a CEL expression evaluated over:
+    #   status — the HTTP status code (int)
+    #   body   — the parsed JSON response (object)
+    response {
+      success = "status == 200 && body.active == true"  # required; must be truthy
+      user_id = "body.user_id"
+      email   = "body.email"
+      roles   = "body.roles"        # list<string>, or a comma-separated string
+      token   = "body.session_id"   # optional; stored on the claims
+    }
+  }
+}
+```
+
+**Behavior**
+
+- **Order:** local JWT validation runs first. Providers are tried only when the
+  credential is not a valid JWT, in declaration order; the first whose `success`
+  expression is truthy wins.
+- **Auth context:** the full response `body` is exposed to flows as
+  `auth.claims.*` (so any field is reachable, not just the mapped ones), and the
+  mapped `user_id` is available as `auth.user_id`.
+- **Provider unavailable:** a timeout or transport error is treated as a
+  validation failure (the request is rejected), never a 5xx from your service.
+- **Fail-fast:** an unsupported `type`, a missing `validate`/`success`, or an
+  invalid CEL expression fails at startup, not silently at runtime.
+
+**Not yet implemented:** response caching (every request hits the provider) and
+`sync_to` (parsed, but setting it only logs a warning today).
+
+See the [`dynamic-api-key` example](../../examples/dynamic-api-key) for a complete setup.
+
 ### User Storage
 
 ```hcl

--- a/examples/dynamic-api-key/README.md
+++ b/examples/dynamic-api-key/README.md
@@ -1,71 +1,74 @@
 # Dynamic API Key Validation Example
 
-This example demonstrates how to validate API keys dynamically against a database instead of using static configuration.
+This example validates each request's API key **at request time** against an
+external HTTP introspection endpoint, instead of a static list baked into the
+config. The provider owns the keys (in a database, a secrets manager, an SSO
+system — whatever it is); Mycel just asks it "is this credential valid, and who
+is it?" on every request.
 
 ## Use Case
 
 When you need to:
-- Store API keys in a database for management
-- Associate keys with users, tenants, or metadata
-- Support key expiration and revocation
-- Track API key usage and permissions
 
-## Configuration
+- Manage API keys outside the service (issue, rotate, revoke without a redeploy)
+- Associate keys with users, tenants, roles, or arbitrary metadata
+- Support expiration and immediate revocation
+- Keep the validation logic (and the key store) in one central place
 
-### Database Schema
+## How It Works
 
-```sql
-CREATE TABLE api_keys (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    key_hash VARCHAR(64) NOT NULL UNIQUE,  -- SHA256 hash of the key
-    user_id UUID NOT NULL REFERENCES users(id),
-    metadata JSONB DEFAULT '{}',
-    active BOOLEAN DEFAULT true,
-    expires_at TIMESTAMP,
-    created_at TIMESTAMP DEFAULT NOW()
-);
+1. The client sends a request with an `Authorization: Bearer <key>` header.
+2. The key is not a local JWT, so Mycel falls through to the configured
+   `provider`, calling its `validate` URL with the key.
+3. The provider responds with JSON; Mycel evaluates the `response` CEL
+   expressions over `status` (the HTTP code) and `body` (the parsed JSON).
+4. If `success` is true, the mapped fields populate the auth context, available
+   to every flow as `auth.user_id` and `auth.claims.*`.
 
-CREATE INDEX idx_api_keys_hash ON api_keys(key_hash) WHERE active = true;
-```
-
-### Dynamic Validation Block
+## The provider block
 
 ```hcl
-connector "api" {
-  type = "rest"
-  port = 8080
+auth {
+  secret = env("AUTH_SECRET", "change-me-in-production")
 
-  auth {
-    type = "api_key"
+  provider "api_keys" {
+    type     = "http"
+    validate = env("KEYS_VALIDATE_URL", "http://localhost:9100/introspect")
 
-    api_key {
-      header = "X-API-Key"
+    # {token} is replaced with the incoming credential.
+    request = {
+      Authorization = "Bearer {token}"
+    }
 
-      # Dynamic validation against database
-      validate {
-        connector = "connector.keys_db"
-        query     = "SELECT user_id, metadata FROM api_keys WHERE key_hash = :key AND active = true"
-      }
+    # CEL expressions over `status` (HTTP code) and `body` (parsed JSON).
+    response {
+      success = "status == 200 && body.active == true"
+      user_id = "body.user_id"
+      email   = "body.email"
+      roles   = "body.roles"
+      # token = "body.session_id"   # optional, stored on the claims
     }
   }
 }
 ```
 
-## How It Works
+A successful introspection response might look like:
 
-1. Client sends request with `X-API-Key` header
-2. Mycel extracts the key and queries the database
-3. If found and active, the `user_id` and `metadata` are added to auth context
-4. Flows can access this via `auth.user_id` and `auth.claims`
+```json
+{ "active": true, "user_id": "u_123", "email": "ada@example.com",
+  "roles": ["admin"], "tenant_id": "acme" }
+```
 
-## Auth Context
+The whole body is exposed as `auth.claims.*`, so `tenant_id` above is reachable
+as `auth.claims.tenant_id` even though it isn't one of the explicitly mapped
+fields.
 
-After validation, flows have access to:
+## Auth context in flows
 
 ```hcl
 transform {
-  user_id   = "auth.user_id"        # From query result
-  tenant_id = "auth.claims.tenant_id"  # From metadata JSON
+  user_id   = "auth.user_id"           # mapped from response.user_id
+  tenant_id = "auth.claims.tenant_id"  # any field from the response body
   role      = "auth.claims.role"
 }
 ```
@@ -73,33 +76,42 @@ transform {
 ## Running
 
 ```bash
-# Set environment variables
-export DB_HOST=localhost
-export DB_USER=mycel
-export DB_PASSWORD=secret
-export DB_NAME=api_keys
+# Point at your introspection endpoint
+export KEYS_VALIDATE_URL=https://auth.internal/introspect
+export AUTH_SECRET=...
 
-# Start the service
+# Application database used by the flows
+export DB_HOST=localhost DB_USER=mycel DB_PASSWORD=secret DB_NAME=api_keys
+
 mycel start --config ./examples/dynamic-api-key
 
-# Test with API key
-curl -H "X-API-Key: your-api-key-here" http://localhost:8080/me
+curl -H "Authorization: Bearer your-api-key" http://localhost:8080/me
 ```
 
-## Comparison: Static vs Dynamic
+## Notes & limits
 
-| Feature | Static Keys | Dynamic Keys |
-|---------|-------------|--------------|
-| Configuration | In HCL file | In database |
-| Key rotation | Requires restart | Immediate |
-| User association | Not supported | Full support |
-| Expiration | Not supported | Supported |
-| Metadata/Claims | Not supported | Full support |
-| Audit trail | Not supported | Can be added |
+- **Order:** local JWT validation runs first; providers are tried only when the
+  credential isn't a valid JWT. Multiple providers are tried in declaration order.
+- **Provider down:** a timeout or transport error is treated as a validation
+  failure (the request is rejected), not a 5xx from your API.
+- **No caching (yet):** every request hits the provider. A TTL cache is a planned
+  addition.
+- **`sync_to` is parsed but not executed yet** — setting it logs a warning. The
+  field is reserved for mirroring the validated identity into a local store.
 
-## Security Notes
+## Comparison: static vs dynamic keys
 
-- Store only key hashes, never plain text keys
-- Use SHA256 or bcrypt for hashing
-- Add rate limiting to prevent brute force
-- Consider key prefix for identification (e.g., `mk_live_xxx`)
+| Feature          | Static keys     | Dynamic (provider) |
+|------------------|-----------------|--------------------|
+| Where keys live  | In the HCL file | In the provider    |
+| Rotation/revoke  | Requires redeploy | Immediate        |
+| User association | Not supported   | Full support       |
+| Expiration       | Not supported   | Provider-side      |
+| Metadata/claims  | Not supported   | Full support       |
+
+## Security notes
+
+- Send the key in a header (`request = { Authorization = "Bearer {token}" }`),
+  not in the URL.
+- Put the introspection endpoint behind TLS.
+- Add rate limiting to blunt brute-force attempts against the endpoint.

--- a/examples/dynamic-api-key/service.mycel
+++ b/examples/dynamic-api-key/service.mycel
@@ -1,13 +1,13 @@
 # Dynamic API Key Validation Example
-# Validates API keys against a database instead of static configuration
-# NOTE: Dynamic API key validation is a planned feature
+# Validates incoming API keys at request time against an external HTTP
+# introspection endpoint, instead of a static list baked into the config.
 
 service {
   name    = "api-with-dynamic-keys"
   version = "1.0.0"
 }
 
-# Database storing API keys
+# Application database (business data the validated identity reads/writes).
 connector "keys_db" {
   type     = "database"
   driver   = "postgres"
@@ -26,6 +26,31 @@ connector "api" {
   cors {
     origins = ["*"]
     methods = ["GET", "POST", "PUT", "DELETE"]
+  }
+}
+
+# Auth: validate each request's bearer credential against an external HTTP
+# provider. The provider receives the key and returns the identity it maps to;
+# the mapped fields populate the auth context (auth.user_id, auth.claims.*).
+auth {
+  secret = env("AUTH_SECRET", "change-me-in-production")
+
+  provider "api_keys" {
+    type     = "http"
+    validate = env("KEYS_VALIDATE_URL", "http://localhost:9100/introspect")
+
+    # {token} is replaced with the incoming credential.
+    request = {
+      Authorization = "Bearer {token}"
+    }
+
+    # CEL expressions over `status` (HTTP code) and `body` (parsed JSON).
+    response {
+      success = "status == 200 && body.active == true"
+      user_id = "body.user_id"
+      email   = "body.email"
+      roles   = "body.roles"
+    }
   }
 }
 

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -27,6 +27,7 @@ type Manager struct {
 	passwordHasher    *PasswordHasher
 	passwordValidator *PasswordValidator
 	mfaService        *MFAService
+	providerValidator *ProviderValidator
 
 	logger *slog.Logger
 }
@@ -134,6 +135,16 @@ func NewManager(config *Config, opts ...ManagerOption) (*Manager, error) {
 			m.mfaStore = NewMemoryMFAStore()
 		}
 		m.mfaService = NewMFAService(config.MFA, m.mfaStore)
+	}
+
+	// Initialize external identity providers if configured. A bad provider
+	// (unsupported type, invalid CEL, missing validate/success) fails startup.
+	if len(config.Providers) > 0 {
+		pv, err := NewProviderValidator(config.Providers, nil, m.logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize auth providers: %w", err)
+		}
+		m.providerValidator = pv
 	}
 
 	return m, nil
@@ -380,6 +391,13 @@ func (m *Manager) ValidateToken(ctx context.Context, accessToken string) (*User,
 	// Validate access token
 	claims, err := m.tokenManager.ValidateAccessToken(accessToken)
 	if err != nil {
+		// Not a valid local JWT — fall back to external identity providers,
+		// which validate the raw credential (e.g. an API key) over HTTP.
+		if m.providerValidator.HasProviders() {
+			if user, pClaims, pErr := m.providerValidator.Validate(ctx, accessToken); pErr == nil {
+				return user, pClaims, nil
+			}
+		}
 		return nil, nil, ErrInvalidToken
 	}
 

--- a/internal/auth/presets.go
+++ b/internal/auth/presets.go
@@ -58,6 +58,7 @@ func strictPreset() *Config {
 			KeyLength:      32,
 		},
 		MFA: &MFAConfig{
+			Enabled:     true,
 			Required:    "true",
 			Methods:     []string{"totp", "webauthn"},
 			GracePeriod: "7d",
@@ -143,6 +144,7 @@ func standardPreset() *Config {
 			KeyLength:      32,
 		},
 		MFA: &MFAConfig{
+			Enabled:     true,
 			Required:    "optional",
 			Methods:     []string{"totp", "webauthn"},
 			GracePeriod: "14d",
@@ -217,6 +219,7 @@ func relaxedPreset() *Config {
 			KeyLength:      32,
 		},
 		MFA: &MFAConfig{
+			Enabled:  true,
 			Required: "false",
 			Methods:  []string{"totp"},
 		},

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -1,0 +1,265 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/cel-go/cel"
+)
+
+// compiledProvider pairs a ProviderConfig with its pre-compiled CEL programs so
+// response mapping is validated once at startup, not per request.
+type compiledProvider struct {
+	cfg     *ProviderConfig
+	success cel.Program
+	userID  cel.Program
+	email   cel.Program
+	roles   cel.Program
+	token   cel.Program
+}
+
+// ProviderValidator validates incoming credentials against external HTTP
+// identity providers declared via `auth { provider "name" { ... } }`.
+//
+// For each request whose token is not a valid local JWT, the configured
+// providers are tried in order: the provider's `validate` URL is called with
+// the token (templated into the URL and/or request headers via `{token}`), and
+// the JSON response is mapped to a User/Claims through CEL expressions. The
+// first provider whose `success` expression is truthy wins.
+type ProviderValidator struct {
+	providers []*compiledProvider
+	client    *http.Client
+	logger    *slog.Logger
+}
+
+// providerCELEnv builds the CEL environment used for response mapping. Two
+// variables are available to every expression: `status` (the HTTP status code)
+// and `body` (the parsed JSON response object).
+func providerCELEnv() (*cel.Env, error) {
+	return cel.NewEnv(
+		cel.Variable("status", cel.IntType),
+		cel.Variable("body", cel.MapType(cel.StringType, cel.DynType)),
+	)
+}
+
+func compileProviderExpr(env *cel.Env, expr string) (cel.Program, error) {
+	if strings.TrimSpace(expr) == "" {
+		return nil, nil
+	}
+	ast, iss := env.Compile(expr)
+	if iss != nil && iss.Err() != nil {
+		return nil, iss.Err()
+	}
+	return env.Program(ast)
+}
+
+// NewProviderValidator compiles the provider configs into a validator. It fails
+// fast on an unsupported provider type, a missing `validate`/`success`, or an
+// invalid CEL expression, so a misconfigured provider is caught at startup
+// instead of silently accepting (or rejecting) every request.
+func NewProviderValidator(providers []*ProviderConfig, client *http.Client, logger *slog.Logger) (*ProviderValidator, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	env, err := providerCELEnv()
+	if err != nil {
+		return nil, fmt.Errorf("auth provider: building CEL env: %w", err)
+	}
+
+	compiled := make([]*compiledProvider, 0, len(providers))
+	for _, p := range providers {
+		if p == nil {
+			continue
+		}
+		if p.Type != "" && p.Type != "http" {
+			return nil, fmt.Errorf("auth provider %q: unsupported type %q (only \"http\" is supported)", p.Name, p.Type)
+		}
+		if strings.TrimSpace(p.Validate) == "" {
+			return nil, fmt.Errorf("auth provider %q: a `validate` URL is required", p.Name)
+		}
+		if p.Response == nil || strings.TrimSpace(p.Response.Success) == "" {
+			return nil, fmt.Errorf("auth provider %q: a `response { success = ... }` expression is required", p.Name)
+		}
+		// sync_to is parsed but not yet executed — surface it loudly rather
+		// than silently ignoring it.
+		if p.SyncTo != "" {
+			logger.Warn("auth provider: sync_to is parsed but not executed yet (planned feature)",
+				"provider", p.Name, "sync_to", p.SyncTo)
+		}
+
+		cp := &compiledProvider{cfg: p}
+		for _, field := range []struct {
+			name string
+			expr string
+			dst  *cel.Program
+		}{
+			{"success", p.Response.Success, &cp.success},
+			{"user_id", p.Response.UserID, &cp.userID},
+			{"email", p.Response.Email, &cp.email},
+			{"roles", p.Response.Roles, &cp.roles},
+			{"token", p.Response.Token, &cp.token},
+		} {
+			prg, err := compileProviderExpr(env, field.expr)
+			if err != nil {
+				return nil, fmt.Errorf("auth provider %q: invalid `%s` expression: %w", p.Name, field.name, err)
+			}
+			*field.dst = prg
+		}
+		compiled = append(compiled, cp)
+	}
+
+	return &ProviderValidator{providers: compiled, client: client, logger: logger}, nil
+}
+
+// HasProviders reports whether any provider is configured. Safe on a nil receiver.
+func (v *ProviderValidator) HasProviders() bool {
+	return v != nil && len(v.providers) > 0
+}
+
+// Validate tries each configured provider in order. The first whose `success`
+// expression is truthy yields the User/Claims. Returns ErrInvalidToken if no
+// provider accepts the credential (including when a provider is unreachable).
+func (v *ProviderValidator) Validate(ctx context.Context, token string) (*User, *Claims, error) {
+	if !v.HasProviders() || token == "" {
+		return nil, nil, ErrInvalidToken
+	}
+	for _, p := range v.providers {
+		if user, claims, ok := v.validateOne(ctx, p, token); ok {
+			return user, claims, nil
+		}
+	}
+	return nil, nil, ErrInvalidToken
+}
+
+func (v *ProviderValidator) validateOne(ctx context.Context, p *compiledProvider, token string) (*User, *Claims, bool) {
+	url := strings.ReplaceAll(p.cfg.Validate, "{token}", token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		v.logger.Warn("auth provider: building request failed", "provider", p.cfg.Name, "error", err)
+		return nil, nil, false
+	}
+	for k, val := range p.cfg.Request {
+		req.Header.Set(k, strings.ReplaceAll(val, "{token}", token))
+	}
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		// Provider unreachable / timed out → treat as a validation failure for
+		// this provider, not a 5xx for the caller.
+		v.logger.Warn("auth provider: request failed", "provider", p.cfg.Name, "error", err)
+		return nil, nil, false
+	}
+	defer resp.Body.Close()
+
+	body := map[string]interface{}{}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // cap at 1MB
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &body); err != nil {
+			v.logger.Warn("auth provider: response body is not a JSON object", "provider", p.cfg.Name, "error", err)
+			body = map[string]interface{}{}
+		}
+	}
+
+	vars := map[string]interface{}{
+		"status": int64(resp.StatusCode),
+		"body":   body,
+	}
+
+	if !v.evalBool(p.success, vars) {
+		return nil, nil, false
+	}
+
+	userID := v.evalString(p.userID, vars)
+	email := v.evalString(p.email, vars)
+	roles := v.evalRoles(p.roles, vars)
+	providerToken := v.evalString(p.token, vars)
+
+	claims := &Claims{
+		UserID:    userID,
+		Email:     email,
+		Roles:     roles,
+		TokenType: "access",
+		Custom:    body, // full provider response available as auth.claims.*
+	}
+	claims.Subject = userID
+	if providerToken != "" {
+		claims.SessionID = providerToken
+	}
+
+	user := &User{
+		ID:       userID,
+		Email:    email,
+		Roles:    roles,
+		Metadata: map[string]interface{}{"auth_provider": p.cfg.Name},
+	}
+	return user, claims, true
+}
+
+func (v *ProviderValidator) evalBool(prg cel.Program, vars map[string]interface{}) bool {
+	if prg == nil {
+		return false
+	}
+	out, _, err := prg.Eval(vars)
+	if err != nil {
+		return false
+	}
+	b, ok := out.Value().(bool)
+	return ok && b
+}
+
+func (v *ProviderValidator) evalString(prg cel.Program, vars map[string]interface{}) string {
+	if prg == nil {
+		return ""
+	}
+	out, _, err := prg.Eval(vars)
+	if err != nil {
+		return ""
+	}
+	switch val := out.Value().(type) {
+	case nil:
+		return ""
+	case string:
+		return val
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+func (v *ProviderValidator) evalRoles(prg cel.Program, vars map[string]interface{}) []string {
+	if prg == nil {
+		return nil
+	}
+	out, _, err := prg.Eval(vars)
+	if err != nil {
+		return nil
+	}
+	// Preferred shape: a list of strings.
+	if native, err := out.ConvertToNative(reflect.TypeOf([]string{})); err == nil {
+		if rs, ok := native.([]string); ok {
+			return rs
+		}
+	}
+	// Fallback: a comma-separated string.
+	if s, ok := out.Value().(string); ok {
+		parts := strings.Split(s, ",")
+		roles := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if t := strings.TrimSpace(part); t != "" {
+				roles = append(roles, t)
+			}
+		}
+		return roles
+	}
+	return nil
+}

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// activeProvider returns a ProviderConfig whose `validate` points at url and
+// maps a typical "introspection" JSON response.
+func activeProvider(name, url string) *ProviderConfig {
+	return &ProviderConfig{
+		Name:     name,
+		Type:     "http",
+		Validate: url,
+		Request:  map[string]string{"Authorization": "Bearer {token}"},
+		Response: &ProviderResponseConfig{
+			Success: "status == 200 && body.active == true",
+			UserID:  "body.sub",
+			Email:   "body.email",
+			Roles:   "body.roles",
+		},
+	}
+}
+
+func TestProviderValidator_Success(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"active":true,"sub":"u1","email":"ada@example.com","roles":["admin","user"]}`))
+	}))
+	defer srv.Close()
+
+	v, err := NewProviderValidator([]*ProviderConfig{activeProvider("keys", srv.URL)}, srv.Client(), nil)
+	if err != nil {
+		t.Fatalf("construct: %v", err)
+	}
+
+	user, claims, err := v.Validate(context.Background(), "tok123")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if gotAuth != "Bearer tok123" {
+		t.Errorf("token not templated into header: got %q", gotAuth)
+	}
+	if user.ID != "u1" || claims.UserID != "u1" {
+		t.Errorf("expected user id u1, got user=%q claims=%q", user.ID, claims.UserID)
+	}
+	if user.Email != "ada@example.com" {
+		t.Errorf("expected email mapped, got %q", user.Email)
+	}
+	if len(claims.Roles) != 2 || claims.Roles[0] != "admin" || claims.Roles[1] != "user" {
+		t.Errorf("expected roles [admin user], got %v", claims.Roles)
+	}
+	// Full body should be available as custom claims.
+	if claims.Custom["sub"] != "u1" {
+		t.Errorf("expected response body exposed via claims.Custom, got %v", claims.Custom)
+	}
+}
+
+func TestProviderValidator_SuccessFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"active":false}`))
+	}))
+	defer srv.Close()
+
+	v, _ := NewProviderValidator([]*ProviderConfig{activeProvider("keys", srv.URL)}, srv.Client(), nil)
+	if _, _, err := v.Validate(context.Background(), "tok"); err != ErrInvalidToken {
+		t.Errorf("expected ErrInvalidToken when success is false, got %v", err)
+	}
+}
+
+func TestProviderValidator_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	v, _ := NewProviderValidator([]*ProviderConfig{activeProvider("keys", srv.URL)}, srv.Client(), nil)
+	if _, _, err := v.Validate(context.Background(), "tok"); err != ErrInvalidToken {
+		t.Errorf("expected ErrInvalidToken on 5xx, got %v", err)
+	}
+}
+
+func TestProviderValidator_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"active":true,"sub":"u1"}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 20 * time.Millisecond}
+	v, _ := NewProviderValidator([]*ProviderConfig{activeProvider("keys", srv.URL)}, client, nil)
+	if _, _, err := v.Validate(context.Background(), "tok"); err != ErrInvalidToken {
+		t.Errorf("expected ErrInvalidToken on timeout, got %v", err)
+	}
+}
+
+func TestProviderValidator_RolesCSV(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"active":true,"sub":"u1","roles":"admin, user , ops"}`))
+	}))
+	defer srv.Close()
+
+	v, _ := NewProviderValidator([]*ProviderConfig{activeProvider("keys", srv.URL)}, srv.Client(), nil)
+	_, claims, err := v.Validate(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	want := []string{"admin", "user", "ops"}
+	if len(claims.Roles) != len(want) {
+		t.Fatalf("expected %v, got %v", want, claims.Roles)
+	}
+	for i := range want {
+		if claims.Roles[i] != want[i] {
+			t.Errorf("role %d: want %q, got %q", i, want[i], claims.Roles[i])
+		}
+	}
+}
+
+func TestProviderValidator_ConstructFailFast(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *ProviderConfig
+	}{
+		{"unsupported type", &ProviderConfig{Name: "x", Type: "grpc", Validate: "http://x", Response: &ProviderResponseConfig{Success: "true"}}},
+		{"missing validate", &ProviderConfig{Name: "x", Type: "http", Response: &ProviderResponseConfig{Success: "true"}}},
+		{"missing success", &ProviderConfig{Name: "x", Type: "http", Validate: "http://x"}},
+		{"bad CEL", &ProviderConfig{Name: "x", Type: "http", Validate: "http://x", Response: &ProviderResponseConfig{Success: "this is not && valid"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewProviderValidator([]*ProviderConfig{tc.cfg}, nil, nil); err == nil {
+				t.Errorf("expected construction to fail for %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestManager_ValidateToken_ProviderFallthrough verifies the end-to-end path:
+// a non-JWT credential falls through local validation to the HTTP provider.
+func TestManager_ValidateToken_ProviderFallthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer apikey-xyz" {
+			http.Error(w, "no key", http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"active":true,"sub":"svc-1","email":"svc@acme.io","roles":["service"]}`))
+	}))
+	defer srv.Close()
+
+	mgr, err := NewManager(&Config{
+		Secret:    "test-secret-please-change",
+		Providers: []*ProviderConfig{activeProvider("keys", srv.URL)},
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	user, claims, err := mgr.ValidateToken(context.Background(), "apikey-xyz")
+	if err != nil {
+		t.Fatalf("expected provider fallthrough to validate, got %v", err)
+	}
+	if user.ID != "svc-1" || len(claims.Roles) != 1 || claims.Roles[0] != "service" {
+		t.Errorf("unexpected identity: user=%q roles=%v", user.ID, claims.Roles)
+	}
+
+	// A bad credential the provider rejects must still fail.
+	if _, _, err := mgr.ValidateToken(context.Background(), "wrong-key"); err != ErrInvalidToken {
+		t.Errorf("expected ErrInvalidToken for rejected key, got %v", err)
+	}
+}

--- a/internal/parser/auth.go
+++ b/internal/parser/auth.go
@@ -210,10 +210,13 @@ func (p *HCLParser) parseAuthPasswordBlock(block *hcl.Block) (*auth.PasswordConf
 }
 
 func (p *HCLParser) parseAuthMFABlock(block *hcl.Block) (*auth.MFAConfig, error) {
-	config := &auth.MFAConfig{}
+	// The presence of an `mfa` block opts MFA in by default; an explicit
+	// `enabled = false` can still disable it without removing the block.
+	config := &auth.MFAConfig{Enabled: true}
 
 	content, diags := block.Body.Content(&hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{
+			{Name: "enabled"},
 			{Name: "required"},
 			{Name: "methods"},
 			{Name: "require_for"},
@@ -235,6 +238,13 @@ func (p *HCLParser) parseAuthMFABlock(block *hcl.Block) (*auth.MFAConfig, error)
 	}
 
 	// Parse attributes
+	if attr, exists := content.Attributes["enabled"]; exists {
+		val, diags := attr.Expr.Value(p.evalCtx)
+		if !diags.HasErrors() {
+			config.Enabled = val.True()
+		}
+	}
+
 	if attr, exists := content.Attributes["required"]; exists {
 		val, diags := attr.Expr.Value(p.evalCtx)
 		if !diags.HasErrors() {

--- a/internal/parser/auth_mfa_test.go
+++ b/internal/parser/auth_mfa_test.go
@@ -1,0 +1,81 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// parseAuthMFA is a small helper that writes an auth config to a temp file,
+// parses it, and returns the resulting MFA config (or fails the test).
+func parseAuthMFA(t *testing.T, hcl string) *struct {
+	Enabled bool
+	Methods []string
+} {
+	t.Helper()
+
+	tmpFile := filepath.Join(t.TempDir(), "auth.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	config, err := NewHCLParser().ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if config.Auth == nil || config.Auth.MFA == nil {
+		t.Fatalf("expected auth.mfa to be parsed, got auth=%v", config.Auth)
+	}
+	return &struct {
+		Enabled bool
+		Methods []string
+	}{Enabled: config.Auth.MFA.Enabled, Methods: config.Auth.MFA.Methods}
+}
+
+// TestParseAuthMFAEnabledExplicit covers the regression where `enabled` was
+// missing from the mfa BodySchema, so setting it was a hard parse error.
+func TestParseAuthMFAEnabledExplicit(t *testing.T) {
+	mfa := parseAuthMFA(t, `
+auth {
+  mfa {
+    enabled = true
+    methods = ["totp"]
+  }
+}
+`)
+	if !mfa.Enabled {
+		t.Errorf("expected mfa.enabled = true, got false")
+	}
+}
+
+// TestParseAuthMFAEnabledDefaultsOnPresence verifies that writing an mfa block
+// opts MFA in even without an explicit `enabled` attribute.
+func TestParseAuthMFAEnabledDefaultsOnPresence(t *testing.T) {
+	mfa := parseAuthMFA(t, `
+auth {
+  mfa {
+    methods = ["totp"]
+  }
+}
+`)
+	if !mfa.Enabled {
+		t.Errorf("expected mfa.enabled to default to true when the mfa block is present, got false")
+	}
+}
+
+// TestParseAuthMFAEnabledExplicitFalse verifies that an explicit `enabled = false`
+// still disables MFA without having to remove the block.
+func TestParseAuthMFAEnabledExplicitFalse(t *testing.T) {
+	mfa := parseAuthMFA(t, `
+auth {
+  mfa {
+    enabled = false
+    methods = ["totp"]
+  }
+}
+`)
+	if mfa.Enabled {
+		t.Errorf("expected explicit mfa.enabled = false to disable MFA, got true")
+	}
+}


### PR DESCRIPTION
Fixes two latent auth bugs found while refreshing `examples/auth` (PR #18) — code that was out of scope there.

## Bug 1 — MFA could never be turned on

`parseAuthMFABlock` left `enabled` out of its `BodySchema`, so setting `mfa { enabled = true }` was a hard parse error. Worse, no preset set the top-level `MFAConfig.Enabled` either, so the gate in `NewManager` (`config.MFA.Enabled`) was effectively always false and the MFA service **never initialized** — not even via a preset.

- Parse `enabled` in the mfa block, and default it to `true` when the block is present (presence is the opt-in). An explicit `enabled = false` still disables it.
- Set `Enabled: true` on the strict/standard/relaxed presets, which configure MFA methods and clearly intend it on. The development preset (no methods) stays off.
- Parser tests for explicit-true, presence-default, and explicit-false.

## Bug 2 — `provider` block was a silent no-op

The `provider` block under `auth` parsed into `config.Providers` but **nothing consumed it**. It silently did nothing, which made the `dynamic-api-key` example's "planned feature" note quietly true — and its README documented syntax that never existed.

Implemented end-to-end (design confirmed with maintainer):

- **`ProviderValidator`** (`internal/auth/provider.go`) validates a credential against an external HTTP endpoint. `{token}` is templated into the `validate` URL and `request` headers; the JSON response is mapped to a `User`/`Claims` through CEL expressions over `status` (HTTP code) and `body` (parsed JSON). The full response body is exposed to flows as `auth.claims.*`.
- **`Manager.ValidateToken`** falls through to providers when a credential isn't a valid local JWT; providers are tried in declaration order, first truthy `success` wins. A provider timeout/transport error is a rejection, **not** a 5xx. CEL is compiled at startup, so a bad `type`/expression/missing `validate` **fails fast** instead of silently.
- **Documented, not silent:** response caching and `sync_to` are not implemented yet (`sync_to` logs a warning when set).
- Rewrote the `dynamic-api-key` example to use a real `provider` block (its README documented non-existent syntax), and documented the block in `docs/guides/auth.md`.

Tests cover success, success=false, 5xx, timeout, role list + CSV, token templating, fail-fast construction, and the JWT→provider fallthrough.

## Verification

- `go test ./...` → 70 ok / 0 fail; `-race` clean on `internal/auth` + `internal/parser`.
- `mycel validate --config examples/dynamic-api-key` passes.

## Semantics example

```hcl
auth {
  provider "api_keys" {
    type     = "http"
    validate = env("KEYS_VALIDATE_URL")
    request  = { Authorization = "Bearer {token}" }
    response {
      success = "status == 200 && body.active == true"
      user_id = "body.user_id"
      roles   = "body.roles"
    }
  }
}
```