### PR TITLE
chore: bump version to 2.9.1

### DIFF
--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.9.0"
+	version = "2.9.1"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Bumps the CLI version constant to 2.9.1 for the consumer/CDC reconnect release (#27).

See CHANGELOG `[2.9.1]`: RabbitMQ consumers and CDC (Postgres logical replication) now reconnect and resume after a connection drop instead of becoming silent non-consuming zombies until a process restart.

Tag `v2.9.1` to follow once merged.