### PR TITLE
Name the missing environment variable in connector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Connector startup errors now name the missing environment variable.** An `env("X")` call for an unset variable with no default silently evaluates to an empty string, so the connector factory failed with a generic message (`http connector requires base_url`) that gave no clue about the real cause. Connector blocks are now scanned at parse time for unresolved `env()` calls, and a registration failure appends them to the error:
+
+  ```
+  ✗ failed to register connector url_ms: factory failed to create connector url_ms: http connector requires base_url
+        → Missing environment variable "URL_MS_BASE", required by connector "url_ms" (base_url)
+  ```
+
+  Nested blocks keep their path (`consumer.queue`), `env("X", "default")` calls are never reported, and the hint only appears when registration actually fails.
+
 ## [2.11.0] - 2026-07-04
 
 ### Added

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -204,6 +204,21 @@ type Config struct {
 	// Environment is the runtime environment (development, staging, production).
 	// Injected by the runtime for environment-aware defaults.
 	Environment string
+
+	// MissingEnv lists env() calls in this connector's block whose environment
+	// variable is unset and has no default. Recorded at parse time so failures
+	// can point at the real cause instead of an empty property.
+	MissingEnv []MissingEnvVar
+}
+
+// MissingEnvVar records an unresolved env() call inside a connector block.
+type MissingEnvVar struct {
+	// Name is the environment variable name, e.g. "URL_MS_BASE".
+	Name string
+
+	// Attr is the attribute path where it was used, e.g. "base_url" or
+	// "consumer.queue".
+	Attr string
 }
 
 // GetOperation finds an operation by name.

--- a/internal/parser/connector.go
+++ b/internal/parser/connector.go
@@ -261,6 +261,10 @@ func parseConnectorBlock(block *hcl.Block, ctx *hcl.EvalContext) (*connector.Con
 		return nil, fmt.Errorf("connector content error: %s", diags.Error())
 	}
 
+	// Record env() calls that resolved to nothing so registration failures can
+	// name the missing variable instead of just the empty property.
+	config.MissingEnv = collectMissingEnv(block.Body)
+
 	// Parse required type attribute
 	if attr, ok := content.Attributes["type"]; ok {
 		val, diags := attr.Expr.Value(ctx)

--- a/internal/parser/env_missing.go
+++ b/internal/parser/env_missing.go
@@ -1,0 +1,89 @@
+package parser
+
+import (
+	"os"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/matutetandil/mycel/internal/connector"
+)
+
+// collectMissingEnv walks a block body looking for env("NAME") calls whose
+// environment variable is unset and that have no default value. Those calls
+// evaluate to an empty string, so the connector factory later fails with a
+// generic "requires X" error; recording them here lets the runtime name the
+// variable that is actually missing.
+func collectMissingEnv(body hcl.Body) []connector.MissingEnvVar {
+	syntaxBody, ok := body.(*hclsyntax.Body)
+	if !ok {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var missing []connector.MissingEnvVar
+	walkBodyForEnv(syntaxBody, "", seen, &missing)
+
+	sort.Slice(missing, func(i, j int) bool {
+		if missing[i].Attr != missing[j].Attr {
+			return missing[i].Attr < missing[j].Attr
+		}
+		return missing[i].Name < missing[j].Name
+	})
+	return missing
+}
+
+// walkBodyForEnv recurses into nested blocks, prefixing attribute paths.
+func walkBodyForEnv(body *hclsyntax.Body, prefix string, seen map[string]bool, missing *[]connector.MissingEnvVar) {
+	for name, attr := range body.Attributes {
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		for _, envName := range unresolvedEnvCalls(attr.Expr) {
+			key := path + "\x00" + envName
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			*missing = append(*missing, connector.MissingEnvVar{Name: envName, Attr: path})
+		}
+	}
+
+	for _, block := range body.Blocks {
+		path := block.Type
+		if prefix != "" {
+			path = prefix + "." + block.Type
+		}
+		walkBodyForEnv(block.Body, path, seen, missing)
+	}
+}
+
+// unresolvedEnvCalls returns the names of env() calls in expr that have no
+// default argument and whose variable is not set in the process environment.
+func unresolvedEnvCalls(expr hclsyntax.Expression) []string {
+	var names []string
+
+	hclsyntax.VisitAll(expr, func(node hclsyntax.Node) hcl.Diagnostics {
+		call, ok := node.(*hclsyntax.FunctionCallExpr)
+		if !ok || call.Name != "env" || len(call.Args) != 1 {
+			return nil
+		}
+
+		// The variable name must be a literal to be reportable.
+		val, diags := call.Args[0].Value(nil)
+		if diags.HasErrors() || val.IsNull() || val.Type() != cty.String {
+			return nil
+		}
+
+		name := val.AsString()
+		if name != "" && os.Getenv(name) == "" {
+			names = append(names, name)
+		}
+		return nil
+	})
+
+	return names
+}

--- a/internal/parser/env_missing_test.go
+++ b/internal/parser/env_missing_test.go
@@ -1,0 +1,103 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// parseBody parses src and returns the body of its first block.
+func parseBody(t *testing.T, src string) *hclsyntax.Body {
+	t.Helper()
+
+	file, diags := hclsyntax.ParseConfig([]byte(src), "test.mycel", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse error: %s", diags.Error())
+	}
+
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok || len(body.Blocks) == 0 {
+		t.Fatalf("expected at least one block")
+	}
+	return body.Blocks[0].Body
+}
+
+func TestCollectMissingEnv(t *testing.T) {
+	t.Setenv("MYCEL_TEST_SET", "http://example.com")
+
+	tests := []struct {
+		name string
+		src  string
+		want []string // "ATTR=ENV_NAME"
+	}{
+		{
+			name: "unset variable is reported",
+			src: `connector "url_ms" {
+				type     = "http"
+				base_url = env("MYCEL_TEST_MISSING")
+			}`,
+			want: []string{"base_url=MYCEL_TEST_MISSING"},
+		},
+		{
+			name: "variable with default is not reported",
+			src: `connector "url_ms" {
+				base_url = env("MYCEL_TEST_MISSING", "http://localhost")
+			}`,
+			want: nil,
+		},
+		{
+			name: "set variable is not reported",
+			src: `connector "url_ms" {
+				base_url = env("MYCEL_TEST_SET")
+			}`,
+			want: nil,
+		},
+		{
+			name: "interpolated variable is reported",
+			src: `connector "url_ms" {
+				base_url = "${env("MYCEL_TEST_MISSING")}/api"
+			}`,
+			want: []string{"base_url=MYCEL_TEST_MISSING"},
+		},
+		{
+			name: "nested block attribute keeps its path",
+			src: `connector "mq" {
+				consumer {
+					queue = env("MYCEL_TEST_QUEUE")
+				}
+			}`,
+			want: []string{"consumer.queue=MYCEL_TEST_QUEUE"},
+		},
+		{
+			name: "multiple attributes are all reported",
+			src: `connector "pg" {
+				host     = env("MYCEL_TEST_HOST")
+				password = env("MYCEL_TEST_PASSWORD")
+			}`,
+			want: []string{"host=MYCEL_TEST_HOST", "password=MYCEL_TEST_PASSWORD"},
+		},
+		{
+			name: "no env calls at all",
+			src: `connector "sqlite" {
+				database = "./data/app.db"
+			}`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectMissingEnv(parseBody(t, tt.src))
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d missing vars %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i, m := range got {
+				if key := m.Attr + "=" + m.Name; key != tt.want[i] {
+					t.Errorf("entry %d = %q, want %q", i, key, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/runtime/env_hint.go
+++ b/internal/runtime/env_hint.go
@@ -1,0 +1,26 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/matutetandil/mycel/internal/connector"
+)
+
+// missingEnvHint builds a suffix naming the environment variables the connector
+// referenced through env() that are not set. Those calls evaluate to an empty
+// string, so factories report a generic "requires X" error; this points at the
+// real cause. Returns an empty string when nothing is missing.
+func missingEnvHint(cfg *connector.Config) string {
+	if cfg == nil || len(cfg.MissingEnv) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, m := range cfg.MissingEnv {
+		b.WriteString(fmt.Sprintf(
+			"\n      → Missing environment variable %q, required by connector %q (%s)",
+			m.Name, cfg.Name, m.Attr))
+	}
+	return b.String()
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -992,7 +992,7 @@ func (r *Runtime) initConnectors(ctx context.Context) error {
 		r.operationResolver.Register(cfg)
 
 		if err := r.connectors.Register(ctx, cfg); err != nil {
-			return fmt.Errorf("failed to register connector %s: %w", cfg.Name, err)
+			return fmt.Errorf("failed to register connector %s: %w%s", cfg.Name, err, missingEnvHint(cfg))
 		}
 
 		// Build details string based on connector type


### PR DESCRIPTION
An env("X") call for an unset variable with no default evaluates to an empty string, so connector factories failed with a generic message ("http connector requires base_url") that gave no hint about the real cause.

Connector blocks are now scanned at parse time for env() calls with no default whose variable is unset, and a registration failure appends them to the error:

  failed to register connector url_ms: http connector requires base_url
    -> Missing environment variable "URL_MS_BASE", required by connector
       "url_ms" (base_url)

Nested blocks keep their attribute path (consumer.queue), env("X", "def") calls are never reported, and the hint only shows when registration actually fails.

<!--
Thanks for contributing to Mycel! Please fill in the sections below.
See CONTRIBUTING.md for conventions.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (behavior or config changes that aren't backward compatible)
- [ ] Docs only
- [ ] Refactor / chore

## How it was tested

<!-- Unit tests, example validated, integration suite, manual steps, etc. -->

## Checklist

- [ ] `go build ./...`, `go vet ./...`, and `go test ./...` all pass
- [ ] Added/updated tests for the change
- [ ] Updated docs (`docs/`, `README.md`, and any affected example)
- [ ] Updated `CHANGELOG.md` for user-facing changes
- [ ] New/changed `examples/` validate with `mycel validate`
- [ ] Breaking changes are called out above and in `CHANGELOG.md`
