### PR TITLE
fix(metrics): expose flow metrics at /metrics (registry clobber) + bump v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2026-06-03
+
+### Fixed
+
+- **Flow metrics were recorded but never exposed at `/metrics`.** A running service recorded flow executions (`mycel_flow_executions_total`, `mycel_flow_duration_seconds`, `mycel_flow_errors_total`) but `/metrics` exposed none of them — only the Go/process collectors plus `mycel_goroutines`, `mycel_uptime_seconds`, and `mycel_service_info` showed up. The cause was `metrics.Default()`: it lazily created a fallback registry behind a `sync.Once`, and the first recorder call fired that `Once` **after** `SetDefault` had already installed the registry the admin/REST endpoint serves — clobbering it with a throwaway `"unknown"` registry that nothing exposes. Every flow/connector recorder then wrote into the orphaned registry. The metrics that *did* appear were written directly on the served registry, which is why they were unaffected. `Default()` no longer self-initializes over an assigned registry (mutex + nil-check instead of `sync.Once`), so `SetDefault` sticks and recorders write into the registry that is actually served. Message throughput is now derivable, e.g. `rate(mycel_flow_executions_total{flow="..."}[1m])`.
+
 ## [2.8.0] - 2026-06-02
 
 ### Fixed

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.8.0"
+	version = "2.8.1"
 	commit  = "dev"
 )
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,7 +14,7 @@ import (
 var (
 	// Default metrics registry
 	defaultRegistry *Registry
-	initOnce        sync.Once
+	defaultMu       sync.Mutex
 )
 
 // Registry holds all Mycel metrics.
@@ -32,9 +32,9 @@ type Registry struct {
 	ConnectorLatency    *prometheus.HistogramVec
 
 	// Flow metrics
-	FlowExecutions   *prometheus.CounterVec
-	FlowDuration     *prometheus.HistogramVec
-	FlowErrors       *prometheus.CounterVec
+	FlowExecutions *prometheus.CounterVec
+	FlowDuration   *prometheus.HistogramVec
+	FlowErrors     *prometheus.CounterVec
 
 	// Cache metrics
 	CacheHits   *prometheus.CounterVec
@@ -56,23 +56,23 @@ type Registry struct {
 	SemaphoreAvailable   *prometheus.GaugeVec
 
 	// Coordinate metrics
-	CoordinateSignal      *prometheus.CounterVec
-	CoordinateWait        *prometheus.CounterVec
-	CoordinateWaitSeconds *prometheus.HistogramVec
-	CoordinateTimeout     *prometheus.CounterVec
+	CoordinateSignal       *prometheus.CounterVec
+	CoordinateWait         *prometheus.CounterVec
+	CoordinateWaitSeconds  *prometheus.HistogramVec
+	CoordinateTimeout      *prometheus.CounterVec
 	CoordinatePreflightHit *prometheus.CounterVec
-	CoordinateActiveWaits *prometheus.GaugeVec
+	CoordinateActiveWaits  *prometheus.GaugeVec
 
 	// Scheduler metrics
 	ScheduledFlows   *prometheus.GaugeVec
 	ScheduleExecuted *prometheus.CounterVec
 
 	// Profile metrics
-	ProfileActive    *prometheus.GaugeVec
-	ProfileRequests  *prometheus.CounterVec
-	ProfileErrors    *prometheus.CounterVec
-	ProfileFallback  *prometheus.CounterVec
-	ProfileLatency   *prometheus.HistogramVec
+	ProfileActive   *prometheus.GaugeVec
+	ProfileRequests *prometheus.CounterVec
+	ProfileErrors   *prometheus.CounterVec
+	ProfileFallback *prometheus.CounterVec
+	ProfileLatency  *prometheus.HistogramVec
 
 	// Runtime metrics
 	UptimeSeconds *prometheus.GaugeVec
@@ -591,16 +591,28 @@ func (r *Registry) SetGoRoutines(count int) {
 	r.GoRoutines.Set(float64(count))
 }
 
-// Default returns the default metrics registry.
-// Creates one with default settings if not already initialized.
+// Default returns the default metrics registry, lazily creating a fallback one
+// only if SetDefault was never called. Recorders (RecordFlowExecution, etc.)
+// route through here, so it MUST return the same registry the runtime serves.
+//
+// Previously this used a sync.Once to lazy-init, which clobbered the registry
+// SetDefault had assigned: the first Default() call fired the Once and replaced
+// the runtime's registry with a throwaway "unknown" one that nothing serves —
+// so flow/connector metrics were recorded but never exposed at /metrics.
 func Default() *Registry {
-	initOnce.Do(func() {
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
+	if defaultRegistry == nil {
 		defaultRegistry = NewRegistry("mycel", "unknown", "unknown", "unknown")
-	})
+	}
 	return defaultRegistry
 }
 
-// SetDefault sets the default metrics registry.
+// SetDefault sets the default metrics registry. The runtime calls this during
+// startup so every recorder writes into the same registry the admin/REST
+// endpoint serves.
 func SetDefault(r *Registry) {
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
 	defaultRegistry = r
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
@@ -273,7 +272,6 @@ func TestRegistry_Handler(t *testing.T) {
 func TestDefault(t *testing.T) {
 	// Reset default
 	defaultRegistry = nil
-	initOnce = sync.Once{}
 
 	reg := Default()
 	if reg == nil {
@@ -284,6 +282,30 @@ func TestDefault(t *testing.T) {
 	reg2 := Default()
 	if reg != reg2 {
 		t.Error("expected same instance")
+	}
+}
+
+// TestSetDefaultNotClobberedByLazyInit guards a production bug: a sync.Once in
+// Default() used to overwrite the registry SetDefault had assigned, the first
+// time Default() was called — so recorders wrote into a throwaway registry that
+// nothing served, and flow/connector metrics never appeared at /metrics.
+func TestSetDefaultNotClobberedByLazyInit(t *testing.T) {
+	defaultRegistry = nil
+
+	custom := NewRegistry("svc", "1.0.0", "2.0.0", "test")
+	SetDefault(custom)
+
+	// The FIRST Default() call must not replace what SetDefault assigned.
+	if got := Default(); got != custom {
+		t.Fatalf("Default() clobbered the registry set by SetDefault: got %p, want %p", got, custom)
+	}
+	// A metric recorded via Default() must be visible on custom's handler.
+	Default().RecordFlowExecution("f", "success", 0)
+
+	rec := httptest.NewRecorder()
+	custom.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if !strings.Contains(rec.Body.String(), "mycel_flow_executions_total") {
+		t.Fatal("flow metric recorded via Default() is not exposed by the registry SetDefault assigned")
 	}
 }
 

--- a/internal/runtime/metrics_exposure_test.go
+++ b/internal/runtime/metrics_exposure_test.go
@@ -1,0 +1,96 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matutetandil/mycel/internal/metrics"
+)
+
+// TestFlowMetricsExposedOnAdminServer guards a production bug: on a service
+// without a REST connector (e.g. an MQ consumer), flow metrics are recorded on
+// every execution via metrics.Default() (flow_registry.go), yet `mycel_flow_*`
+// never appeared at /metrics.
+//
+// Root cause: Default() lazy-initialised through a sync.Once that clobbered the
+// registry SetDefault had assigned — the first Default() call replaced the
+// runtime's registry with a throwaway one nothing serves. This test records the
+// way the flow handler does and asserts the series is exposed on the admin endpoint.
+func TestFlowMetricsExposedOnAdminServer(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "mycel-metrics-repro-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	const port = 19097
+	configHCL := `
+service {
+  name    = "metrics-repro"
+  version = "1.0.0"
+  admin_port = 19097
+}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(configHCL), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rt, err := startTestRuntime(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("start runtime: %v", err)
+	}
+	defer rt.Shutdown()
+	waitForServer(t, port)
+
+	// Record a flow execution the same way FlowHandler.HandleRequest does:
+	// through the package-level Default() registry.
+	metrics.Default().RecordFlowExecution("repro_flow", "success", 5*time.Millisecond)
+
+	body := scrapeText(t, fmt.Sprintf("http://localhost:%d/metrics", port))
+	if !strings.Contains(body, "mycel_flow_executions_total") {
+		t.Fatalf("flow metrics recorded via metrics.Default() are NOT exposed on the admin /metrics "+
+			"(metrics.Default() must be the same registry the server serves). mycel_* families present: %s",
+			familiesPresent(body))
+	}
+}
+
+func scrapeText(t *testing.T, url string) string {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}
+
+// familiesPresent lists the mycel_* metric family names in the body, for a
+// readable failure message.
+func familiesPresent(body string) string {
+	seen := map[string]bool{}
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "mycel_") {
+			name := line
+			if i := strings.IndexAny(name, "{ "); i >= 0 {
+				name = name[:i]
+			}
+			seen[name] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	return strings.Join(names, ", ")
+}


### PR DESCRIPTION
## What

Fixes a bug where flow metrics were **recorded but never exposed** at `/metrics`. A running service emitted only the Go/process collectors plus `mycel_goroutines`, `mycel_uptime_seconds`, and `mycel_service_info` — `mycel_flow_executions_total`, `mycel_flow_duration_seconds`, and `mycel_flow_errors_total` were all missing, even under full load.

## Root cause

`metrics.Default()` lazily created a fallback registry behind a `sync.Once`. The runtime calls `SetDefault(metricsReg)` at startup to install the registry the admin/REST endpoint serves, but the first recorder call (`RecordFlowExecution`) fired the `Once` **after** that — replacing the served registry with a throwaway `"unknown"` one that nothing exposes. Every flow/connector recorder then wrote into the orphaned registry.

The metrics that *did* show up (`mycel_goroutines`/`uptime`/`service_info`) are written directly on the served registry, which is why they were unaffected — and why the bug was easy to miss.

## Fix

`Default()` no longer self-initializes over an already-assigned registry: a mutex + nil-check replaces the `sync.Once`, so `SetDefault` sticks and recorders write into the registry that is actually served.

## Verification

- New hermetic repro `internal/runtime/metrics_exposure_test.go` (red before, green after).
- Live A/B on the real binary against **v2.8.0** (the deployed buggy version), example `examples/basic` (REST → SQLite), admin on an isolated port:
  - **v2.8.0:** 29 requests → **0** `mycel_flow_*` exposed.
  - **this branch:** same 29 requests → full `mycel_flow_*`, counts matching traffic exactly (`get_users` success=25, `create_user` error=1, duration histograms correct).
- `go build ./...` clean, `go test ./internal/metrics/... ./internal/runtime/...` green, `-race` clean.

Message throughput is now derivable, e.g. `rate(mycel_flow_executions_total{flow="..."}[1m])`.

## Changes

- `internal/metrics/metrics.go` — drop `sync.Once`, guard `Default()`/`SetDefault()` with a mutex + nil-check.
- `internal/runtime/metrics_exposure_test.go` — new end-to-end exposure test.
- `internal/metrics/metrics_test.go` — cover the clobber case.
- `cmd/mycel/main.go` + `CHANGELOG.md` — bump to **2.8.1**.

## Notes

Many other metrics (connector/lock/semaphore/coordinate/cache/schedule) are defined but still have no call-sites — out of scope here, tracked separately.