### PR TITLE
feat(logging): incoming payload logging via MYCEL_PAYLOAD_SHOW (v2.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2026-06-04
+
+### Added
+
+- **Incoming payload logging via `MYCEL_PAYLOAD_SHOW`.** Set `MYCEL_PAYLOAD_SHOW=true` (together with `MYCEL_LOG_LEVEL=debug`) to log the raw payload entering every flow, regardless of source connector — a queue message, an HTTP body, a TCP frame, etc. Previously the only way to see an incoming payload was `--verbose-flow`, which traces every pipeline stage and is disabled outside development mode; this logs *just* the incoming payload at the single choke-point all requests pass through (`FlowHandler.HandleRequest`), so it works for every connector and in any environment, including production. The payload is logged raw, on entry — before sanitization and validation — so the line appears even for requests that later fail validation. Off by default because payloads may carry PII or secrets.
+
+  ```bash
+  MYCEL_LOG_LEVEL=debug MYCEL_PAYLOAD_SHOW=true mycel start
+  # DBG incoming payload flow=create_user source=api payload={"name":"Ada","email":"..."}
+  ```
+
+  `MYCEL_PAYLOAD_SIZE` caps the logged size (default `4k`; accepts a plain byte count or a `k`/`m` suffix, e.g. `512`, `4k`, `1m`), with truncated payloads marked `…(truncated, N bytes total)`. Both `MYCEL_PAYLOAD_SHOW=true` and debug level are required; setting `MYCEL_PAYLOAD_SHOW=true` without debug logs a one-time startup warning. The `Enabled()` guard skips JSON marshalling unless debug logging is active, so there is no hot-path cost when it isn't.
+
 ## [2.8.1] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -260,6 +260,13 @@ mycel start --verbose-flow
 
 All debug features are **development-only** — automatically disabled in staging/production with zero overhead.
 
+**Incoming payload logging.** To see the raw payload entering a flow — regardless of source connector, and in any environment including production — set `MYCEL_PAYLOAD_SHOW=true` together with `MYCEL_LOG_LEVEL=debug`. It logs the payload on entry (before sanitization/validation) at the single choke-point every request passes through, so it works for queues, HTTP, TCP, etc. Off by default (payloads may carry PII/secrets); `MYCEL_PAYLOAD_SIZE` caps the logged size (default `4k`, e.g. `512`/`4k`/`1m`).
+
+```bash
+MYCEL_LOG_LEVEL=debug MYCEL_PAYLOAD_SHOW=true mycel start
+# DBG incoming payload flow=create_user source=api payload={"name":"Ada","email":"..."}
+```
+
 **Profiling (`pprof`).** For diagnosing a live process — goroutine leaks, heap growth, CPU hotspots — set `MYCEL_PPROF=true` to mount the Go `net/http/pprof` endpoints under `/debug/pprof/` on the admin server (`:9090`). It's off by default and safe to enable in any environment, including production: the admin port is internal (reach it with `kubectl port-forward`). Then:
 
 ```bash
@@ -287,7 +294,7 @@ mycel plugin remove <name>
 mycel plugin update [name]
 ```
 
-Environment: `MYCEL_ENV` (default: development), `MYCEL_LOG_LEVEL` (default: info), `MYCEL_LOG_FORMAT` (default: text), `MYCEL_PPROF` (default: off — mounts `pprof` on the admin server when truthy). Flags take precedence.
+Environment: `MYCEL_ENV` (default: development), `MYCEL_LOG_LEVEL` (default: info), `MYCEL_LOG_FORMAT` (default: text), `MYCEL_PPROF` (default: off — mounts `pprof` on the admin server when truthy), `MYCEL_PAYLOAD_SHOW` (default: off — logs incoming flow payloads at debug level) with `MYCEL_PAYLOAD_SIZE` (default: `4k`). Flags take precedence.
 
 See the [Debugging Guide](docs/guides/debugging.md) for `mycel trace` usage and examples.
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.8.1"
+	version = "2.9.0"
 	commit  = "dev"
 )
 
@@ -55,9 +55,11 @@ Quick Start:
   mycel check --config ./my-service     Test connector connectivity
 
 Environment Variables:
-  MYCEL_ENV         Environment (development, staging, production)
-  MYCEL_LOG_LEVEL   Log level (debug, info, warn, error)
-  MYCEL_LOG_FORMAT  Log format (text, json)
+  MYCEL_ENV          Environment (development, staging, production)
+  MYCEL_LOG_LEVEL    Log level (debug, info, warn, error)
+  MYCEL_LOG_FORMAT   Log format (text, json)
+  MYCEL_PAYLOAD_SHOW Log incoming flow payloads (requires debug level)
+  MYCEL_PAYLOAD_SIZE Max logged payload bytes (e.g. 512, 4k, 1m; default 4k)
 
 Documentation:
   https://github.com/matutetandil/mycel`,
@@ -317,14 +319,23 @@ func runStart(cmd *cobra.Command, args []string) error {
 		effectiveDebugSuspend = false
 	}
 
+	// Incoming-payload debug logging (MYCEL_PAYLOAD_SHOW / MYCEL_PAYLOAD_SIZE).
+	// Payloads only emit at debug level, so warn if opted in without it.
+	payloadCfg := logging.PayloadLogFromEnv()
+	if payloadCfg.Show && !logger.Enabled(context.Background(), slog.LevelDebug) {
+		logger.Warn("MYCEL_PAYLOAD_SHOW=true but log level is not debug; payloads will not be logged. Set MYCEL_LOG_LEVEL=debug.")
+	}
+
 	// Create runtime
 	rt, err := runtime.New(runtime.Options{
-		ConfigDir:    configDir,
-		Environment:  env,
-		Logger:       logger,
-		HotReload:    hotReloadEnabled,
-		VerboseFlow:  effectiveVerboseFlow,
-		DebugSuspend: effectiveDebugSuspend,
+		ConfigDir:       configDir,
+		Environment:     env,
+		Logger:          logger,
+		HotReload:       hotReloadEnabled,
+		VerboseFlow:     effectiveVerboseFlow,
+		ShowPayload:     payloadCfg.Show,
+		PayloadMaxBytes: payloadCfg.MaxBytes,
+		DebugSuspend:    effectiveDebugSuspend,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create runtime: %w", err)

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -29,6 +29,7 @@ All debug features (breakpoints, DAP, verbose flow) are **development-only** —
   - [Start Suspended Mode](#start-suspended-mode)
 - [Verbose Flow Logging](#verbose-flow-logging)
 - [Log-Level Debugging](#log-level-debugging)
+- [Incoming Payload Logging](#incoming-payload-logging)
 - [Local vs Docker](#local-vs-docker)
 - [Troubleshooting](#troubleshooting)
 - [CLI Reference](#cli-reference)
@@ -599,6 +600,40 @@ Log levels from most to least verbose:
 
 ---
 
+## Incoming Payload Logging
+
+When you need to see the **raw payload entering a flow** — no matter which connector it came from (a queue message, an HTTP body, a TCP frame, etc.) — opt in with `MYCEL_PAYLOAD_SHOW`. Mycel logs the payload at the single choke-point every request passes through, so it works for **every** source connector and in **any** environment (including production — unlike `--verbose-flow`, which is dev-only).
+
+```bash
+# Show incoming payloads (requires debug level to actually emit)
+MYCEL_LOG_LEVEL=debug MYCEL_PAYLOAD_SHOW=true mycel start
+
+# Cap how much of the payload is logged (default 4k)
+MYCEL_LOG_LEVEL=debug MYCEL_PAYLOAD_SHOW=true MYCEL_PAYLOAD_SIZE=512 mycel start
+```
+
+Example output (one line per request, regardless of connector):
+
+```
+DBG incoming payload flow=create_user source=api payload={"name":"Ada","email":"Ada@Example.com","age":36}
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MYCEL_PAYLOAD_SHOW` | `false` | Opt in to logging the incoming payload of every flow. |
+| `MYCEL_PAYLOAD_SIZE` | `4k` | Truncation cap. Accepts bytes or a `k`/`m` suffix (`512`, `4k`, `1m`). Truncated payloads are marked `…(truncated, N bytes total)`. |
+
+Notes:
+
+- **Both `MYCEL_PAYLOAD_SHOW=true` and debug level are required.** Payloads only emit at debug level; if you set `MYCEL_PAYLOAD_SHOW=true` without it, Mycel logs a one-time warning at startup and nothing else.
+- **The payload is logged raw, on entry — before sanitization and validation.** This is what you want for "what did the client actually send me?", and it means the line appears even for requests that later fail validation.
+- **Off by default for a reason.** Payloads may contain PII or secrets. Enable it deliberately, and prefer a small `MYCEL_PAYLOAD_SIZE` when you only need to confirm shape.
+- The `Enabled()` guard skips JSON marshalling entirely unless debug logging is active, so leaving `MYCEL_PAYLOAD_SHOW=true` set with a non-debug level has no runtime cost.
+
+This differs from [Verbose Flow Logging](#verbose-flow-logging): that traces *every pipeline stage* (sanitize → validate → transform → write) and is dev-only; this logs *just the incoming payload* and runs anywhere.
+
+---
+
 ## Local vs Docker
 
 For the best debugging experience, **run Mycel locally**:
@@ -719,6 +754,8 @@ Flags:
 
 Environment Variables:
   MYCEL_DEBUG_SUSPEND=true   Same as --debug-suspend
+  MYCEL_PAYLOAD_SHOW=true    Log the incoming payload of every flow (requires debug level)
+  MYCEL_PAYLOAD_SIZE=4k      Max logged payload bytes (e.g. 512, 4k, 1m; default 4k)
 
 Global Flags:
   -c, --config string   Configuration directory (default ".")

--- a/internal/logging/payload.go
+++ b/internal/logging/payload.go
@@ -1,0 +1,87 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Payload logging environment variables.
+const (
+	// EnvPayloadShow opts in to logging the incoming payload of every flow.
+	// It is independent of MYCEL_LOG_LEVEL, but payloads are only emitted at
+	// debug level, so both must be set to actually see them. Kept off by
+	// default because payloads may contain PII or secrets.
+	EnvPayloadShow = "MYCEL_PAYLOAD_SHOW"
+
+	// EnvPayloadSize caps how many bytes of the (JSON-encoded) payload are
+	// logged. Accepts a plain byte count or a size with a k/m suffix
+	// (e.g. "512", "4k", "1m"). Defaults to DefaultPayloadMaxBytes.
+	EnvPayloadSize = "MYCEL_PAYLOAD_SIZE"
+)
+
+// DefaultPayloadMaxBytes is the truncation cap used when MYCEL_PAYLOAD_SIZE
+// is unset or unparseable.
+const DefaultPayloadMaxBytes = 4096
+
+// PayloadLogConfig controls debug logging of incoming flow payloads.
+type PayloadLogConfig struct {
+	// Show enables logging the incoming payload. Off by default.
+	Show bool
+
+	// MaxBytes is the truncation cap for the logged payload.
+	MaxBytes int
+}
+
+// PayloadLogFromEnv builds a PayloadLogConfig from environment variables,
+// falling back to safe defaults (disabled, 4k cap).
+func PayloadLogFromEnv() PayloadLogConfig {
+	cfg := PayloadLogConfig{
+		Show:     false,
+		MaxBytes: DefaultPayloadMaxBytes,
+	}
+
+	if v := os.Getenv(EnvPayloadShow); v != "" {
+		cfg.Show = strings.EqualFold(v, "true") || v == "1"
+	}
+
+	if v := os.Getenv(EnvPayloadSize); v != "" {
+		if n, err := ParseSize(v); err == nil && n > 0 {
+			cfg.MaxBytes = n
+		}
+	}
+
+	return cfg
+}
+
+// ParseSize parses a human-friendly byte size. It accepts a plain integer
+// (bytes) or an integer with a single k/m suffix (case-insensitive, decimal
+// units: 1k = 1024, 1m = 1024*1024). A "b" suffix is treated as bytes.
+func ParseSize(s string) (int, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+
+	mult := 1
+	switch s[len(s)-1] {
+	case 'k':
+		mult = 1024
+		s = s[:len(s)-1]
+	case 'm':
+		mult = 1024 * 1024
+		s = s[:len(s)-1]
+	case 'b':
+		s = s[:len(s)-1]
+	}
+
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q: %w", s, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("negative size %q", s)
+	}
+	return n * mult, nil
+}

--- a/internal/logging/payload_test.go
+++ b/internal/logging/payload_test.go
@@ -1,0 +1,80 @@
+package logging
+
+import (
+	"testing"
+)
+
+func TestParseSize(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"512", 512, false},
+		{"4k", 4096, false},
+		{"4K", 4096, false},
+		{"1m", 1024 * 1024, false},
+		{"1M", 1024 * 1024, false},
+		{"2048b", 2048, false},
+		{" 4k ", 4096, false},
+		{"0", 0, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"-1", 0, true},
+		{"4kk", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseSize(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("ParseSize(%q): expected error, got %d", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseSize(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseSize(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPayloadLogFromEnv(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		t.Setenv(EnvPayloadShow, "")
+		t.Setenv(EnvPayloadSize, "")
+		cfg := PayloadLogFromEnv()
+		if cfg.Show {
+			t.Error("Show should default to false")
+		}
+		if cfg.MaxBytes != DefaultPayloadMaxBytes {
+			t.Errorf("MaxBytes = %d, want %d", cfg.MaxBytes, DefaultPayloadMaxBytes)
+		}
+	})
+
+	t.Run("show true and custom size", func(t *testing.T) {
+		t.Setenv(EnvPayloadShow, "true")
+		t.Setenv(EnvPayloadSize, "8k")
+		cfg := PayloadLogFromEnv()
+		if !cfg.Show {
+			t.Error("Show should be true")
+		}
+		if cfg.MaxBytes != 8192 {
+			t.Errorf("MaxBytes = %d, want 8192", cfg.MaxBytes)
+		}
+	})
+
+	t.Run("invalid size falls back to default", func(t *testing.T) {
+		t.Setenv(EnvPayloadShow, "1")
+		t.Setenv(EnvPayloadSize, "garbage")
+		cfg := PayloadLogFromEnv()
+		if !cfg.Show {
+			t.Error("Show should be true for \"1\"")
+		}
+		if cfg.MaxBytes != DefaultPayloadMaxBytes {
+			t.Errorf("MaxBytes = %d, want default %d", cfg.MaxBytes, DefaultPayloadMaxBytes)
+		}
+	})
+}

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -20,6 +20,7 @@ import (
 	"github.com/matutetandil/mycel/internal/connector/cache"
 	"github.com/matutetandil/mycel/internal/flow"
 	"github.com/matutetandil/mycel/internal/functions"
+	"github.com/matutetandil/mycel/internal/logging"
 	"github.com/matutetandil/mycel/internal/metrics"
 	"github.com/matutetandil/mycel/internal/sanitize"
 	"github.com/matutetandil/mycel/internal/trace"
@@ -165,6 +166,14 @@ type FlowHandler struct {
 	// VerboseFlow enables per-request trace logging via LogCollector.
 	VerboseFlow bool
 
+	// ShowPayload logs the incoming payload at debug level on entry,
+	// regardless of source connector (MYCEL_PAYLOAD_SHOW).
+	ShowPayload bool
+
+	// PayloadMaxBytes caps the logged payload size before truncation
+	// (MYCEL_PAYLOAD_SIZE).
+	PayloadMaxBytes int
+
 	// DebugServer provides access to the Studio debug protocol server.
 	// When a debug client is connected, trace context and breakpoints are injected.
 	DebugServer *debug.Server
@@ -186,6 +195,37 @@ type FlowHandler struct {
 // Used for backwards compatibility when no rejection policy is configured.
 var FilteredResult = &struct{ Filtered bool }{Filtered: true}
 
+// logIncomingPayload emits the raw incoming payload at debug level when
+// MYCEL_PAYLOAD_SHOW opted in. The Enabled() guard skips the JSON marshal
+// entirely unless debug logging is actually active.
+func (h *FlowHandler) logIncomingPayload(ctx context.Context, input map[string]interface{}) {
+	if !h.ShowPayload || h.Logger == nil || !h.Logger.Enabled(ctx, slog.LevelDebug) {
+		return
+	}
+	h.Logger.LogAttrs(ctx, slog.LevelDebug, "incoming payload",
+		slog.String("flow", h.Config.Name),
+		slog.String("source", h.Config.From.Connector),
+		slog.String("payload", formatPayload(input, h.PayloadMaxBytes)),
+	)
+}
+
+// formatPayload renders a payload as JSON for debug logging, truncating to
+// maxBytes (a non-positive maxBytes falls back to the default cap). A
+// truncation marker is appended so cut payloads are obvious in the logs.
+func formatPayload(payload interface{}, maxBytes int) string {
+	if maxBytes <= 0 {
+		maxBytes = logging.DefaultPayloadMaxBytes
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		b = []byte(fmt.Sprintf("%v", payload))
+	}
+	if len(b) > maxBytes {
+		return fmt.Sprintf("%s…(truncated, %d bytes total)", b[:maxBytes], len(b))
+	}
+	return string(b)
+}
+
 // HandleRequest processes an incoming request through the flow.
 func (h *FlowHandler) HandleRequest(ctx context.Context, input map[string]interface{}) (result interface{}, err error) {
 	h.Logger.Info("HandleRequest entered",
@@ -194,6 +234,11 @@ func (h *FlowHandler) HandleRequest(ctx context.Context, input map[string]interf
 		"hasClients", h.DebugServer != nil && h.DebugServer.HasClients(),
 		"isTracing", trace.IsTracing(ctx),
 	)
+
+	// Log the raw incoming payload when explicitly opted in via
+	// MYCEL_PAYLOAD_SHOW. This is the single choke-point every connector's
+	// payload passes through, so it works regardless of source.
+	h.logIncomingPayload(ctx, input)
 
 	// Attach Studio debug context when a debug client is connected.
 	// This takes priority over verbose flow to ensure breakpoints work.

--- a/internal/runtime/payload_log_test.go
+++ b/internal/runtime/payload_log_test.go
@@ -1,0 +1,86 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+// newPayloadTestHandler builds a minimal FlowHandler wired to a buffer logger
+// at the given level, sufficient to exercise logIncomingPayload.
+func newPayloadTestHandler(level slog.Level, show bool, maxBytes int) (*FlowHandler, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: level}))
+	h := &FlowHandler{
+		Config: &flow.Config{
+			Name: "ingest_orders",
+			From: &flow.FromConfig{Connector: "orders_queue"},
+		},
+		Logger:          logger,
+		ShowPayload:     show,
+		PayloadMaxBytes: maxBytes,
+	}
+	return h, buf
+}
+
+func TestLogIncomingPayload_ShowsAtDebug(t *testing.T) {
+	h, buf := newPayloadTestHandler(slog.LevelDebug, true, 4096)
+	h.logIncomingPayload(context.Background(), map[string]interface{}{
+		"order_id": "A-1",
+		"email":    "Foo@Bar.com",
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "incoming payload") {
+		t.Fatalf("expected 'incoming payload' line, got: %s", out)
+	}
+	if !strings.Contains(out, "orders_queue") {
+		t.Errorf("expected source connector in log, got: %s", out)
+	}
+	if !strings.Contains(out, "A-1") || !strings.Contains(out, "Foo@Bar.com") {
+		t.Errorf("expected payload contents in log, got: %s", out)
+	}
+}
+
+func TestLogIncomingPayload_DisabledWhenShowFalse(t *testing.T) {
+	h, buf := newPayloadTestHandler(slog.LevelDebug, false, 4096)
+	h.logIncomingPayload(context.Background(), map[string]interface{}{"k": "v"})
+	if strings.Contains(buf.String(), "incoming payload") {
+		t.Errorf("payload should not be logged when ShowPayload=false, got: %s", buf.String())
+	}
+}
+
+func TestLogIncomingPayload_SilentBelowDebug(t *testing.T) {
+	// MYCEL_PAYLOAD_SHOW=true but level is info: nothing should be emitted.
+	h, buf := newPayloadTestHandler(slog.LevelInfo, true, 4096)
+	h.logIncomingPayload(context.Background(), map[string]interface{}{"k": "v"})
+	if strings.Contains(buf.String(), "incoming payload") {
+		t.Errorf("payload should not be logged below debug level, got: %s", buf.String())
+	}
+}
+
+func TestLogIncomingPayload_Truncates(t *testing.T) {
+	big := strings.Repeat("x", 5000)
+	h, buf := newPayloadTestHandler(slog.LevelDebug, true, 100)
+	h.logIncomingPayload(context.Background(), map[string]interface{}{"blob": big})
+
+	out := buf.String()
+	if !strings.Contains(out, "truncated") {
+		t.Errorf("expected truncation marker, got: %s", out)
+	}
+	// The full 5000-char blob must not be present verbatim.
+	if strings.Contains(out, big) {
+		t.Errorf("payload was not truncated")
+	}
+}
+
+func TestFormatPayload_DefaultCapWhenNonPositive(t *testing.T) {
+	got := formatPayload(map[string]interface{}{"a": 1}, 0)
+	if got != `{"a":1}` {
+		t.Errorf("formatPayload = %q, want %q", got, `{"a":1}`)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -136,6 +136,10 @@ type Runtime struct {
 	// Verbose flow tracing (logs all pipeline stages per request)
 	verboseFlow bool
 
+	// Incoming payload debug logging (MYCEL_PAYLOAD_SHOW / MYCEL_PAYLOAD_SIZE)
+	showPayload     bool
+	payloadMaxBytes int
+
 	// Hot reload components
 	hotReloadEnabled bool
 	hotReloader      *hotreload.Reloader
@@ -192,6 +196,15 @@ type Options struct {
 	// When true, every pipeline stage (sanitize, validate, transform, read/write)
 	// is logged at debug level for all flows.
 	VerboseFlow bool
+
+	// ShowPayload logs the incoming payload of every flow at debug level,
+	// regardless of source connector. Off by default (payloads may carry
+	// PII/secrets); driven by MYCEL_PAYLOAD_SHOW.
+	ShowPayload bool
+
+	// PayloadMaxBytes caps how many bytes of the logged payload are emitted
+	// before truncation. Driven by MYCEL_PAYLOAD_SIZE.
+	PayloadMaxBytes int
 
 	// MockConnectors is a comma-separated list of connectors to mock.
 	// Empty means mock all when mocking is enabled.
@@ -498,6 +511,8 @@ func New(opts Options) (*Runtime, error) {
 		environment:       env,
 		configDir:         opts.ConfigDir,
 		verboseFlow:       opts.VerboseFlow,
+		showPayload:       opts.ShowPayload,
+		payloadMaxBytes:   opts.PayloadMaxBytes,
 		hotReloadEnabled:  opts.HotReload,
 		debugSuspend:      opts.DebugSuspend,
 		shutdownTimeout:   opts.ShutdownTimeout,
@@ -1210,6 +1225,8 @@ func (r *Runtime) registerFlows() error {
 			ValidatorRegistry:  r.validatorRegistry,
 			Logger:             r.logger,
 			VerboseFlow:        r.verboseFlow,
+			ShowPayload:        r.showPayload,
+			PayloadMaxBytes:    r.payloadMaxBytes,
 			DebugServer:        r.debugServer,
 		}
 


### PR DESCRIPTION
## What

Adds an opt-in, env-driven way to see the **raw payload entering any flow**, regardless of source connector.

```bash
MYCEL_LOG_LEVEL=debug MYCEL_PAYLOAD_SHOW=true mycel start
# DBG incoming payload flow=create_user source=api payload={"name":"Ada","email":"..."}
```

## Why

`MYCEL_LOG_LEVEL=debug` only sets the slog level — it never logged the incoming payload. The only existing path was `--verbose-flow`, which traces *every* pipeline stage and is **dev-only** (force-disabled outside development). There was no simple "show me what the client actually sent" knob that works in production.

## How

- Logs at `FlowHandler.HandleRequest` — the single choke-point every request passes through — so it works for **every** connector (queue, HTTP, TCP, …) and in **any** environment, including production.
- The payload is logged **raw, on entry — before sanitization and validation**, so the line appears even for requests that later fail validation.
- Emits at **debug** level, so both `MYCEL_PAYLOAD_SHOW=true` **and** `MYCEL_LOG_LEVEL=debug` are required. Opting in without debug logs a one-time startup warning.
- `MYCEL_PAYLOAD_SIZE` caps the logged size (default `4k`; accepts `512`/`4k`/`1m`), truncated payloads marked `…(truncated, N bytes total)`.
- **Off by default** (payloads may carry PII/secrets). The `Enabled()` guard skips JSON marshalling unless debug is active → no hot-path cost when off.

## Env vars

| Variable | Default | Description |
|----------|---------|-------------|
| `MYCEL_PAYLOAD_SHOW` | `false` | Opt in to logging the incoming payload of every flow. |
| `MYCEL_PAYLOAD_SIZE` | `4k` | Truncation cap (bytes, or `k`/`m` suffix). |

## Tests

- `internal/logging/payload_test.go` — size parser + env config.
- `internal/runtime/payload_log_test.go` — gate (show/no-show), silence below debug, truncation, default cap.
- Full suite green (`go test ./...`, `-race` clean).
- Verified against the real binary on `examples/basic`: POST logged the raw payload before validation; negative cases (show=false → nothing; show=true + info level → startup warning + nothing) confirmed.

## Docs

- `README.md` — debugging section + env var list.
- `docs/guides/debugging.md` — new "Incoming Payload Logging" section + TOC + CLI reference.
- `CHANGELOG.md` — `[2.9.0]`.

Bumps version to **2.9.0**.