### PR TITLE
fix(docker): bump builder image to golang:1.25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+# Go 1.25: go.mod requires >= 1.25 (grpc / golang.org/x/* pulled in by the
+# OpenTelemetry deps declare go 1.25). Keep in sync with the go directive.
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /build
 

--- a/tests/integration/mock-server/Dockerfile
+++ b/tests/integration/mock-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /build
 COPY main.go .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o mock-server main.go


### PR DESCRIPTION
The v2.10.0 release Docker build failed with `go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`.

The OpenTelemetry deps (#29) pulled in grpc and `golang.org/x/*` versions that declare `go 1.25`, so `go mod tidy` bumped the module's go directive to 1.25.0. CI was unaffected (it installs Go via `go-version-file: go.mod`), but the release Dockerfile was pinned to `golang:1.24-alpine` with `GOTOOLCHAIN=local`.

Bumps both builder images (release + integration mock-server) to `golang:1.25-alpine` to match the go directive.