### PR TITLE
chore: bump version to 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.11.1] - 2026-07-27
 
 ### Changed
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.11.0"
+	version = "2.11.1"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for the connector env-var error message improvement merged in #34.

- `cmd/mycel/main.go`: `2.11.0` → `2.11.1`
- `CHANGELOG.md`: `[Unreleased]` → `[2.11.1] - 2026-07-27`

Patch release: diagnostics-only change, no config surface added, fully backward compatible.

## What ships in 2.11.1

Connector registration failures now name the environment variable that is actually missing. An `env("X")` call for an unset variable with no default evaluates to an empty string, so factories used to fail with a generic message:

```
✗ failed to register connector url_ms: factory failed to create connector url_ms: http connector requires base_url
      → Missing environment variable "URL_MS_BASE", required by connector "url_ms" (base_url)
```

Nested blocks keep their attribute path (`consumer.queue`), `env("X", "default")` calls are never reported, and the hint only appears when registration actually fails.