### PR TITLE
Enforce required flow source parameters and make the flow reference findable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Flow source parameters are validated against the connector's schema.** Connectors have always declared which flow parameters they require via `ConnectorSchemaProvider.SourceSchema`, but only the IDE engine consumed that contract. A REST flow missing its `operation` parsed cleanly and registered a handler for the empty operation instead of failing. `mycel validate` and `mycel start` now check every flow's `from` block and report each missing required attribute:
+
+  ```
+  flow "create_user": from block is missing attribute "operation" required by connector "api" (rest)
+  ```
+
+  Only attributes marked required are enforced, so connectors that default a parameter are unaffected — message queues, MQTT, CDC, WebSocket and file watch all default `operation` to the catch-all `"*"` and stay legal without it. Connectors with no registered schema, such as plugin-provided ones, are skipped. Verified against all 81 example config directories with no new failures.
+
+### Documentation
+
+- **`operation` was documented as always required in the `from` block; it isn't.** It is required for `rest`, `graphql`, `grpc`, `soap`, `tcp` and `sse`, and optional for `mq`, `mqtt`, `cdc`, `websocket` and `file` watch, which default it to `"*"`. The flows page and the source properties reference now state which case each connector falls into, and the catch-all default is documented for the first time.
+- **The connector type for message queues was documented as `queue`.** The real HCL type is `mq` — `queue` parses but fails when the runtime builds the connector.
+- **New "Flow Anatomy" section opens the flows page**: the pipeline diagram, then a table of all 21 blocks and 4 attributes a flow can contain, each with what it does and a link to its full documentation. Writing it surfaced blocks the configuration reference had missed entirely — `accept` and `sequence_guard` were parseable but undocumented there, and the PDF connector had no section at all; all three added, plus a `sequence_guard` section on the flows page.
+- **Navigation repairs.** The reusable blocks and resilience pages existed but were absent from the site navigation. Guides were ordered alphabetically in the nav while the documentation index ordered them as a learning path; the nav now follows the index. Top-level groups render as tabs instead of listing every page in one scroll. Every broken link and heading anchor is fixed — links leaving `docs/` now use absolute repository URLs (they resolved from the wrong depth and 404'd on the site), and heading slugs are GitHub-compatible so the same anchor works in both places. `mkdocs build --strict` completes with no warnings.
+
 ## [2.11.1] - 2026-07-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Only attributes marked required are enforced, so connectors that default a parameter are unaffected — message queues, MQTT, CDC, WebSocket and file watch all default `operation` to the catch-all `"*"` and stay legal without it. Connectors with no registered schema, such as plugin-provided ones, are skipped. Verified against all 81 example config directories with no new failures.
 
+### Fixed
+
+- **CLI errors no longer dump the usage text.** Every failure printed the full flag list after the error, burying the diagnostics — a config that fails to validate is not a usage mistake. Usage is suppressed from the point a command starts running; flag and argument errors are raised before that and still print it, and unknown commands keep cobra's `Run 'mycel --help' for usage.` hint. `main` also printed the error a second time after cobra had already reported it.
+
 ### Documentation
 
 - **`operation` was documented as always required in the `from` block; it isn't.** It is required for `rest`, `graphql`, `grpc`, `soap`, `tcp` and `sse`, and optional for `mq`, `mqtt`, `cdc`, `websocket` and `file` watch, which default it to `"*"`. The flows page and the source properties reference now state which case each connector falls into, and the catch-all default is documented for the first time.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ On top of this, you can add [transforms](docs/core-concepts/transforms.md) (resh
 
 Every Mycel service automatically includes health checks (`/health`, `/health/live`, `/health/ready`), Prometheus metrics (`/metrics`), and hot reload — no configuration needed. Change a `.mycel` file and the service reloads with zero downtime.
 
-That's the whole model. Everything else is configuration. Learn more in [Core Concepts](docs/core-concepts/connectors.md).
+That's the whole model. Everything else is configuration.
+
+**Want to write your first flow?** [Flow Anatomy](docs/core-concepts/flows.md#flow-anatomy) lists every block a flow can contain and what each one is for, in the order they run. For the bare syntax of every block in the language, see the [HCL Syntax Reference](docs/reference/configuration.md).
 
 ## Quick Start
 
@@ -367,7 +369,8 @@ Full documentation is at [docs/index.md](docs/index.md). Quick links:
 
 **Core Concepts**
 - [Connectors](docs/core-concepts/connectors.md) — All connector types
-- [Flows](docs/core-concepts/flows.md) — Complete flow reference
+- [Flows](docs/core-concepts/flows.md) — Complete flow reference, starting with [Flow Anatomy](docs/core-concepts/flows.md#flow-anatomy): every block a flow can contain
+- [Reusable Blocks](docs/core-concepts/reusable-blocks.md) — Declare `dedupe`, `retry`, `lock` and friends once, reference them from many flows
 - [Transforms](docs/core-concepts/transforms.md) — CEL functions and expressions
 - [Types](docs/core-concepts/types.md) — Schema validation and field constraints
 - [Aspects](docs/core-concepts/aspects.md) — Cross-cutting concerns (AOP) applied across flows by pattern
@@ -387,7 +390,9 @@ Full documentation is at [docs/index.md](docs/index.md). Quick links:
 - [Extending Mycel](docs/guides/extending.md) — Validators, WASM functions, mocks, plugins
 
 **Reference**
-- [Configuration Reference](docs/reference/configuration.md) — Complete HCL syntax
+- [HCL Syntax Reference](docs/reference/configuration.md) — Every block type and attribute
+- [Source Properties](docs/reference/source-properties.md) — What `operation` means per connector, and the `input.*` variables it gives you
+- [Destination Properties](docs/reference/destination-properties.md) — What `target`, `operation` and `query` mean per connector
 - [CEL Functions](docs/reference/cel-functions.md) — All built-in transform functions
 - [CLI Reference](docs/reference/cli.md) — All commands and flags
 - [API Endpoints](docs/reference/api-endpoints.md) — Health, metrics, workflow, auth endpoints

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -32,8 +32,8 @@ var (
 )
 
 func main() {
+	// Cobra has already reported the error; just set the exit status.
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
@@ -66,6 +66,14 @@ Environment Variables:
 Documentation:
   https://github.com/matutetandil/mycel`,
 	Version: fmt.Sprintf("%s (commit: %s)", version, commit),
+
+	// Suppress the usage dump once a command is actually running: a config that
+	// fails to validate is not a usage mistake, and burying the diagnostics
+	// under the flag list helps nobody. Flag and argument errors are raised
+	// before this hook runs, so those still print usage.
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+		cmd.SilenceUsage = true
+	},
 }
 
 var startCmd = &cobra.Command{

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -407,10 +407,21 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Config dir: %s\n", configDir)
 
 	// Parse configuration
-	p := parser.NewHCLParser()
+	schemaReg := runtime.NewSchemaRegistry()
+	p := parser.NewHCLParserWithRegistry(schemaReg)
 	config, err := p.Parse(context.Background(), configDir)
 	if err != nil {
 		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	// Check every flow's "from" block against its source connector's schema
+	if errs := runtime.ValidateFlowSchemas(config, schemaReg); len(errs) > 0 {
+		fmt.Printf("\n✗ Configuration is invalid:\n\n")
+		for _, e := range errs {
+			fmt.Printf("    - %s\n", e)
+		}
+		fmt.Println()
+		return fmt.Errorf("validation failed: %d flow error(s)", len(errs))
 	}
 
 	// Report success

--- a/docs/advanced/federation.md
+++ b/docs/advanced/federation.md
@@ -218,5 +218,5 @@ The SDL includes all `@key`, `@external`, `@shareable`, and other federation dir
 ## See Also
 
 - [GraphQL Connector](../connectors/graphql.md) — connector configuration, named operations, subscriptions
-- [graphql-federation example](../../examples/graphql-federation) — complete multi-service setup with Cosmo Router
+- [graphql-federation example](https://github.com/matutetandil/mycel/tree/main/examples/graphql-federation) — complete multi-service setup with Cosmo Router
 - [Configuration Reference — Types](../reference/configuration.md#types) — all field directives including federation annotations

--- a/docs/advanced/federation.md
+++ b/docs/advanced/federation.md
@@ -219,4 +219,4 @@ The SDL includes all `@key`, `@external`, `@shareable`, and other federation dir
 
 - [GraphQL Connector](../connectors/graphql.md) — connector configuration, named operations, subscriptions
 - [graphql-federation example](https://github.com/matutetandil/mycel/tree/main/examples/graphql-federation) — complete multi-service setup with Cosmo Router
-- [Configuration Reference — Types](../reference/configuration.md#types) — all field directives including federation annotations
+- [Configuration Reference — Types](../reference/configuration.md#type) — all field directives including federation annotations

--- a/docs/advanced/integration-patterns.md
+++ b/docs/advanced/integration-patterns.md
@@ -1198,10 +1198,10 @@ transform {
 
 ## More Examples
 
-- [GraphQL Full Example](../examples/graphql/README.md)
-- [Message Queue Example](../examples/mq/README.md)
-- [Data Enrichment](../examples/enrich/README.md)
-- [TCP Connector](../examples/tcp/README.md)
+- [GraphQL Full Example](https://github.com/matutetandil/mycel/tree/main/examples/graphql)
+- [Message Queue Example](https://github.com/matutetandil/mycel/tree/main/examples/mq)
+- [Data Enrichment](https://github.com/matutetandil/mycel/tree/main/examples/enrich)
+- [TCP Connector](https://github.com/matutetandil/mycel/tree/main/examples/tcp)
 - [Transformations Guide](../core-concepts/transforms.md)
 
 ---

--- a/docs/advanced/plugins.md
+++ b/docs/advanced/plugins.md
@@ -133,4 +133,4 @@ See [WASM Documentation](wasm.md) for complete interface details and language-sp
 
 - [WASM Documentation](wasm.md) — WASM interface spec, 6 language examples
 - [Extending Mycel](../guides/extending.md) — validators, functions, mocks
-- [Plugin example](../../examples/plugin)
+- [Plugin example](https://github.com/matutetandil/mycel/tree/main/examples/plugin)

--- a/docs/advanced/wasm.md
+++ b/docs/advanced/wasm.md
@@ -638,7 +638,7 @@ plugin "salesforce" {
 }
 ```
 
-See [Plugin Example](../examples/plugin/) for the full plugin manifest and connector interface.
+See [Plugin Example](https://github.com/matutetandil/mycel/tree/main/examples/plugin) for the full plugin manifest and connector interface.
 
 ---
 
@@ -669,8 +669,7 @@ Approximate `.wasm` sizes for the CUIT validator example:
 
 ## See Also
 
-- [WASM Validator Example](../examples/wasm-validator/) — Complete Rust validator
-- [WASM Functions Example](../examples/wasm-functions/) — Custom CEL functions in Rust
-- [Plugin Example](../examples/plugin/) — Custom connector via WASM
-- [CONCEPTS.md](./CONCEPTS.md#wasm) — WASM section in concepts overview
+- [WASM Validator Example](https://github.com/matutetandil/mycel/tree/main/examples/wasm-validator) — Complete Rust validator
+- [WASM Functions Example](https://github.com/matutetandil/mycel/tree/main/examples/wasm-functions) — Custom CEL functions in Rust
+- [Plugin Example](https://github.com/matutetandil/mycel/tree/main/examples/plugin) — Custom connector via WASM
 - [Plugins](./plugins.md) — Plugin system and extensibility

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -2,7 +2,7 @@
 
 Mycel connectors are bidirectional adapters between your service and external systems. Each connector can act as a **source** (receives data that triggers a flow) or a **target** (destination where a flow writes data).
 
-For the general connector concept and how they fit into the Mycel model, see [Concepts — Connectors](../CONCEPTS.md#connectors).
+For the general connector concept and how they fit into the Mycel model, see [Connectors](../core-concepts/connectors.md).
 
 ---
 

--- a/docs/connectors/cache.md
+++ b/docs/connectors/cache.md
@@ -78,7 +78,7 @@ flow "get_user_cached" {
 }
 ```
 
-See the [cache example](../../examples/cache/) and [redis-cluster example](../../examples/redis-cluster/) for complete setups.
+See the [cache example](https://github.com/matutetandil/mycel/tree/main/examples/cache) and [redis-cluster example](https://github.com/matutetandil/mycel/tree/main/examples/redis-cluster) for complete setups.
 
 ---
 

--- a/docs/connectors/cdc.md
+++ b/docs/connectors/cdc.md
@@ -99,7 +99,7 @@ flow "audit_products" {
 }
 ```
 
-See the [cdc example](../../examples/cdc/) for a complete working setup.
+See the [cdc example](https://github.com/matutetandil/mycel/tree/main/examples/cdc) for a complete working setup.
 
 ---
 

--- a/docs/connectors/database.md
+++ b/docs/connectors/database.md
@@ -105,7 +105,7 @@ To write several statements **atomically** on a single pinned connection (with
 `LAST_INSERT_ID` / `SELECT` capture and per-element iteration), use the
 `to { transaction { } }` block instead of a single `query`/`target`. See
 [Flows → Transactional write](../core-concepts/flows.md#transactional-write-transaction)
-and the [transactional-write example](../../examples/transactional-write/).
+and the [transactional-write example](https://github.com/matutetandil/mycel/tree/main/examples/transactional-write).
 
 ## Example
 
@@ -139,7 +139,7 @@ flow "get_user" {
 }
 ```
 
-See the [basic example](../../examples/basic/) (SQLite) and [mongodb example](../../examples/mongodb/) for complete setups.
+See the [basic example](https://github.com/matutetandil/mycel/tree/main/examples/basic) (SQLite) and [mongodb example](https://github.com/matutetandil/mycel/tree/main/examples/mongodb) for complete setups.
 
 ---
 

--- a/docs/connectors/elasticsearch.md
+++ b/docs/connectors/elasticsearch.md
@@ -82,7 +82,7 @@ flow "index_product" {
 }
 ```
 
-See the [elasticsearch example](../../examples/elasticsearch/) for a complete working setup.
+See the [elasticsearch example](https://github.com/matutetandil/mycel/tree/main/examples/elasticsearch) for a complete working setup.
 
 ---
 

--- a/docs/connectors/exec.md
+++ b/docs/connectors/exec.md
@@ -78,7 +78,7 @@ flow "run_report" {
 }
 ```
 
-See the [exec example](../../examples/exec/) for a complete working setup.
+See the [exec example](https://github.com/matutetandil/mycel/tree/main/examples/exec) for a complete working setup.
 
 ---
 

--- a/docs/connectors/filesystem.md
+++ b/docs/connectors/filesystem.md
@@ -495,7 +495,7 @@ flow "import_csv" {
 }
 ```
 
-See the [files example](../../examples/files/) for a complete working setup.
+See the [files example](https://github.com/matutetandil/mycel/tree/main/examples/files) for a complete working setup.
 
 ---
 

--- a/docs/connectors/ftp.md
+++ b/docs/connectors/ftp.md
@@ -116,7 +116,7 @@ flow "upload_result" {
 }
 ```
 
-See the [ftp example](../../examples/ftp/) for a complete working setup.
+See the [ftp example](https://github.com/matutetandil/mycel/tree/main/examples/ftp) for a complete working setup.
 
 ---
 

--- a/docs/connectors/ftp.md
+++ b/docs/connectors/ftp.md
@@ -120,4 +120,4 @@ See the [ftp example](https://github.com/matutetandil/mycel/tree/main/examples/f
 
 ---
 
-> **Full configuration reference:** See [FTP](../reference/configuration.md#ftp) in the Configuration Reference.
+> **Full configuration reference:** See [FTP](../reference/configuration.md#ftp--sftp) in the Configuration Reference.

--- a/docs/connectors/graphql.md
+++ b/docs/connectors/graphql.md
@@ -109,7 +109,7 @@ flow "order_updates" {
 }
 ```
 
-See the [graphql example](../../examples/graphql/), [graphql-federation example](../../examples/graphql-federation/), and [graphql-optimization example](../../examples/graphql-optimization/) for complete setups.
+See the [graphql example](https://github.com/matutetandil/mycel/tree/main/examples/graphql), [graphql-federation example](https://github.com/matutetandil/mycel/tree/main/examples/graphql-federation), and [graphql-optimization example](https://github.com/matutetandil/mycel/tree/main/examples/graphql-optimization) for complete setups.
 
 ---
 

--- a/docs/connectors/grpc.md
+++ b/docs/connectors/grpc.md
@@ -75,7 +75,7 @@ flow "get_user" {
 }
 ```
 
-See the [grpc example](../../examples/grpc/) and [grpc-loadbalancing example](../../examples/grpc-loadbalancing/) for complete setups.
+See the [grpc example](https://github.com/matutetandil/mycel/tree/main/examples/grpc) and [grpc-loadbalancing example](https://github.com/matutetandil/mycel/tree/main/examples/grpc-loadbalancing) for complete setups.
 
 ---
 

--- a/docs/connectors/message-queues.md
+++ b/docs/connectors/message-queues.md
@@ -533,7 +533,7 @@ flow "enqueue_order" {
 }
 ```
 
-See the [mq example](../../examples/mq/) for a complete working setup.
+See the [mq example](https://github.com/matutetandil/mycel/tree/main/examples/mq) for a complete working setup.
 
 ---
 

--- a/docs/connectors/mqtt.md
+++ b/docs/connectors/mqtt.md
@@ -125,7 +125,7 @@ flow "temperature_alert" {
 }
 ```
 
-See the [mqtt example](../../examples/mqtt/) for a complete working setup.
+See the [mqtt example](https://github.com/matutetandil/mycel/tree/main/examples/mqtt) for a complete working setup.
 
 ---
 

--- a/docs/connectors/notifications.md
+++ b/docs/connectors/notifications.md
@@ -673,4 +673,4 @@ flow "receive_stripe" {
 
 ---
 
-See the [notifications example](../../examples/notifications/) for a complete working setup.
+See the [notifications example](https://github.com/matutetandil/mycel/tree/main/examples/notifications) for a complete working setup.

--- a/docs/connectors/oauth.md
+++ b/docs/connectors/oauth.md
@@ -80,4 +80,4 @@ flow "google_callback" {
 }
 ```
 
-See the [oauth example](../../examples/oauth/) for a complete working setup.
+See the [oauth example](https://github.com/matutetandil/mycel/tree/main/examples/oauth) for a complete working setup.

--- a/docs/connectors/profile.md
+++ b/docs/connectors/profile.md
@@ -88,7 +88,7 @@ flow "get_product_price" {
 
 The flow always targets `pricing` — the profile connector handles backend selection, fallback, and response normalization transparently.
 
-See the [profiles example](../../examples/profiles/) for a complete working setup.
+See the [profiles example](https://github.com/matutetandil/mycel/tree/main/examples/profiles) for a complete working setup.
 
 ---
 

--- a/docs/connectors/rest.md
+++ b/docs/connectors/rest.md
@@ -178,7 +178,7 @@ flow "create_user" {
 }
 ```
 
-See the [basic example](../../examples/basic/) for a complete working setup.
+See the [basic example](https://github.com/matutetandil/mycel/tree/main/examples/basic) for a complete working setup.
 
 ## File Upload (multipart/form-data)
 

--- a/docs/connectors/s3.md
+++ b/docs/connectors/s3.md
@@ -63,7 +63,7 @@ flow "download_file" {
 }
 ```
 
-See the [s3 example](../../examples/s3/) for a complete working setup.
+See the [s3 example](https://github.com/matutetandil/mycel/tree/main/examples/s3) for a complete working setup.
 
 ---
 

--- a/docs/connectors/sse.md
+++ b/docs/connectors/sse.md
@@ -90,7 +90,7 @@ flow "user_notification" {
 }
 ```
 
-See the [sse example](../../examples/sse/) for a complete working setup.
+See the [sse example](https://github.com/matutetandil/mycel/tree/main/examples/sse) for a complete working setup.
 
 ---
 

--- a/docs/connectors/tcp.md
+++ b/docs/connectors/tcp.md
@@ -69,7 +69,7 @@ flow "forward_to_tcp" {
 }
 ```
 
-See the [tcp example](../../examples/tcp/) for a complete working setup.
+See the [tcp example](https://github.com/matutetandil/mycel/tree/main/examples/tcp) for a complete working setup.
 
 ---
 

--- a/docs/connectors/websocket.md
+++ b/docs/connectors/websocket.md
@@ -90,7 +90,7 @@ flow "room_notification" {
 }
 ```
 
-See the [websocket example](../../examples/websocket/) for a complete working setup.
+See the [websocket example](https://github.com/matutetandil/mycel/tree/main/examples/websocket) for a complete working setup.
 
 ---
 

--- a/docs/core-concepts/aspects.md
+++ b/docs/core-concepts/aspects.md
@@ -115,4 +115,4 @@ on = ["get_product*"]               # Flows starting with "get_product"
 - [Flows](flows.md) — the unit of work aspects bind to
 - [Transforms](transforms.md) — the CEL expressions used inside aspect actions
 - [Error Handling](../guides/error-handling.md) — retries, DLQ, and `on_error` dispositions that complement `on_error` aspects
-- [Aspects example](../../examples/aspects)
+- [Aspects example](https://github.com/matutetandil/mycel/tree/main/examples/aspects)

--- a/docs/core-concepts/connectors.md
+++ b/docs/core-concepts/connectors.md
@@ -302,7 +302,7 @@ flow "list_active_users" {
 }
 ```
 
-See the [named-operations example](../../examples/named-operations) for complete patterns.
+See the [named-operations example](https://github.com/matutetandil/mycel/tree/main/examples/named-operations) for complete patterns.
 
 ## Connector Profiles
 
@@ -349,7 +349,7 @@ connector "cache" {
 }
 ```
 
-See the [profiles example](../../examples/profiles) for details.
+See the [profiles example](https://github.com/matutetandil/mycel/tree/main/examples/profiles) for details.
 
 ## Per-Connector Reference
 

--- a/docs/core-concepts/connectors.md
+++ b/docs/core-concepts/connectors.md
@@ -10,14 +10,14 @@ A connector is a bidirectional adapter between Mycel and an external system. Eve
 | `http` | HTTP client | — | Call APIs |
 | `database` | `postgres`, `mysql`, `sqlite`, `mongodb` | Query data | Insert/Update/Delete |
 | `graphql` | GraphQL server/client | Expose schema | Query/Mutate |
-| `queue` | `rabbitmq`, `kafka`, `redis` | Consume messages | Publish messages |
+| `mq` | `rabbitmq`, `kafka`, `redis` | Consume messages | Publish messages |
 | `grpc` | gRPC server/client | Expose services | Call services |
 | `tcp` | TCP server/client | Receive connections | Send data |
 | `cache` | `memory`, `redis` | — | Read/write cache |
 | `file` | Local filesystem | Watch for files | Write files |
 | `s3` | AWS S3, MinIO | Read objects | Write objects |
-| `websocket` | WebSocket server | — | Push to clients |
-| `sse` | Server-Sent Events | — | Push events |
+| `websocket` | WebSocket server | Receive client events | Push to clients |
+| `sse` | Server-Sent Events | Connect/disconnect events | Push events |
 | `cdc` | PostgreSQL WAL | Stream DB changes | — |
 | `exec` | Shell commands | — | Execute commands |
 | `email` | SMTP | — | Send emails |
@@ -31,6 +31,7 @@ A connector is a bidirectional adapter between Mycel and an external system. Eve
 | `oauth` | Google, GitHub, Apple, OIDC | OAuth callback | — |
 | `mqtt` | MQTT 3.1.1/5.0 | Subscribe to topics | Publish messages |
 | `ftp` | FTP, FTPS, SFTP | List/Download files | Upload/Delete files |
+| `pdf` | PDF generation | — | Render documents |
 
 ## Defining a Connector
 

--- a/docs/core-concepts/flows.md
+++ b/docs/core-concepts/flows.md
@@ -26,7 +26,7 @@ A flow needs only `from` and `to`. Everything else is optional.
 ```hcl
 from {
   connector = "api"           # Required: connector name
-  operation = "GET /users"    # Required: event type or endpoint
+  operation = "GET /users"    # Event type or endpoint — required for some connectors (see below)
   format    = "json"          # Optional: expected input format ("json", "xml", "csv", "tsv")
 }
 ```
@@ -36,9 +36,48 @@ from {
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `connector` | string | yes | Name of the source connector |
-| `operation` | string | yes | Operation or event to listen for |
+| `operation` | string | **depends on the connector** | Operation or event to listen for — see below |
 | `format` | string | no | Input format: `json`, `xml`, `csv` (default: `json`) |
 | `filter` | string/block | no | CEL condition to skip non-matching events |
+
+### Is `operation` required?
+
+It depends on the source connector. Request/RPC-style sources address a specific
+endpoint, so `operation` is mandatory. Stream-style sources subscribe to whatever
+the connector is already configured to consume, so `operation` merely *narrows*
+what this flow handles — omit it and the flow receives everything.
+
+| Source connector | `operation` | If omitted |
+|------------------|-------------|------------|
+| `rest` | **required** | Startup error |
+| `graphql` | **required** | Startup error |
+| `grpc` | **required** | Startup error |
+| `soap` | **required** | Startup error |
+| `tcp` | **required** | Startup error |
+| `sse` | **required** | Startup error |
+| `mq` (RabbitMQ, Kafka, Redis Pub/Sub) | optional | Defaults to `"*"` — catch-all |
+| `mqtt` | optional | Defaults to `"*"` — catch-all |
+| `cdc` | optional | Defaults to `"*"` — every trigger, every table |
+| `websocket` | optional | Defaults to `"*"` — every event type |
+| `file` (watch) | optional | Defaults to `"*"` — every matched file |
+
+A missing required `operation` is caught by `mycel validate` and at startup:
+
+```
+flow "create_user": from block is missing attribute "operation" required by connector "api" (rest)
+```
+
+So a queue consumer that handles every message on its queue needs no `operation`
+at all:
+
+```hcl
+flow "process_all_orders" {
+  from {
+    connector = "rabbit"    # consumes whatever the connector's consumer{} block is bound to
+  }
+  to { connector = "db", target = "orders" }
+}
+```
 
 > **What does `operation` mean for each connector, and what `input.*` variables are available?** See the [Source Properties by Connector](../reference/source-properties.md) reference.
 

--- a/docs/core-concepts/flows.md
+++ b/docs/core-concepts/flows.md
@@ -19,6 +19,63 @@ flow "get_users" {
 
 A flow needs only `from` and `to`. Everything else is optional.
 
+## Flow Anatomy
+
+Everything a flow can contain, in the order it runs. Each block is optional
+except `from`; a flow with no `to` is an [echo flow](#response) that answers from
+its own `response` block.
+
+```
+        from ─── filter ─── accept ─── validate ─── enrich ─── transform ─── dedupe ─── to
+       source     drop      business    schema     fetch more   reshape     skip     write
+       event    non-matching  gate       check     data/steps    payload  duplicates
+```
+
+`lock`, `semaphore`, `coordinate` and `sequence_guard` wrap the whole pipeline;
+`error_handling`, `cache`, `batch`, `async` and `idempotency` change how it is
+scheduled and retried; `after` runs once the write succeeds.
+
+### Blocks
+
+| Block | What it does | Where it's documented |
+|-------|--------------|-----------------------|
+| `from` | The trigger: which connector fires the flow, and for what event | [below](#the-from-block) · [source properties](../reference/source-properties.md) |
+| `to` | Where the flow writes. Repeat it to fan out, nest `transaction` for all-or-nothing writes | [below](#the-to-block) · [destination properties](../reference/destination-properties.md) |
+| `accept` | Business-level gate — "is this message mine?" — with an ack/reject/requeue policy | [below](#the-accept-block) |
+| `validate` | Check the payload against a `type` before and/or after transforming | [below](#validate-block) · [types](types.md) |
+| `require` | Demand that specific fields be present, with a custom error | [below](#require-block) |
+| `enrich` | Pull extra data from another connector and merge it into the payload | [below](#enrich-block) · [multi-step flows](../guides/multi-step-flows.md) |
+| `step` | Named intermediate connector calls, referenced later as `step.<name>.<field>` | [below](#step-block) · [multi-step flows](../guides/multi-step-flows.md) |
+| `transform` | Reshape the payload with CEL | [below](#transform) · [transforms](transforms.md) |
+| `response` | Shape what the caller gets back, independently of what was written | [below](#response) |
+| `after` | Fire-and-forget work once the write succeeds | [below](#after-block) |
+| `cache` | Serve reads from cache and invalidate on write | [below](#cache-block) · [caching](../guides/caching.md) |
+| `dedupe` | Skip a message whose transformed payload matches the last one processed | [below](#dedupe-block) · [caching](../guides/caching.md) |
+| `idempotency` | Replay the stored result when the same idempotency key arrives twice | [configuration reference](../reference/configuration.md#idempotency-block) |
+| `error_handling` | Retry with backoff, dead-letter queues, circuit breakers, per-class dispositions | [below](#error-handling-block) · [error handling](../guides/error-handling.md) |
+| `lock` | Distributed mutex — one flow instance per key at a time | [below](#lock-mutex) · [synchronization](../guides/synchronization.md) |
+| `semaphore` | Allow at most N concurrent instances | [below](#semaphore-n-concurrent) · [synchronization](../guides/synchronization.md) |
+| `coordinate` | Signal/wait between flows | [below](#coordinate-signalwait) · [synchronization](../guides/synchronization.md) |
+| `sequence_guard` | Reject messages that arrive out of order, by monotonic sequence number | [below](#sequence-guard-ordering) · [synchronization](../guides/synchronization.md) |
+| `batch` | Process large datasets in chunks | [batch processing](../guides/batch-processing.md) |
+| `async` | Answer `202 Accepted` immediately and run the flow in the background | [configuration reference](../reference/configuration.md#async-block) |
+| `state_transition` | Drive a state machine as part of the flow | [below](#state-transition-block) · [sagas & state machines](../guides/sagas.md) |
+
+Any of these blocks can also be declared once at the top level and reused across
+flows with `use = "<kind>.<name>"` — see [Reusable Blocks](reusable-blocks.md).
+
+### Flow-level attributes
+
+| Attribute | What it does | Where it's documented |
+|-----------|--------------|-----------------------|
+| `when` | Run on a cron schedule instead of waiting for a source event | [below](#scheduled-flows-cron) |
+| `cache` | Reference a named cache — `cache = "cache.<name>"` | [caching](../guides/caching.md) |
+| `returns` | GraphQL return type for HCL-first schemas | [below](#returns-graphql-type) |
+| `entity` | Mark the flow as a GraphQL Federation entity resolver | [below](#federation-entity-resolver) |
+
+> Looking for the bare syntax of every block, without the prose? See the
+> [Configuration Reference](../reference/configuration.md#flow).
+
 ## The `from` Block
 
 `from` defines the trigger: which connector fires the flow and for what event.
@@ -969,6 +1026,45 @@ flow "consume_data" {
   }
 }
 ```
+
+### Sequence guard (ordering)
+
+Reject a message whose sequence number is not strictly greater than the last one
+already processed for the same key. This is the guard against *out-of-order*
+replays — redelivery, requeue, multiple workers — where an older update would
+otherwise overwrite a newer one already applied.
+
+```hcl
+flow "apply_product_update" {
+  from {
+    connector = "rabbit"
+    operation = "products.updated"
+  }
+
+  sequence_guard {
+    key      = "'sku_seq:' + input.body.sku"
+    sequence = "input.body.version"
+    on_older = "ack"          # ack | reject | requeue
+    ttl      = "30d"
+
+    storage {
+      driver = "redis"
+      url    = env("REDIS_URL")
+    }
+  }
+
+  to {
+    connector = "db"
+    target    = "products"
+  }
+}
+```
+
+`sequence_guard` is comparative (rejects by *ordering*), while
+[`dedupe`](#dedupe-block) is content-based (rejects by *sameness*). They compose:
+`sequence_guard` drops stale replays, then `dedupe` drops no-op rewrites.
+
+Ordering inside a flow is `lock → coordinate → sequence_guard → transform → to`.
 
 See [Synchronization Guide](../guides/synchronization.md) for details.
 

--- a/docs/core-concepts/reusable-blocks.md
+++ b/docs/core-concepts/reusable-blocks.md
@@ -147,4 +147,4 @@ Strictly additive. Every existing inline block — written without `use` — beh
 exactly as before. Names live in a per-kind namespace, so `flow "x"` and
 `dedupe "x"` never collide.
 
-See the runnable example in [`examples/reusable-blocks/`](../../examples/reusable-blocks/).
+See the runnable example in [`examples/reusable-blocks/`](https://github.com/matutetandil/mycel/tree/main/examples/reusable-blocks).

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -39,7 +39,7 @@ helm install my-api oci://ghcr.io/matutetandil/charts/mycel \
 | `autoscaling.enabled` | `false` | Enable HPA |
 | `ingress.enabled` | `false` | Enable Ingress |
 
-See [helm/mycel/README.md](../../helm/mycel/README.md) for the complete values reference.
+See [helm/mycel/README.md](https://github.com/matutetandil/mycel/blob/main/helm/mycel/README.md) for the complete values reference.
 
 ## Manual Deployment
 
@@ -250,4 +250,4 @@ metadata:
 
 - [Docker Deployment](docker.md)
 - [Production Checklist](production.md)
-- [Helm Chart README](../../helm/mycel/README.md)
+- [Helm Chart README](https://github.com/matutetandil/mycel/blob/main/helm/mycel/README.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -96,7 +96,7 @@ helm install my-api oci://ghcr.io/matutetandil/charts/mycel \
   --set envFrom[0].secretRef.name=my-api-secrets
 ```
 
-See [helm/mycel/README.md](../../helm/mycel/README.md) for the full values reference.
+See [helm/mycel/README.md](https://github.com/matutetandil/mycel/blob/main/helm/mycel/README.md) for the full values reference.
 
 ## Docker Compose
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -304,4 +304,4 @@ docker run \
 - [Core Concepts: Transforms](../core-concepts/transforms.md)
 - [Core Concepts: Types](../core-concepts/types.md)
 - [Deployment Guide](../deployment/docker.md)
-- [Examples](../../examples/)
+- [Examples](https://github.com/matutetandil/mycel/tree/main/examples)

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -286,7 +286,7 @@ auth {
 **Not yet implemented:** response caching (every request hits the provider) and
 `sync_to` (parsed, but setting it only logs a warning today).
 
-See the [`dynamic-api-key` example](../../examples/dynamic-api-key) for a complete setup.
+See the [`dynamic-api-key` example](https://github.com/matutetandil/mycel/tree/main/examples/dynamic-api-key) for a complete setup.
 
 ### User Storage
 
@@ -534,4 +534,4 @@ CREATE INDEX idx_audit_created ON auth_audit_log(created_at);
 
 ## Examples
 
-See [examples/auth](../examples/auth) for a complete working example.
+See [examples/auth](https://github.com/matutetandil/mycel/tree/main/examples/auth) for a complete working example.

--- a/docs/guides/batch-processing.md
+++ b/docs/guides/batch-processing.md
@@ -273,4 +273,4 @@ flow "daily_sync" {
 
 - [Core Concepts: Flows](../core-concepts/flows.md) — flow trigger (`when`) reference
 - [Guides: Synchronization](synchronization.md) — lock for preventing duplicate jobs
-- [Examples: Batch](../../examples/batch)
+- [Examples: Batch](https://github.com/matutetandil/mycel/tree/main/examples/batch)

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -345,4 +345,4 @@ flow "handle_inventory_update" {
 
 - [Connectors: Cache](../connectors/cache.md)
 - [Guides: Error Handling](error-handling.md)
-- [Examples: Cache](../../examples/cache)
+- [Examples: Cache](https://github.com/matutetandil/mycel/tree/main/examples/cache)

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -694,7 +694,7 @@ echo "MYCEL_ENV=development" >> .env
 
 ### Breakpoints not hitting
 
-1. Make sure you're using valid stage names (see [Pipeline Stages](#pipeline-stages) table)
+1. Make sure you're using valid stage names (see [Available Stages for --break-at](#available-stages-for---break-at) table)
 2. Not all stages execute for every flow — e.g., `enrich` only runs if the flow has enrichments configured
 3. Use `--breakpoints` (all stages) first to see which stages your flow actually goes through
 

--- a/docs/guides/extending.md
+++ b/docs/guides/extending.md
@@ -237,7 +237,7 @@ Aspects (cross-cutting concerns applied across flows by pattern matching) are a 
 ## See Also
 
 - [WASM Documentation](../advanced/wasm.md) — complete WASM interface and language examples
-- [Plugins example](../../examples/plugin)
-- [Validators example](../../examples/validators)
-- [Aspects example](../../examples/aspects)
-- [Mocks example](../../examples/mocks)
+- [Plugins example](https://github.com/matutetandil/mycel/tree/main/examples/plugin)
+- [Validators example](https://github.com/matutetandil/mycel/tree/main/examples/validators)
+- [Aspects example](https://github.com/matutetandil/mycel/tree/main/examples/aspects)
+- [Mocks example](https://github.com/matutetandil/mycel/tree/main/examples/mocks)

--- a/docs/guides/multi-step-flows.md
+++ b/docs/guides/multi-step-flows.md
@@ -250,4 +250,4 @@ flow "checkout" {
 
 - [Core Concepts: Flows](../core-concepts/flows.md) — complete flow reference
 - [Core Concepts: Transforms](../core-concepts/transforms.md) — CEL functions
-- [Examples: Steps](../../examples/steps) — runnable step examples
+- [Examples: Steps](https://github.com/matutetandil/mycel/tree/main/examples/steps) — runnable step examples

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -723,4 +723,4 @@ scrape_configs:
 
 - [Configuration Reference](../reference/configuration.md) - Full HCL reference
 - [Troubleshooting Guide](troubleshooting.md) - Common issues
-- [Helm Chart](../../helm/mycel/README.md) - Kubernetes deployment
+- [Helm Chart](https://github.com/matutetandil/mycel/blob/main/helm/mycel/README.md) - Kubernetes deployment

--- a/docs/guides/real-time.md
+++ b/docs/guides/real-time.md
@@ -289,7 +289,7 @@ flow "react_to_price_change" {
 
 The client automatically reconnects with exponential backoff if the connection drops.
 
-See the [GraphQL connector docs](../connectors/graphql.md) and [federation example](../../examples/graphql-federation) for complete setup.
+See the [GraphQL connector docs](../connectors/graphql.md) and [federation example](https://github.com/matutetandil/mycel/tree/main/examples/graphql-federation) for complete setup.
 
 ## Combining Real-Time Patterns
 

--- a/docs/guides/sagas.md
+++ b/docs/guides/sagas.md
@@ -317,5 +317,5 @@ Workflow state can be persisted to: PostgreSQL, MySQL, SQLite.
 - [Sagas](#sagas)
 - [State Machines](#state-machines)
 - [Long-Running Workflows](#long-running-workflows)
-- [Examples: Saga](../../examples/saga)
-- [Examples: State Machine](../../examples/state-machine)
+- [Examples: Saga](https://github.com/matutetandil/mycel/tree/main/examples/saga)
+- [Examples: State Machine](https://github.com/matutetandil/mycel/tree/main/examples/state-machine)

--- a/docs/guides/synchronization.md
+++ b/docs/guides/synchronization.md
@@ -539,5 +539,5 @@ lock → coordinate → sequence_guard → transform → to → (write-back)
 
 ## See Also
 
-- [Examples: Sync](../../examples/sync)
+- [Examples: Sync](https://github.com/matutetandil/mycel/tree/main/examples/sync)
 - [Guides: Caching](caching.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ The foundational building blocks of every Mycel service.
 |----------|-------------|
 | [Connectors](core-concepts/connectors.md) | Bidirectional adapters: REST, database, queues, gRPC, WebSocket, file, and more |
 | [Flows](core-concepts/flows.md) | The unit of work — wiring connectors together with transforms, validation, caching, and error handling |
+| [Reusable Blocks](core-concepts/reusable-blocks.md) | Declare `dedupe`, `retry`, `lock`, `accept`, `response` and friends once by name, reference them from many flows with `use = "<kind>.<name>"` |
 | [Transforms](core-concepts/transforms.md) | CEL-based data transformations and the complete built-in function reference |
 | [Types](core-concepts/types.md) | Schema validation with field constraints, custom validators, and federation directives |
 | [Aspects](core-concepts/aspects.md) | Cross-cutting concerns (AOP) — audit, metrics, alerting, response enrichment — applied across flows by name pattern |
@@ -126,12 +127,14 @@ Documentation for each connector type.
 | [Elasticsearch](connectors/elasticsearch.md) | Write | Search and analytics |
 | [OAuth](connectors/oauth.md) | Server | Social login and OIDC |
 | [SOAP](connectors/soap.md) | Server + Client | SOAP 1.1/1.2 web services |
-| [Email](connectors/email.md) | Send | SMTP, SendGrid, AWS SES |
-| [Slack](connectors/slack.md) | Send | Slack Bot API |
-| [Discord](connectors/discord.md) | Send | Discord Bot API |
-| [SMS](connectors/sms.md) | Send | Twilio, AWS SNS |
-| [Push](connectors/push.md) | Send | FCM, APNs |
-| [Webhook](connectors/webhook.md) | Send | HTTP callbacks |
+| [Email](connectors/notifications.md#email) | Send | SMTP, SendGrid, AWS SES |
+| [Slack](connectors/notifications.md#slack) | Send | Slack Bot API |
+| [Discord](connectors/notifications.md#discord) | Send | Discord Bot API |
+| [SMS](connectors/notifications.md#sms) | Send | Twilio, AWS SNS |
+| [Push](connectors/notifications.md#push-notifications) | Send | FCM, APNs |
+| [Webhook](connectors/notifications.md#webhook) | Send | HTTP callbacks |
+| [PDF](connectors/pdf.md) | Write | Render PDF documents |
+| [Exec](connectors/exec.md) | Write | Run shell commands |
 
 ---
 
@@ -141,4 +144,4 @@ Documentation for each connector type.
 |----------|-------------|
 | [Architecture](architecture.md) | Design decisions: why HCL, why CEL, why WASM, why Go, trade-offs |
 | [Roadmap](ROADMAP.md) | Implementation status, phase history, and pending work |
-| [Changelog](../CHANGELOG.md) | Version history with detailed change descriptions |
+| [Changelog](https://github.com/matutetandil/mycel/blob/main/CHANGELOG.md) | Version history with detailed change descriptions |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,6 +7,11 @@ Complete HCL syntax reference for all Mycel block types. Every block is document
 - [service](#service)
 - [connector](#connector)
 - [flow](#flow)
+    - [from](#from-block) · [to](#to-block) · [accept](#accept-block) · [step](#step-block) · [enrich](#enrich-block)
+    - [transform](#transform-block) · [response](#response-block) · [validate](#validate-block) · [require](#require-block)
+    - [cache](#cache-block) · [after](#after-block) · [dedupe](#dedupe-block) · [idempotency](#idempotency-block) · [async](#async-block)
+    - [error_handling](#error_handling-block) · [lock](#lock-block) · [semaphore](#semaphore-block) · [coordinate](#coordinate-block) · [sequence_guard](#sequence_guard-block)
+    - [batch](#batch-block) · [state_transition](#state_transition-block)
 - [type](#type)
 - [transform](#transform)
 - [cache (named)](#cache-named)
@@ -534,6 +539,24 @@ connector "soap_server" {
 }
 ```
 
+### PDF
+
+```hcl
+connector "invoice_pdf" {
+  type         = "pdf"
+  template     = "./templates/invoice.html"   # Required: HTML template path
+  page_size    = "A4"                         # A4, Letter, Legal
+  font         = "Helvetica"
+  margin_left  = 15                           # Millimetres
+  margin_top   = 15
+  margin_right = 15
+  output_dir   = "./pdfs"                     # Used by the "save" operation
+}
+```
+
+Flow `operation` values: `generate` (default — returns the PDF as binary) or
+`save` (writes it to `output_dir`). See [PDF](../connectors/pdf.md).
+
 ### Connector Profiles
 
 ```hcl
@@ -572,6 +595,7 @@ flow "NAME" {
 
   from { ... }
   to { ... }
+  accept { ... }
   step "NAME" { ... }
   enrich "NAME" { ... }
   transform { ... }
@@ -585,12 +609,17 @@ flow "NAME" {
   lock { ... }
   semaphore { ... }
   coordinate { ... }
+  sequence_guard { ... }
   batch { ... }
   state_transition { ... }
   idempotency { ... }
   async { ... }
 }
 ```
+
+That is the complete set: 21 blocks and 4 attributes. Every one of them is
+optional except `from`. For what each block is *for*, rather than its bare
+syntax, see [Flow Anatomy](../core-concepts/flows.md#flow-anatomy).
 
 ### from block
 
@@ -631,6 +660,19 @@ to {
   parallel     = true                                      # Parallel multi-to (default: true)
 
   transform { ... }    # Per-destination transform
+}
+```
+
+### accept block
+
+Business-level gate. Runs after `filter` and before `transform`: `filter` decides
+whether a message *matches* this flow, `accept` decides whether this flow should
+*process* it. Useful when several flows consume the same queue.
+
+```hcl
+accept {
+  when      = "input.payload.type == 'A1'"   # Required — CEL, must return true to proceed
+  on_reject = "requeue"                      # "ack" (default), "reject", "requeue"
 }
 ```
 
@@ -871,6 +913,30 @@ coordinate {
     query     = "SELECT id FROM products WHERE sku = ?"
     params    = { sku = "input.parent_sku" }
     if_exists = "pass"                        # "pass" = skip wait, "fail" = error
+  }
+}
+```
+
+### sequence_guard block
+
+Rejects messages that arrive out of order: the incoming `sequence` must be
+strictly greater than the last one recorded for the same `key`. Composes inside
+`lock` and `coordinate`, and runs before `transform`.
+
+```hcl
+sequence_guard {
+  key      = "'sku_seq:' + input.body.sku"   # Required: CEL, the ordering scope
+  sequence = "input.body.version"            # Required: CEL, monotonic number
+  on_older = "ack"                           # "ack" (default), "reject", "requeue"
+  ttl      = "30d"                           # How long a key's sequence is remembered
+
+  storage {
+    driver   = "redis"       # Required
+    url      = env("REDIS_URL")
+    host     = "localhost"   # Alternative to url
+    port     = 6379
+    password = env("REDIS_PASSWORD")
+    db       = 0
   }
 }
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -597,7 +597,8 @@ flow "NAME" {
 ```hcl
 from {
   connector = "api"           # Required
-  operation = "GET /users"    # Required
+  operation = "GET /users"    # Required for rest/graphql/grpc/soap/tcp/sse;
+                              # optional (defaults to "*") for mq/mqtt/cdc/websocket/file
   format    = "json"          # "json", "xml", "csv", "tsv"
 
   # Simple filter (string)

--- a/docs/reference/source-properties.md
+++ b/docs/reference/source-properties.md
@@ -11,9 +11,28 @@ Available on every `from` block regardless of connector type:
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `connector` | string | yes | Name of the source connector |
-| `operation` | string | yes | Event type or endpoint (meaning varies per connector — see below) |
+| `operation` | string | depends — see below | Event type or endpoint (meaning varies per connector) |
 | `format` | string | no | Input format: `json`, `xml`, `csv` (default: `json`) |
 | `filter` | string/block | no | CEL condition to skip non-matching events |
+
+### Is `operation` required?
+
+Request/RPC-style sources address a specific endpoint, so `operation` is
+mandatory. Stream-style sources subscribe to whatever the connector already
+consumes, so `operation` only *narrows* what this flow handles — omit it and the
+flow receives everything.
+
+| `operation` **required** | `operation` **optional** (defaults to `"*"`, catch-all) |
+|---|---|
+| REST, GraphQL, gRPC, SOAP, TCP, SSE | RabbitMQ, Kafka, Redis Pub/Sub, MQTT, CDC, WebSocket, File watch |
+
+A missing required `operation` is reported by `mycel validate` and fails startup:
+
+```
+flow "create_user": from block is missing attribute "operation" required by connector "api" (rest)
+```
+
+Each connector section below states which case it falls into.
 
 ### Filter (block form — message queues)
 
@@ -53,6 +72,7 @@ flow "nightly_sync" {
 |----------|-------|
 | **Connector type** | `rest` |
 | **`operation` format** | `"METHOD /path"` — e.g., `"GET /users"`, `"POST /orders"`, `"GET /users/:id"` |
+| **`operation` required?** | **Required** |
 
 Path parameters use colon syntax (`:id`, `:user_id`).
 
@@ -85,6 +105,7 @@ from {
 |----------|-------|
 | **Connector type** | `graphql` |
 | **`operation` format** | `"Query.fieldName"`, `"Mutation.fieldName"`, `"Subscription.fieldName"` |
+| **`operation` required?** | **Required** |
 
 ### `input.*` variables
 
@@ -109,6 +130,7 @@ from {
 |----------|-------|
 | **Connector type** | `grpc` |
 | **`operation` format** | `"Service/Method"` or `"package.Service/Method"` |
+| **`operation` required?** | **Required** |
 
 ### `input.*` variables
 
@@ -133,6 +155,7 @@ from {
 |----------|-------|
 | **Connector type** | `soap` (with `driver = "server"`) |
 | **`operation` format** | SOAP operation name — e.g., `"CreateOrder"`, `"GetUser"` |
+| **`operation` required?** | **Required** |
 
 Extracted from the SOAP envelope body element name.
 
@@ -159,6 +182,7 @@ from {
 |----------|-------|
 | **Connector type** | `tcp` |
 | **`operation` format** | Message type string (json/msgpack) or NestJS pattern string |
+| **`operation` required?** | **Required** |
 
 ### `input.*` variables
 
@@ -181,8 +205,9 @@ from {
 
 | Property | Value |
 |----------|-------|
-| **Connector type** | `queue` (with `driver = "rabbitmq"`) |
+| **Connector type** | `mq` (with `driver = "rabbitmq"`) |
 | **`operation` format** | Routing key — e.g., `"orders.created"`, `"user.*"`, `"#"` |
+| **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 Supports AMQP topic exchange patterns: `*` matches one word, `#` matches zero or more.
 
@@ -213,8 +238,9 @@ from {
 
 | Property | Value |
 |----------|-------|
-| **Connector type** | `queue` (with `driver = "kafka"`) |
+| **Connector type** | `mq` (with `driver = "kafka"`) |
 | **`operation` format** | Topic name — e.g., `"orders"`, `"user-events"` |
+| **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 ### `input.*` variables
 
@@ -243,8 +269,9 @@ from {
 
 | Property | Value |
 |----------|-------|
-| **Connector type** | `queue` (with `driver = "redis"`) |
+| **Connector type** | `mq` (with `driver = "redis"`) |
 | **`operation` format** | Channel name or glob pattern — e.g., `"orders"`, `"user.*"`, `"*"` |
+| **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 Exact channel match first, then pattern match (from PSubscribe), then wildcard `"*"`.
 
@@ -274,6 +301,7 @@ from {
 |----------|-------|
 | **Connector type** | `mqtt` |
 | **`operation` format** | MQTT topic pattern — e.g., `"sensors/+/temperature"`, `"home/#"` |
+| **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 Supports MQTT wildcards: `+` matches single level, `#` matches multi-level.
 
@@ -305,6 +333,7 @@ from {
 |----------|-------|
 | **Connector type** | `websocket` |
 | **`operation` format** | Event type: `"connect"`, `"disconnect"`, `"message"`, or custom type string |
+| **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 ### `input.*` variables
 
@@ -332,6 +361,7 @@ from {
 |----------|-------|
 | **Connector type** | `sse` |
 | **`operation` format** | `"connect"` or `"disconnect"` |
+| **`operation` required?** | **Required** |
 
 SSE is unidirectional (server-to-client push). The `from` block only fires on lifecycle events.
 
@@ -359,6 +389,7 @@ from {
 |----------|-------|
 | **Connector type** | `cdc` |
 | **`operation` format** | `"TRIGGER:table"` — e.g., `"INSERT:users"`, `"UPDATE:orders"`, `"*:*"` |
+| **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 Trigger is uppercase (`INSERT`, `UPDATE`, `DELETE`). Wildcards: `"*:users"` (any trigger), `"INSERT:*"` (any table), `"*:*"` or `"*"` (all).
 
@@ -390,6 +421,7 @@ from {
 |----------|-------|
 | **Connector type** | `file` (with `watch = true`) |
 | **`operation` format** | Glob pattern — e.g., `"*.csv"`, `"reports/*.json"`, `"**/*.csv"` |
+| **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 Matches against filename, relative path, or `**/` prefix with filename suffix.
 
@@ -419,21 +451,21 @@ from {
 
 ## Summary
 
-| Connector | `operation` format | Key `input.*` fields |
-|-----------|--------------------|----------------------|
-| REST | `"METHOD /path"` (e.g., `"GET /users/:id"`) | path params, query params, body fields, `headers` |
-| GraphQL | `"Query.field"` / `"Mutation.field"` / `"Subscription.field"` | argument fields |
-| gRPC | `"Service/Method"` | proto message fields |
-| SOAP | `"OperationName"` | SOAP body element children |
-| TCP | message type/pattern string | `msg.Data` fields |
-| RabbitMQ | routing key (`*` / `#` wildcards) | `body`, `headers`, `properties`, `routing_key`, `exchange` |
-| Kafka | topic name | `body`, `headers`, `topic`, `partition`, `offset`, `key`, `timestamp` |
-| Redis Pub/Sub | channel name or glob pattern | `_channel`, `_pattern`, payload fields |
-| MQTT | topic pattern (`+` / `#` wildcards) | `_topic`, `_message_id`, `_qos`, `_retained`, payload fields |
-| WebSocket | `"connect"` / `"disconnect"` / `"message"` / custom type | `event`, data fields, `user_id`, `room` |
-| SSE | `"connect"` / `"disconnect"` | `event`, `client_id`, `remote_addr` |
-| CDC | `"TRIGGER:table"` (e.g., `"INSERT:users"`) | `trigger`, `table`, `schema`, `new`, `old`, `timestamp` |
-| File watch | glob pattern (e.g., `"*.csv"`) | `_path`, `_name`, `_size`, `_mod_time`, `_event`, content fields |
+| Connector | `type` | `operation` | `operation` format | Key `input.*` fields |
+|-----------|--------|-------------|--------------------|----------------------|
+| REST | `rest` | required | `"METHOD /path"` (e.g., `"GET /users/:id"`) | path params, query params, body fields, `headers` |
+| GraphQL | `graphql` | required | `"Query.field"` / `"Mutation.field"` / `"Subscription.field"` | argument fields |
+| gRPC | `grpc` | required | `"Service/Method"` | proto message fields |
+| SOAP | `soap` | required | `"OperationName"` | SOAP body element children |
+| TCP | `tcp` | required | message type/pattern string | `msg.Data` fields |
+| SSE | `sse` | required | `"connect"` / `"disconnect"` | `event`, `client_id`, `remote_addr` |
+| RabbitMQ | `mq` + `driver = "rabbitmq"` | optional (`"*"`) | routing key (`*` / `#` wildcards) | `body`, `headers`, `properties`, `routing_key`, `exchange` |
+| Kafka | `mq` + `driver = "kafka"` | optional (`"*"`) | topic name | `body`, `headers`, `topic`, `partition`, `offset`, `key`, `timestamp` |
+| Redis Pub/Sub | `mq` + `driver = "redis"` | optional (`"*"`) | channel name or glob pattern | `_channel`, `_pattern`, payload fields |
+| MQTT | `mqtt` | optional (`"*"`) | topic pattern (`+` / `#` wildcards) | `_topic`, `_message_id`, `_qos`, `_retained`, payload fields |
+| WebSocket | `websocket` | optional (`"*"`) | `"connect"` / `"disconnect"` / `"message"` / custom type | `event`, data fields, `user_id`, `room` |
+| CDC | `cdc` | optional (`"*"`) | `"TRIGGER:table"` (e.g., `"INSERT:users"`) | `trigger`, `table`, `schema`, `new`, `old`, `timestamp` |
+| File watch | `file` + `watch = true` | optional (`"*"`) | glob pattern (e.g., `"*.csv"`) | `_path`, `_name`, `_size`, `_mod_time`, `_event`, content fields |
 
 ---
 

--- a/internal/runtime/flow_schema_validation.go
+++ b/internal/runtime/flow_schema_validation.go
@@ -1,0 +1,123 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/matutetandil/mycel/internal/parser"
+	"github.com/matutetandil/mycel/pkg/schema"
+)
+
+// ValidateFlowSchemas checks every flow's "from" block against the source schema
+// declared by its connector. Connectors describe which flow parameters they need
+// (see ConnectorSchemaProvider.SourceSchema); until now that contract was only
+// consumed by the IDE engine, so a REST flow missing its "operation" reached the
+// runtime and failed later with an unrelated error — or silently registered a
+// handler for the empty operation.
+//
+// Only attributes marked Required are enforced. Connectors that default a
+// parameter (message queues default "operation" to the catch-all "*") declare it
+// optional and are left alone.
+//
+// Returns one error per offending flow, sorted by flow name for stable output.
+// Connectors with no registered schema (plugins, custom types) are skipped.
+func ValidateFlowSchemas(config *parser.Configuration, reg *schema.Registry) []error {
+	if config == nil || reg == nil {
+		return nil
+	}
+
+	// Index connectors by name so each flow can resolve its source type/driver.
+	byName := make(map[string]*connectorRef, len(config.Connectors))
+	for _, c := range config.Connectors {
+		if c == nil {
+			continue
+		}
+		byName[c.Name] = &connectorRef{Type: c.Type, Driver: c.Driver}
+	}
+
+	var errs []error
+	for _, f := range config.Flows {
+		if f == nil || f.From == nil || f.From.Connector == "" {
+			continue
+		}
+
+		ref, ok := byName[f.From.Connector]
+		if !ok {
+			// Unknown connector: registerFlows reports this with a better message.
+			continue
+		}
+
+		provider := reg.Lookup(ref.Type, ref.Driver)
+		if provider == nil {
+			continue
+		}
+
+		src := provider.SourceSchema()
+		if src == nil {
+			continue
+		}
+
+		var missing []string
+		for _, attr := range src.Attrs {
+			if !attr.Required {
+				continue
+			}
+			if !hasParam(f.From.ConnectorParams, attr.Name) {
+				missing = append(missing, attr.Name)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+
+		sort.Strings(missing)
+		errs = append(errs, fmt.Errorf(
+			"flow %q: from block is missing %s required by connector %q (%s)",
+			f.Name, quoteList(missing), f.From.Connector, describeType(ref),
+		))
+	}
+
+	sort.Slice(errs, func(i, j int) bool { return errs[i].Error() < errs[j].Error() })
+	return errs
+}
+
+// connectorRef is the minimal connector identity needed for a schema lookup.
+type connectorRef struct {
+	Type   string
+	Driver string
+}
+
+// describeType renders "type" or "type/driver" for error messages.
+func describeType(ref *connectorRef) string {
+	if ref.Driver != "" {
+		return ref.Type + "/" + ref.Driver
+	}
+	return ref.Type
+}
+
+// hasParam reports whether params holds a non-empty value for name.
+// A present-but-blank attribute (operation = "") counts as missing: it is a
+// typo, not a deliberate catch-all.
+func hasParam(params map[string]interface{}, name string) bool {
+	v, ok := params[name]
+	if !ok || v == nil {
+		return false
+	}
+	if s, isStr := v.(string); isStr {
+		return strings.TrimSpace(s) != ""
+	}
+	return true
+}
+
+// quoteList renders attribute names as `"a"` or `"a", "b"`.
+func quoteList(names []string) string {
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = fmt.Sprintf("%q", n)
+	}
+	if len(quoted) == 1 {
+		return "attribute " + quoted[0]
+	}
+	return "attributes " + strings.Join(quoted, ", ")
+}

--- a/internal/runtime/flow_schema_validation_test.go
+++ b/internal/runtime/flow_schema_validation_test.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/flow"
+	"github.com/matutetandil/mycel/internal/parser"
+)
+
+// newConfig builds a Configuration with one connector and one flow reading from it.
+func newConfig(connName, connType, driver string, fromParams map[string]interface{}) *parser.Configuration {
+	return &parser.Configuration{
+		Connectors: []*connector.Config{
+			{Name: connName, Type: connType, Driver: driver},
+		},
+		Flows: []*flow.Config{
+			{
+				Name: "test_flow",
+				From: &flow.FromConfig{Connector: connName, ConnectorParams: fromParams},
+			},
+		},
+	}
+}
+
+func TestValidateFlowSchemas_RESTRequiresOperation(t *testing.T) {
+	reg := NewSchemaRegistry()
+	cfg := newConfig("api", "rest", "", map[string]interface{}{})
+
+	errs := ValidateFlowSchemas(cfg, reg)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	msg := errs[0].Error()
+	for _, want := range []string{"test_flow", "operation", "api", "rest"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestValidateFlowSchemas_RESTWithOperationPasses(t *testing.T) {
+	reg := NewSchemaRegistry()
+	cfg := newConfig("api", "rest", "", map[string]interface{}{"operation": "GET /users"})
+
+	if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateFlowSchemas_QueueOperationIsOptional(t *testing.T) {
+	// Message queues default operation to the catch-all "*", so omitting it is legal.
+	reg := NewSchemaRegistry()
+	for _, driver := range []string{"rabbitmq", "kafka", "redis"} {
+		cfg := newConfig("q", "mq", driver, map[string]interface{}{})
+		if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 0 {
+			t.Errorf("driver %s: expected no errors, got: %v", driver, errs)
+		}
+	}
+}
+
+func TestValidateFlowSchemas_OtherOptionalSources(t *testing.T) {
+	reg := NewSchemaRegistry()
+	for _, connType := range []string{"mqtt", "cdc", "websocket", "file"} {
+		cfg := newConfig("src", connType, "", map[string]interface{}{})
+		if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 0 {
+			t.Errorf("type %s: expected no errors, got: %v", connType, errs)
+		}
+	}
+}
+
+func TestValidateFlowSchemas_OtherRequiredSources(t *testing.T) {
+	reg := NewSchemaRegistry()
+	for _, connType := range []string{"graphql", "grpc", "soap", "tcp", "sse"} {
+		cfg := newConfig("src", connType, "", map[string]interface{}{})
+		if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 1 {
+			t.Errorf("type %s: expected 1 error, got %d: %v", connType, len(errs), errs)
+		}
+	}
+}
+
+func TestValidateFlowSchemas_BlankOperationCountsAsMissing(t *testing.T) {
+	reg := NewSchemaRegistry()
+	cfg := newConfig("api", "rest", "", map[string]interface{}{"operation": "   "})
+
+	if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 1 {
+		t.Fatalf("expected 1 error for blank operation, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateFlowSchemas_UnknownConnectorTypeSkipped(t *testing.T) {
+	// Plugin-provided connectors have no registered schema; they must not be flagged.
+	reg := NewSchemaRegistry()
+	cfg := newConfig("custom", "my-wasm-plugin", "", map[string]interface{}{})
+
+	if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 0 {
+		t.Fatalf("expected no errors for unknown connector type, got: %v", errs)
+	}
+}
+
+func TestValidateFlowSchemas_UnknownConnectorNameSkipped(t *testing.T) {
+	// registerFlows reports the dangling reference with a clearer message.
+	reg := NewSchemaRegistry()
+	cfg := newConfig("api", "rest", "", map[string]interface{}{"operation": "GET /x"})
+	cfg.Flows[0].From.Connector = "does_not_exist"
+
+	if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 0 {
+		t.Fatalf("expected no errors for unknown connector name, got: %v", errs)
+	}
+}
+
+func TestValidateFlowSchemas_NoFromBlockSkipped(t *testing.T) {
+	reg := NewSchemaRegistry()
+	cfg := newConfig("api", "rest", "", nil)
+	cfg.Flows[0].From = nil
+
+	if errs := ValidateFlowSchemas(cfg, reg); len(errs) != 0 {
+		t.Fatalf("expected no errors for flow without from block, got: %v", errs)
+	}
+}
+
+func TestValidateFlowSchemas_NilInputs(t *testing.T) {
+	if errs := ValidateFlowSchemas(nil, NewSchemaRegistry()); errs != nil {
+		t.Errorf("expected nil for nil config, got: %v", errs)
+	}
+	if errs := ValidateFlowSchemas(newConfig("api", "rest", "", nil), nil); errs != nil {
+		t.Errorf("expected nil for nil registry, got: %v", errs)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -244,6 +245,13 @@ func New(opts Options) (*Runtime, error) {
 	config, err := p.Parse(context.Background(), opts.ConfigDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse configuration: %w", err)
+	}
+
+	// Check each flow's "from" block against its source connector's schema,
+	// so a missing required parameter fails here instead of surfacing later
+	// as a confusing runtime error.
+	if errs := ValidateFlowSchemas(config, schemaReg); len(errs) > 0 {
+		return nil, fmt.Errorf("invalid configuration: %w", errors.Join(errs...))
 	}
 
 	// Create connector registry

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,10 @@ markdown_extensions:
   - tables
   - toc:
       permalink: true
+      # GitHub-compatible heading slugs, so the same anchor link resolves both
+      # on github.com and on the published site. The default slugify collapses
+      # the double dash that GitHub keeps in headings like "REST → Database".
+      slugify: !!python/object/apply:pymdownx.slugs.slugify {kwds: {case: lower}}
 
 nav:
   - Home: index.md
@@ -118,7 +122,7 @@ nav:
       - Production: deployment/production.md
   - Reference:
       - CLI: reference/cli.md
-      - Configuration: reference/configuration.md
+      - HCL Syntax (all blocks): reference/configuration.md
       - CEL Functions: reference/cel-functions.md
       - API Endpoints: reference/api-endpoints.md
       - Source Properties: reference/source-properties.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,9 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
+    # Top-level groups become tabs so the sidebar shows one section at a time
+    # instead of ~65 links in a single scroll.
+    - navigation.tabs
     - navigation.sections
     - navigation.expand
     - navigation.top
@@ -57,6 +60,7 @@ nav:
   - Core Concepts:
       - Connectors: core-concepts/connectors.md
       - Flows: core-concepts/flows.md
+      - Reusable Blocks: core-concepts/reusable-blocks.md
       - Transforms: core-concepts/transforms.md
       - Types: core-concepts/types.md
       - Aspects: core-concepts/aspects.md
@@ -85,21 +89,23 @@ nav:
       - Exec: connectors/exec.md
       - Profiles: connectors/profile.md
   - Guides:
-      - Authentication: guides/auth.md
-      - Caching: guides/caching.md
-      - Debugging: guides/debugging.md
-      - Error Handling: guides/error-handling.md
-      - Extending: guides/extending.md
-      - Format System: guides/format-system.md
+      # Ordered as a learning path, not alphabetically.
+      - Common Use Cases: guides/use-cases.md
       - Multi-Step Flows: guides/multi-step-flows.md
-      - Notifications: guides/notifications.md
-      - Observability: guides/observability.md
-      - Real-Time: guides/real-time.md
-      - Sagas: guides/sagas.md
-      - Security: guides/security.md
+      - Caching: guides/caching.md
       - Synchronization: guides/synchronization.md
+      - Sagas & State Machines: guides/sagas.md
+      - Real-Time: guides/real-time.md
       - Batch Processing: guides/batch-processing.md
-      - Use Cases: guides/use-cases.md
+      - Notifications: guides/notifications.md
+      - Authentication: guides/auth.md
+      - Security: guides/security.md
+      - Error Handling: guides/error-handling.md
+      - Resilience & Failure Recovery: guides/resilience.md
+      - Format System: guides/format-system.md
+      - Extending Mycel: guides/extending.md
+      - Debugging: guides/debugging.md
+      - Observability: guides/observability.md
       - Troubleshooting: guides/troubleshooting.md
   - Advanced:
       - GraphQL Federation: advanced/federation.md
@@ -117,5 +123,8 @@ nav:
       - API Endpoints: reference/api-endpoints.md
       - Source Properties: reference/source-properties.md
       - Destination Properties: reference/destination-properties.md
-  - Architecture: architecture.md
-  - Studio Debug Protocol: STUDIO-DEBUG-PROTOCOL.md
+  - Project:
+      - Architecture: architecture.md
+      - Roadmap: ROADMAP.md
+      - Studio Debug Protocol: STUDIO-DEBUG-PROTOCOL.md
+      - IDE Engine: IDE-ENGINE.md


### PR DESCRIPTION
## Summary

Started as a documentation review of two complaints — "`operation` is documented as required but a queue flow doesn't need it" and "I couldn't find how a flow is defined" — and ended up fixing the code behind the first one.

**`operation` was documented as always required. It isn't, and it wasn't checked either.**

It is required for `rest`, `graphql`, `grpc`, `soap`, `tcp` and `sse`; optional for `mq`, `mqtt`, `cdc`, `websocket` and `file` watch, which default it to the catch-all `"*"`. Three places in the docs claimed otherwise, and the catch-all default was undocumented.

Worse, nothing enforced it. Connectors have always declared their required flow parameters via `ConnectorSchemaProvider.SourceSchema`, but only the IDE engine consumed that contract — a REST flow missing its `operation` parsed cleanly and registered a handler for the empty operation. `mycel validate` and `mycel start` now check every flow's `from` block against its source connector's schema:

```
flow "create_user": from block is missing attribute "operation" required by connector "api" (rest)
```

Only attributes marked required are enforced, so connectors that default a parameter are untouched. Connectors with no registered schema (plugin-provided ones) are skipped.

**Nothing answered "what can go inside a flow?"**

The information existed, but the flows page opened with a minimal example and then ran for a thousand lines of prose, with the pipeline order buried mid-page inside the `accept` section; the complete block inventory lived in the configuration reference, filed under Reference and named after configuration rather than flows.

`docs/core-concepts/flows.md` now opens with **Flow Anatomy**: the pipeline diagram, then a table of all 21 blocks and 4 attributes, each with one line on what it does and a link to its full documentation. The README and the configuration reference point at it.

## Also fixed along the way

- **The connector type for message queues was documented as `queue`.** The real HCL type is `mq` — `queue` parses but fails when the runtime builds the connector.
- **The configuration reference was incomplete** despite advertising "every block type": `accept` and `sequence_guard` were parseable but undocumented there, and the PDF connector had no section at all. All three added, plus a `sequence_guard` section on the flows page.
- **Two pages were unreachable from the published site**: reusable blocks — which the docs themselves label as recommended — and the resilience guide were absent from the nav.
- **Every broken link and heading anchor.** Links leaving `docs/` resolved from the wrong depth and 404'd on the site regardless, so they now use absolute repository URLs. Heading slugs are GitHub-compatible, so anchors like `#4-rabbitmq--database` resolve in both places — that alone fixed eleven dead in-page links.
- **CLI errors no longer dump the usage text.** Every failure printed the full flag list after the error, burying the diagnostics. Usage is suppressed from the point a command starts running; flag and argument errors still print it, and unknown commands keep cobra's `Run 'mycel --help' for usage.` hint. `main` also printed the error a second time after cobra had already reported it.
- Guides were ordered alphabetically in the nav while the docs index ordered them as a learning path; the nav now follows the index. Top-level groups render as tabs instead of listing every page in one scroll.

## Related issue

None.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (behavior or config changes that aren't backward compatible)
- [ ] Docs only
- [ ] Refactor / chore

**Worth flagging for the version bump:** `mycel validate` now fails on configs that previously passed. Those configs were already broken at runtime, but a CI job running `mycel validate` goes from green to red without the user's config having changed. That reads as a minor bump rather than a patch.

## How it was tested

- `internal/runtime/flow_schema_validation_test.go` — 10 cases: required per connector type, optional per connector type, blank value counts as missing, unknown connector type/name skipped, no `from` block, nil inputs.
- All **81 example config directories** validate with no new failures.
- Negative test against a real binary: a config with one REST flow and one queue flow, both missing `operation`, flags exactly the REST one.
- The new `sequence_guard` documentation example was validated against the real binary rather than written from memory.
- CLI behavior checked across four paths: schema error (diagnostics, no usage, exit 1), bad flag (usage shown — it is a usage mistake), unknown command (cobra's suggestion intact), missing config dir (error only).
- `mkdocs build --strict` completes with zero warnings; previously it aborted on 5 and reported 14 broken anchors.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` all pass
- [x] Added/updated tests for the change
- [x] Updated docs (`docs/`, `README.md`, and any affected example)
- [x] Updated `CHANGELOG.md` for user-facing changes
- [x] New/changed `examples/` validate with `mycel validate`
- [x] Breaking changes are called out above and in `CHANGELOG.md`
