### PR TITLE
chore: bump version to 2.10.0

### DIFF
--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.9.1"
+	version = "2.10.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Bumps the CLI version constant to 2.10.0 for the OpenTelemetry distributed tracing release (#29).

See CHANGELOG `[2.10.0]`: opt-in OTLP tracing — root span per flow, inbound/outbound W3C context propagation (HTTP + RabbitMQ + Kafka), depth spans (transform / transaction / each), and trace↔log correlation. Off by default, no-op when unconfigured.

Tag `v2.10.0` to follow once merged.