### PR TITLE
chore: bump version to 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.11.0] - 2026-07-04
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.10.0"
+	version = "2.11.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Bumps the binary version to 2.11.0 and dates the CHANGELOG entry.

Release highlights (merged in #32):
- HTTP QUERY method (RFC 10008) supported end-to-end — server, runtime read path + cache, client, QUERY proxying, `Accept-Query`, IDE, conditional OpenAPI 3.2 export, and the [`examples/query-method`](examples/query-method) example.
- HTTP connector fixes: the schema-documented `"METHOD /path"` operation form works now (DB-flavored operations no longer clobber the verb or drop the body), and `Call` is implemented — saga, state machine, and step actions against HTTP APIs work end-to-end, compensations included.