### PR TITLE
chore: bump version to 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.12.0] - 2026-08-04
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.11.1"
+	version = "2.12.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
## Summary

Releases 2.12.0, covering the work merged in #36. Two lines: the `[Unreleased]` changelog heading becomes `[2.12.0] - 2026-08-04`, and the embedded version string moves from `2.11.1` to `2.12.0`.

**Minor rather than patch:** `mycel validate` now rejects configs that previously passed — a flow whose `from` block omits a parameter its source connector declares as required. Those configs were already broken at runtime (a REST flow with no `operation` registered a handler for the empty operation), but a CI job running `mycel validate` goes from green to red without the user's configuration having changed. That is a behavior change users can trip over, so it does not belong in a patch release.

The Helm chart is untouched on purpose: `release.yml` rewrites `appVersion` from the tag at package time.

## Related issue

Releases #36.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking, additive)
- [ ] Breaking change (behavior or config changes that aren't backward compatible)
- [ ] Docs only
- [x] Refactor / chore

## How it was tested

Rebuilt the binary and confirmed it reports the new version:

```
$ mycel --version
mycel version 2.12.0 (commit: dev)
```

Full verification ran on #36 before merge; this PR changes no logic.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` all pass
- [ ] Added/updated tests for the change — n/a, version bump
- [ ] Updated docs — n/a, version bump
- [x] Updated `CHANGELOG.md` for user-facing changes
- [ ] New/changed `examples/` validate with `mycel validate` — n/a, no example changes
- [x] Breaking changes are called out above and in `CHANGELOG.md`
