### PR TITLE
fix(sync): per-message goroutine leak in redis coordinate + add pprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,15 @@ mycel start --verbose-flow
 
 All debug features are **development-only** — automatically disabled in staging/production with zero overhead.
 
+**Profiling (`pprof`).** For diagnosing a live process — goroutine leaks, heap growth, CPU hotspots — set `MYCEL_PPROF=true` to mount the Go `net/http/pprof` endpoints under `/debug/pprof/` on the admin server (`:9090`). It's off by default and safe to enable in any environment, including production: the admin port is internal (reach it with `kubectl port-forward`). Then:
+
+```bash
+# Full goroutine dump (what reveals a leak)
+curl 'http://localhost:9090/debug/pprof/goroutine?debug=2'
+# Or interactively
+go tool pprof http://localhost:9090/debug/pprof/goroutine
+```
+
 See the [Debugging Guide](docs/guides/debugging.md) for full documentation including IDE setup.
 
 ## CLI
@@ -278,7 +287,7 @@ mycel plugin remove <name>
 mycel plugin update [name]
 ```
 
-Environment: `MYCEL_ENV` (default: development), `MYCEL_LOG_LEVEL` (default: info), `MYCEL_LOG_FORMAT` (default: text). Flags take precedence.
+Environment: `MYCEL_ENV` (default: development), `MYCEL_LOG_LEVEL` (default: info), `MYCEL_LOG_FORMAT` (default: text), `MYCEL_PPROF` (default: off — mounts `pprof` on the admin server when truthy). Flags take precedence.
 
 See the [Debugging Guide](docs/guides/debugging.md) for `mycel trace` usage and examples.
 

--- a/internal/runtime/pprof_test.go
+++ b/internal/runtime/pprof_test.go
@@ -1,0 +1,34 @@
+package runtime
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterPprofHandlers_Gated(t *testing.T) {
+	// Off by default (env unset).
+	t.Setenv("MYCEL_PPROF", "")
+	if registerPprofHandlers(http.NewServeMux()) {
+		t.Fatal("pprof must be disabled when MYCEL_PPROF is unset")
+	}
+
+	// Off for non-truthy values.
+	t.Setenv("MYCEL_PPROF", "no")
+	if registerPprofHandlers(http.NewServeMux()) {
+		t.Fatal("pprof must be disabled for MYCEL_PPROF=no")
+	}
+
+	// On when enabled, and the goroutine profile actually responds.
+	t.Setenv("MYCEL_PPROF", "true")
+	mux := http.NewServeMux()
+	if !registerPprofHandlers(mux) {
+		t.Fatal("pprof must be enabled when MYCEL_PPROF=true")
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/goroutine?debug=1", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from /debug/pprof/goroutine, got %d", rec.Code)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	httppprof "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -25,49 +26,48 @@ import (
 	"github.com/matutetandil/mycel/internal/codec"
 	"github.com/matutetandil/mycel/internal/connector"
 	"github.com/matutetandil/mycel/internal/connector/cache"
-	"github.com/matutetandil/mycel/internal/connector/discord"
-	"github.com/matutetandil/mycel/internal/connector/email"
-	"github.com/matutetandil/mycel/internal/connector/profile"
-	"github.com/matutetandil/mycel/internal/connector/push"
-	"github.com/matutetandil/mycel/internal/connector/slack"
-	"github.com/matutetandil/mycel/internal/connector/sms"
-	"github.com/matutetandil/mycel/internal/connector/webhook"
+	conncdc "github.com/matutetandil/mycel/internal/connector/cdc"
 	"github.com/matutetandil/mycel/internal/connector/database/mongodb"
 	"github.com/matutetandil/mycel/internal/connector/database/mysql"
 	"github.com/matutetandil/mycel/internal/connector/database/postgres"
 	"github.com/matutetandil/mycel/internal/connector/database/sqlite"
+	"github.com/matutetandil/mycel/internal/connector/discord"
+	connelastic "github.com/matutetandil/mycel/internal/connector/elasticsearch"
+	"github.com/matutetandil/mycel/internal/connector/email"
 	"github.com/matutetandil/mycel/internal/connector/exec"
-	"github.com/matutetandil/mycel/internal/debug"
-	"github.com/matutetandil/mycel/internal/envdefaults"
 	"github.com/matutetandil/mycel/internal/connector/file"
+	connftp "github.com/matutetandil/mycel/internal/connector/ftp"
 	"github.com/matutetandil/mycel/internal/connector/graphql"
-	conns3 "github.com/matutetandil/mycel/internal/connector/s3"
 	conngrpc "github.com/matutetandil/mycel/internal/connector/grpc"
 	connhttp "github.com/matutetandil/mycel/internal/connector/http"
 	"github.com/matutetandil/mycel/internal/connector/mq"
-	"github.com/matutetandil/mycel/internal/connector/rest"
-	"github.com/matutetandil/mycel/internal/connector/tcp"
-	conncdc "github.com/matutetandil/mycel/internal/connector/cdc"
-	connelastic "github.com/matutetandil/mycel/internal/connector/elasticsearch"
-	connoauth "github.com/matutetandil/mycel/internal/connector/oauth"
 	connmqtt "github.com/matutetandil/mycel/internal/connector/mqtt"
-	connftp "github.com/matutetandil/mycel/internal/connector/ftp"
+	connoauth "github.com/matutetandil/mycel/internal/connector/oauth"
 	connpdf "github.com/matutetandil/mycel/internal/connector/pdf"
+	"github.com/matutetandil/mycel/internal/connector/profile"
+	"github.com/matutetandil/mycel/internal/connector/push"
+	"github.com/matutetandil/mycel/internal/connector/rest"
+	conns3 "github.com/matutetandil/mycel/internal/connector/s3"
+	"github.com/matutetandil/mycel/internal/connector/slack"
+	"github.com/matutetandil/mycel/internal/connector/sms"
 	connsoap "github.com/matutetandil/mycel/internal/connector/soap"
 	connsse "github.com/matutetandil/mycel/internal/connector/sse"
+	"github.com/matutetandil/mycel/internal/connector/tcp"
+	"github.com/matutetandil/mycel/internal/connector/webhook"
 	connws "github.com/matutetandil/mycel/internal/connector/websocket"
+	"github.com/matutetandil/mycel/internal/debug"
+	"github.com/matutetandil/mycel/internal/envdefaults"
 	"github.com/matutetandil/mycel/internal/flow"
-	"github.com/matutetandil/mycel/internal/saga"
-	"github.com/matutetandil/mycel/internal/sanitize"
 	"github.com/matutetandil/mycel/internal/functions"
 	"github.com/matutetandil/mycel/internal/health"
 	"github.com/matutetandil/mycel/internal/hotreload"
-	"github.com/matutetandil/mycel/internal/mock"
 	"github.com/matutetandil/mycel/internal/metrics"
+	"github.com/matutetandil/mycel/internal/mock"
 	"github.com/matutetandil/mycel/internal/parser"
 	"github.com/matutetandil/mycel/internal/plugin"
 	"github.com/matutetandil/mycel/internal/ratelimit"
-	goredis "github.com/redis/go-redis/v9"
+	"github.com/matutetandil/mycel/internal/saga"
+	"github.com/matutetandil/mycel/internal/sanitize"
 	"github.com/matutetandil/mycel/internal/scheduler"
 	"github.com/matutetandil/mycel/internal/statemachine"
 	msync "github.com/matutetandil/mycel/internal/sync"
@@ -75,6 +75,7 @@ import (
 	"github.com/matutetandil/mycel/internal/validate"
 	"github.com/matutetandil/mycel/internal/validator"
 	"github.com/matutetandil/mycel/internal/workflow"
+	goredis "github.com/redis/go-redis/v9"
 )
 
 // Version is the current version of Mycel.
@@ -148,8 +149,8 @@ type Runtime struct {
 	debugServer *debug.Server
 
 	// Debug suspend: event-driven connectors defer Start() until a debugger connects
-	debugSuspend       bool
-	suspendedStarters  []suspendedConnector
+	debugSuspend      bool
+	suspendedStarters []suspendedConnector
 
 	// shutdownTimeout is the maximum time to wait for graceful shutdown.
 	shutdownTimeout time.Duration
@@ -1490,6 +1491,20 @@ func (r *Runtime) startAdminServer() error {
 	// Register debug protocol (Mycel Studio IDE)
 	r.debugServer.RegisterHandlers(mux)
 
+	// Optional pprof profiling endpoints under /debug/pprof/. Opt-in via
+	// MYCEL_PPROF: off by default because pprof exposes runtime internals and
+	// the profile/trace endpoints are CPU-heavy. The admin port is internal
+	// (reachable via `kubectl port-forward`), so it's safe to enable in any
+	// environment — including production — to diagnose a live process.
+	pprofEnabled := false
+	if registerPprofHandlers(mux) {
+		pprofEnabled = true
+		r.logger.Warn("pprof profiling enabled on admin server",
+			"path", "/debug/pprof/",
+			"toggle", "MYCEL_PPROF",
+			"hint", "kubectl port-forward then: go tool pprof http://<host>:9090/debug/pprof/goroutine")
+	}
+
 	addr := fmt.Sprintf(":%d", port)
 
 	listener, err := net.Listen("tcp", addr)
@@ -1507,10 +1522,34 @@ func (r *Runtime) startAdminServer() error {
 		}
 	}()
 
-	r.logger.Info("admin server started", "port", port, "endpoints", []string{"/health", "/health/live", "/health/ready", "/metrics", "/debug"})
+	endpoints := []string{"/health", "/health/live", "/health/ready", "/metrics", "/debug"}
+	if pprofEnabled {
+		endpoints = append(endpoints, "/debug/pprof/")
+	}
+	r.logger.Info("admin server started", "port", port, "endpoints", endpoints)
 	banner.PrintConnector("admin", "http", fmt.Sprintf("health + metrics + debug on :%d", port))
 
 	return nil
+}
+
+// registerPprofHandlers mounts the net/http/pprof endpoints on the admin mux
+// when MYCEL_PPROF is set to a truthy value. Returns whether they were mounted.
+// They live under /debug/pprof/ (distinct from the Studio /debug WebSocket).
+func registerPprofHandlers(mux *http.ServeMux) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MYCEL_PPROF"))) {
+	case "1", "true", "yes", "on":
+	default:
+		return false
+	}
+
+	// pprof.Index also serves the named profiles (goroutine, heap, allocs,
+	// block, mutex, threadcreate) at /debug/pprof/<name>.
+	mux.HandleFunc("/debug/pprof/", httppprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", httppprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", httppprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", httppprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", httppprof.Trace)
+	return true
 }
 
 // registerWorkflowEndpoints adds workflow management endpoints to an HTTP mux.

--- a/internal/sync/coordinate_cache_test.go
+++ b/internal/sync/coordinate_cache_test.go
@@ -1,0 +1,53 @@
+package sync
+
+import (
+	"context"
+	"testing"
+)
+
+// TestGetCoordinator_RedisIsCachedNotPerCall guards the goroutine leak fixed in
+// v2.7.x: GetCoordinator used to return a fresh RedisCoordinator on every call,
+// and each one PSubscribes (holding a pooled Redis connection) and spawns a
+// listener goroutine that is never stopped. Called once per ExecuteWithCoordinate
+// (i.e. once per message), that leaked ~2-3 goroutines + a connection per message.
+//
+// The coordinator is a long-lived Pub/Sub hub by design, so it must be shared.
+// This test asserts GetCoordinator returns the SAME cached instance across calls.
+// (Uses a closed local port: redis.NewClient is lazy and the subscription only
+// connects in the background, so no live Redis is needed for the identity check.)
+func TestGetCoordinator_RedisIsCachedNotPerCall(t *testing.T) {
+	m := NewManager()
+	t.Cleanup(func() { _ = m.Close() })
+
+	cfg := &SyncStorageConfig{Driver: "redis", Host: "127.0.0.1", Port: 6399, DB: 0}
+
+	c1, err := m.GetCoordinator(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("GetCoordinator (1): %v", err)
+	}
+	c2, err := m.GetCoordinator(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("GetCoordinator (2): %v", err)
+	}
+
+	rc1, ok1 := c1.(*RedisCoordinator)
+	rc2, ok2 := c2.(*RedisCoordinator)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected *RedisCoordinator, got %T and %T", c1, c2)
+	}
+	if rc1 != rc2 {
+		t.Fatal("GetCoordinator returned two distinct coordinators for the same storage; " +
+			"each call PSubscribes + spawns a listener goroutine, so per-call creation leaks " +
+			"a goroutine and a Redis connection per message")
+	}
+
+	// A different storage target must still get its own coordinator.
+	cfgB := &SyncStorageConfig{Driver: "redis", Host: "127.0.0.1", Port: 6400, DB: 0}
+	c3, err := m.GetCoordinator(context.Background(), cfgB)
+	if err != nil {
+		t.Fatalf("GetCoordinator (3): %v", err)
+	}
+	if rc3, _ := c3.(*RedisCoordinator); rc3 == rc1 {
+		t.Fatal("distinct storage targets must not share a coordinator")
+	}
+}

--- a/internal/sync/coordinate_redis.go
+++ b/internal/sync/coordinate_redis.go
@@ -18,8 +18,9 @@ type RedisCoordinator struct {
 	mu      sync.RWMutex
 	waiters map[string][]chan struct{} // signal -> waiting channels
 
-	sub  *redis.PubSub
-	done chan struct{}
+	sub      *redis.PubSub
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // RedisCoordinatorConfig holds configuration for RedisCoordinator.
@@ -222,30 +223,43 @@ func (c *RedisCoordinator) Exists(ctx context.Context, signal string) (bool, err
 	return exists > 0, nil
 }
 
-// Close closes the Redis client and pub/sub.
-func (c *RedisCoordinator) Close() error {
-	close(c.done)
+// stop releases the coordinator's hub resources — the Pub/Sub subscription
+// and its listener goroutine — and unblocks any waiters, WITHOUT closing the
+// Redis client. The client may be shared (coordinators created via
+// NewRedisCoordinatorFromClient reuse the manager's cached client), so its
+// lifecycle is owned elsewhere. Idempotent and safe to call repeatedly.
+func (c *RedisCoordinator) stop() {
+	c.stopOnce.Do(func() {
+		close(c.done)
 
-	// Close pub/sub
-	if c.sub != nil {
-		c.sub.Close()
-	}
-
-	// Notify all waiters
-	c.mu.Lock()
-	for signal, waiters := range c.waiters {
-		for _, ch := range waiters {
-			select {
-			case <-ch:
-				// Already closed
-			default:
-				close(ch)
-			}
+		// Close pub/sub (stops the go-redis channel pump and frees the
+		// dedicated subscription connection).
+		if c.sub != nil {
+			c.sub.Close()
 		}
-		delete(c.waiters, signal)
-	}
-	c.mu.Unlock()
 
+		// Notify all waiters so nobody blocks forever on shutdown.
+		c.mu.Lock()
+		for signal, waiters := range c.waiters {
+			for _, ch := range waiters {
+				select {
+				case <-ch:
+					// Already closed
+				default:
+					close(ch)
+				}
+			}
+			delete(c.waiters, signal)
+		}
+		c.mu.Unlock()
+	})
+}
+
+// Close stops the coordinator and closes its Redis client. Use only when the
+// coordinator owns the client (NewRedisCoordinator). For client-shared
+// coordinators the manager calls stop() and closes the shared client itself.
+func (c *RedisCoordinator) Close() error {
+	c.stop()
 	return c.client.Close()
 }
 
@@ -266,8 +280,8 @@ func (c *RedisCoordinator) Stats(ctx context.Context) (map[string]interface{}, e
 	}
 
 	return map[string]interface{}{
-		"active_signals":    len(keys),
-		"active_waiters":    totalWaiters,
+		"active_signals":     len(keys),
+		"active_waiters":     totalWaiters,
 		"waiter_signal_keys": signalKeys,
 	}, nil
 }

--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -60,6 +60,12 @@ type Manager struct {
 	// Cached Redis clients, keyed by resolved address
 	redisClients map[string]*redis.Client
 
+	// Cached Redis coordinators, keyed by resolved address. A coordinator
+	// owns a long-lived Pub/Sub subscription + listener goroutine, so it
+	// MUST be shared across flows/messages — creating one per operation
+	// leaks the subscription (a pooled connection) and its goroutine.
+	redisCoordinators map[string]*RedisCoordinator
+
 	mu gosync.RWMutex
 }
 
@@ -71,6 +77,7 @@ func NewManager() *Manager {
 		memoryCoordinator:   NewMemoryCoordinator(time.Second),
 		memorySequenceGuard: NewMemorySequenceGuard(time.Minute),
 		redisClients:        make(map[string]*redis.Client),
+		redisCoordinators:   make(map[string]*RedisCoordinator),
 	}
 }
 
@@ -139,13 +146,40 @@ func (m *Manager) GetCoordinator(ctx context.Context, cfg *SyncStorageConfig) (C
 		return m.memoryCoordinator, nil
 	}
 	if cfg.Driver == "redis" {
-		client, err := m.getOrCreateRedisClient(cfg)
-		if err != nil {
-			return nil, err
-		}
-		return NewRedisCoordinatorFromClient(client, "mycel:coord:"), nil
+		return m.getOrCreateRedisCoordinator(cfg)
 	}
 	return nil, fmt.Errorf("unsupported sync storage driver: %s", cfg.Driver)
+}
+
+// getOrCreateRedisCoordinator returns a cached coordinator or creates one.
+// The coordinator holds a long-lived Pub/Sub subscription and listener
+// goroutine, so it must be shared — never created per operation.
+func (m *Manager) getOrCreateRedisCoordinator(cfg *SyncStorageConfig) (*RedisCoordinator, error) {
+	key := cfg.cacheKey()
+
+	m.mu.RLock()
+	if coord, ok := m.redisCoordinators[key]; ok {
+		m.mu.RUnlock()
+		return coord, nil
+	}
+	m.mu.RUnlock()
+
+	client, err := m.getOrCreateRedisClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if coord, ok := m.redisCoordinators[key]; ok {
+		return coord, nil
+	}
+
+	coord := NewRedisCoordinatorFromClient(client, "mycel:coord:")
+	m.redisCoordinators[key] = coord
+	return coord, nil
 }
 
 // GetSequenceGuard returns a SequenceGuard implementation based on the
@@ -196,6 +230,13 @@ func (m *Manager) Close() error {
 			errs = append(errs, err)
 		}
 	}
+
+	// Stop cached coordinators (pub/sub + listener goroutine) before closing
+	// the shared clients they ride on.
+	for _, coord := range m.redisCoordinators {
+		coord.stop()
+	}
+	m.redisCoordinators = make(map[string]*RedisCoordinator)
 
 	for _, client := range m.redisClients {
 		if err := client.Close(); err != nil {


### PR DESCRIPTION
Fixes a confirmed goroutine leak in the runtime (measured in dev: goroutines climbed linearly under steady ~1.2 msg/s load with an empty queue — 1705 → 3440 in ~7.4 min, ~3 goroutines per message — RSS climbing with them, heading for OOMKill; flat only when truly idle).

## Root cause

A redis-backed `coordinate` block leaked ~2-3 goroutines **and a pooled Redis connection per message**.

- `Manager.GetCoordinator` (`internal/sync/manager.go`) returned a **fresh** `NewRedisCoordinatorFromClient` on **every call**.
- `ExecuteWithCoordinate` calls `GetCoordinator` **once per execution = once per message** — unconditionally, even when the preflight skips the wait (`return fn()`).
- Each `RedisCoordinator` `PSubscribe`s to `<prefix>signal:*` (a dedicated subscription connection) and spawns `go c.listen()` (plus go-redis's own `Channel()` pump). The per-call coordinator was **never `Close()`d**, so the subscription, its connection, and the goroutines leaked permanently.

The coordinator is a **long-lived Pub/Sub hub by design** (its own doc: *"single Pub/Sub subscription hub"*) — it must be shared, like the manager's cached memory coordinator and redis clients.

### Not the cause (checked)
- **Lock heartbeat is clean** — `ExecuteWithLock` does `hbCancel()` + `<-hbDone` in a `defer` and the goroutine selects on `hbCtx.Done()`; it stops on every path. `dedupe` uses `ExecuteWithLock` too.
- Other redis primitives (lock / semaphore / sequence_guard) are stateless per call — no subscription, no goroutine.
- Fan-out chains (`ChainEventDriven`) are `wg.Wait()`-joined; the MQ worker processes synchronously; DB connectors share a pool and `defer rows.Close()`.

## The fix (`d8c9fd9`)

- **Cache** `RedisCoordinator`s in the `Manager` keyed by storage target (`getOrCreateRedisCoordinator`, double-checked locking) — one hub + listener reused across all flows and messages.
- Split `RedisCoordinator.Close()` into an idempotent `stop()` that releases the pub/sub + listener **without** closing the (shared) client; `Manager.Close()` stops cached coordinators before closing the shared clients.
- More correct as well as leak-free: the hub is now actually used as a hub.
- **Regression test**: `GetCoordinator` returns the same cached instance across calls (per-call creation *is* the leak); distinct targets get distinct hubs.

## Also: pprof on the admin server (`dbdd2f9`)

pprof wasn't mounted (`/debug/pprof/*` → 404), so this had to be found by reading code. Now opt-in via `MYCEL_PPROF` it mounts `net/http/pprof` under `/debug/pprof/` on the admin port (`:9090`). Off by default (pprof exposes internals; profile/trace are CPU-heavy), safe to enable in any environment since the admin port is internal:

```bash
MYCEL_PPROF=true ...        # on the pod
kubectl port-forward pod/<consumer> 9090:9090
curl 'http://localhost:9090/debug/pprof/goroutine?debug=2'   # would have shown thousands of (*RedisCoordinator).listen frames
```

Distinct from the Studio `/debug` WebSocket. Test covers the env gate + that the goroutine profile responds. README documents it.

## Verification

- `go test -race ./internal/sync/` clean; full suite **70 ok / 0 fail**.
- Live confirmation pending: deploy and watch goroutines flatten under load (now observable via `MYCEL_PPROF`).

No config/HCL changes; the consumer repo is untouched.