### PR TITLE
Make silent failures loud: dispatch, drops, connectivity and metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ Every item here has the same shape: a misconfiguration that produced no error, j
 
   Exits non-zero when anything is unreachable, so it works as a deploy gate. `connection refused` (something answered and said no) is distinguished from `no response within <timeout>` (nothing answered at all), and failures to build the connector are reported the same way, including the missing environment variable behind an empty `env()`.
 
+- **Per-flow timing extremes and throughput**, over successful executions only: `mycel_flow_duration_fastest_seconds`, `mycel_flow_duration_slowest_seconds`, `mycel_flow_duration_average_seconds` and `mycel_flow_messages_per_second`.
+
+  Most of this was already derivable from the `mycel_flow_duration_seconds` histogram — `rate(_count)` is the throughput and `rate(_sum)/rate(_count)` the average — and those queries remain the better instrument where a Prometheus server is available, being windowed rather than cumulative. Two things were not derivable: a histogram records which bucket a value fell into rather than the value, so the true fastest and slowest cannot be recovered from it, and the histogram is not split by status, so nothing from it can be narrowed to messages that actually succeeded. A flow failing in 1 ms would otherwise take the "fastest" spot and pull the average down.
+
+  Computed at scrape time by a collector, with no background goroutine, and bounded memory per flow (throughput uses a fixed 60-slot ring, not a list of samples). The existing histogram is unchanged and still observes every execution.
+
 - **The sync, cache and connector metrics are recorded.** They were defined, registered and documented from the start — including a Grafana panel for cache hit rate — with no call sites anywhere, so they were permanently absent from `/metrics`. Now emitted: `mycel_lock_*`, `mycel_semaphore_*`, `mycel_coordinate_*`, `mycel_cache_{hits,misses}_total`, `mycel_connector_health`, `mycel_connector_operations_total` and `mycel_connector_latency_seconds`.
 
   `mycel_lock_wait_seconds` is the one worth watching: time spent waiting for a lock is invisible in `mycel_flow_duration_seconds`, so a consumer that looks fast per message can still be serialized behind a hot key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ Every item here has the same shape: a misconfiguration that produced no error, j
 
   **The sync metrics are now labelled by `flow`, not by `key`.** Lock, semaphore and signal keys are CEL expressions evaluated per message — one per order, per SKU, per customer — so recording them as declared would have grown the time series set without bound. `mycel_connector_operations_total` labels the operation coarsely (`read`, `write`, `call`) for the same reason. Since none of these metrics had ever been emitted, no existing dashboard or alert can break.
 
+- **Every deliberate drop explains itself at debug level.** A message Mycel declines to process is not an error, so nothing failed, nothing logged, and the result was indistinguishable from a broker that never delivered it. Each gate already reported a stable reason, but only `on_drop` aspects ever saw it.
+
+  ```
+  DBG message dropped by policy flow=only_big_orders source=api reason=filter
+      decided_by="from { filter }" detail="input.total > 100" disposition=ack
+  ```
+
+  `decided_by` names the HCL block to go and edit, and `detail` the expression, fingerprint or sequence numbers that block was judging — `reason` alone says which gate said no, not why. Covers `filter`, `accept`, `dedupe`, `sequence_guard` and `coordinate` timeouts, logged from the one choke-point every source funnels through, so the line is identical whichever connector delivered the message. The payload can be included with `MYCEL_PAYLOAD_SHOW`, under the same cap as the incoming-payload log; it stays a separate opt-in because a dropped message is still customer data.
+
 ### Changed
 
 - **A message no flow can handle is now an error, not a warning.** This applies to **RabbitMQ, Kafka and Redis**, which all had the same hole: WARN, no metric, message gone. Each states what it just did, because the outcome differs — RabbitMQ nacks without requeue (a dead-letter exchange may still catch it), Kafka commits the offset (it will not be redelivered), Redis pub/sub simply discards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Every item here has the same shape: a misconfiguration that produced no error, just an absence of behaviour. Nothing in this release changes what a correct configuration does.
+
+### Added
+
+- **`mycel version`.** Documented in the CLI reference, the README and the installation guide, but never actually registered — only cobra's `--version` flag existed. It prints the version, build commit, Go toolchain and platform. The same information is in the startup banner, which is no help on a pod that has been running long enough for that line to roll out of the log buffer.
+
+  ```
+  mycel 2.12.0 (commit: 64be3eb, go1.25.0, linux/amd64)
+  ```
+
+- **`mycel_messages_undispatched_total{connector,queue,routing_key}`.** Counts messages that reached a consumer and matched no flow handler. Previously nothing recorded these: the queue showed deliveries with no acks, and no metric moved.
+
+- **`mycel validate` reports unset `env()` references.** Startup already names the missing variable when the empty value leaves a required attribute unset (2.11.1), but validate passed clean on the same config. Unset variables are a warning, not a failure — validate legitimately runs in CI, without the deployment environment — and the output names the connector and attribute each one feeds.
+
+- **`mycel validate` and startup report configuration that has no effect.** `params` on a `to` block is the first case: it parses, and nothing ever reads it. A write sends the transform output, or the raw input when the flow has no transform. The attribute is real on `step`, on `enrich`, and on `exec` inside a `transaction`, which is how it ends up copied onto `to`.
+
+- **`mycel check` actually checks.** It created the runtime, printed `✓ All connectors configured correctly!` and exited zero without opening a single connection — a database on an unroutable address passed, and the documented per-connector output did not exist. It now builds, connects and health-checks every connector, concurrently and each with its own timeout (`--timeout`, default 10s), reporting all of them rather than stopping at the first failure:
+
+  ```
+    ✓ orders_db (database/postgres): connected in 12ms
+    ✗ payments_api (http): no response within 10s
+
+  Error: 1 of 2 connectors unreachable
+  ```
+
+  Exits non-zero when anything is unreachable, so it works as a deploy gate. `connection refused` (something answered and said no) is distinguished from `no response within <timeout>` (nothing answered at all), and failures to build the connector are reported the same way, including the missing environment variable behind an empty `env()`.
+
+- **The sync, cache and connector metrics are recorded.** They were defined, registered and documented from the start — including a Grafana panel for cache hit rate — with no call sites anywhere, so they were permanently absent from `/metrics`. Now emitted: `mycel_lock_*`, `mycel_semaphore_*`, `mycel_coordinate_*`, `mycel_cache_{hits,misses}_total`, `mycel_connector_health`, `mycel_connector_operations_total` and `mycel_connector_latency_seconds`.
+
+  `mycel_lock_wait_seconds` is the one worth watching: time spent waiting for a lock is invisible in `mycel_flow_duration_seconds`, so a consumer that looks fast per message can still be serialized behind a hot key.
+
+  **The sync metrics are now labelled by `flow`, not by `key`.** Lock, semaphore and signal keys are CEL expressions evaluated per message — one per order, per SKU, per customer — so recording them as declared would have grown the time series set without bound. `mycel_connector_operations_total` labels the operation coarsely (`read`, `write`, `call`) for the same reason. Since none of these metrics had ever been emitted, no existing dashboard or alert can break.
+
+### Changed
+
+- **A message no flow can handle is now an error, not a warning.** This applies to **RabbitMQ, Kafka and Redis**, which all had the same hole: WARN, no metric, message gone. Each states what it just did, because the outcome differs — RabbitMQ nacks without requeue (a dead-letter exchange may still catch it), Kafka commits the offset (it will not be redelivered), Redis pub/sub simply discards.
+
+  The usual cause is that on a message queue source `operation` reads like an operation *name* but is a subscription *pattern*, so an invented value matches nothing and every delivery is dropped. The first occurrence per key is logged at ERROR with the patterns flows actually registered alongside it — the difference between the two is the diagnosis. Repeats only move the counter, so a misconfigured consumer does not drown the log.
+
+- **Consumers log the routing keys they will dispatch at startup**, and log an error when a consumer starts with no flow handlers at all. Both make the mismatch visible before the first message arrives.
+
+- **`dlq { enabled = true }` says plainly when it is not in effect.** Mycel provisions the dead-letter exchange only when it declared the queue itself; on a pre-existing queue it provisions nothing, so a message that exhausts its retries is discarded unless the queue already carries `x-dead-letter-exchange` or a server-side policy sets one. This was already warned about, but the message opened with the part that still works and left the conclusion to the end. It now leads with the conclusion and states what to check.
+
+  It stays a warning rather than a startup failure because Mycel genuinely cannot check: AMQP's `queue.declare-ok` returns the name, message count and consumer count and nothing else, and policies are not visible over AMQP at all — a correctly dead-lettered queue and one with no dead-lettering anywhere look identical. New `dlq { external = true }` records the answer once you have checked the broker yourself: Mycel then provisions no DLX or DLQ, sets no `x-dead-letter-exchange` argument (it does not know which exchange name ops chose), and stays quiet. Retry counting is unaffected either way, and omitting the attribute keeps the previous behaviour exactly.
+
+- **Per-delivery handler lookup logging moved from info to debug.** It logged a line for every message in production.
+
 ## [2.12.0] - 2026-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Every item here has the same shape: a misconfiguration that produced no error, j
 
   `mycel_lock_wait_seconds` is the one worth watching: time spent waiting for a lock is invisible in `mycel_flow_duration_seconds`, so a consumer that looks fast per message can still be serialized behind a hot key.
 
+  Lock metrics carry a second label, `purpose`: `flow` for the flow's own `lock {}` block, guarding a business key, and `dedupe` for the critical section around the duplicate check. Contention means different things in each — a hot business key versus duplicate deliveries piling up — and they want different responses.
+
   **The sync metrics are now labelled by `flow`, not by `key`.** Lock, semaphore and signal keys are CEL expressions evaluated per message — one per order, per SKU, per customer — so recording them as declared would have grown the time series set without bound. `mycel_connector_operations_total` labels the operation coarsely (`read`, `write`, `call`) for the same reason. Since none of these metrics had ever been emitted, no existing dashboard or alert can break.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Every item here has the same shape: a misconfiguration that produced no error, j
 
   **The sync metrics are now labelled by `flow`, not by `key`.** Lock, semaphore and signal keys are CEL expressions evaluated per message — one per order, per SKU, per customer — so recording them as declared would have grown the time series set without bound. `mycel_connector_operations_total` labels the operation coarsely (`read`, `write`, `call`) for the same reason. Since none of these metrics had ever been emitted, no existing dashboard or alert can break.
 
+- **`mycel_flow_drops_total{flow,reason}`**, and a `dropped` status on `mycel_flow_executions_total`. A declined message was counted as a success, so a consumer filtering out most of its input reported full productivity and there was no way to graph or alert on drops at all — only to read them out of the log. `reason` matches the drop log line, so the two are read together. **This corrects existing series**: flows with a `filter`, `accept`, `dedupe`, `sequence_guard` or `coordinate` timeout will see `status="success"` fall and a `status="dropped"` series appear.
+
+  Drops are also excluded from the timing gauges above. A drop short-circuits before the transform, so it was owning the "fastest" gauge permanently and pulling the average down — on a flow filtering 8 of 9 messages, `fastest` reported 14µs of doing nothing instead of the 1.9ms of real work.
+
 - **Every deliberate drop explains itself at debug level.** A message Mycel declines to process is not an error, so nothing failed, nothing logged, and the result was indistinguishable from a broker that never delivered it. Each gate already reported a stable reason, but only `on_drop` aspects ever saw it.
 
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,17 @@ Every item here has the same shape: a misconfiguration that produced no error, j
 
   The usual cause is that on a message queue source `operation` reads like an operation *name* but is a subscription *pattern*, so an invented value matches nothing and every delivery is dropped. The first occurrence per key is logged at ERROR with the patterns flows actually registered alongside it — the difference between the two is the diagnosis. Repeats only move the counter, so a misconfigured consumer does not drown the log.
 
-- **Consumers log the routing keys they will dispatch at startup**, and log an error when a consumer starts with no flow handlers at all. Both make the mismatch visible before the first message arrives.
+- **Startup states, per flow, which messages it will actually receive.** On a stream source `operation` is optional, which reads as inert — it is not. Declaring it registers the flow's handler under that key and filters every delivery against it, a *second* filter after the broker's own exchange and binding. Nothing said so, at startup or in the reference.
+
+  ```
+  INF dispatch: flow only accepts matching messages connector=rabbit flow=item_create
+      operation=all.in.magento.q meaning="only deliveries whose key matches \"all.in.magento.q\" reach this flow"
+  WRN dispatch: messages matching no pattern will be DROPPED connector=rabbit
+      patterns="\"all.in.magento.q\"" hint="on a message queue source `operation` is a
+      subscription pattern, not an operation name; omit it to accept every message"
+  ```
+
+  The warning fires only when **every** flow on a connector is narrowed, since one catch-all sibling guarantees a handler for anything that arrives. It runs before connectors are dialled, so the dispatch shape is visible even when the broker is down and startup is about to fail, and it is driver-agnostic: which connectors treat `operation` as a subscription pattern comes from their own `SourceSchema`, so RabbitMQ, Kafka, Redis, MQTT, CDC, WebSocket and file watch are all covered without a per-driver list. RabbitMQ consumers additionally log an error when they start with no flow handlers at all.
 
 - **`dlq { enabled = true }` says plainly when it is not in effect.** Mycel provisions the dead-letter exchange only when it declared the queue itself; on a pre-existing queue it provisions nothing, so a message that exhausts its retries is discarded unless the queue already carries `x-dead-letter-exchange` or a server-side policy sets one. This was already warned about, but the message opened with the part that still works and left the conclusion to the end. It now leads with the conclusion and states what to check.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Every item here has the same shape: a misconfiguration that produced no error, j
 
   Exits non-zero when anything is unreachable, so it works as a deploy gate. `connection refused` (something answered and said no) is distinguished from `no response within <timeout>` (nothing answered at all), and failures to build the connector are reported the same way, including the missing environment variable behind an empty `env()`.
 
+  Connectors that listen rather than dial — REST, GraphQL, gRPC, SOAP and TCP servers, plus SSE and WebSocket — are reported as such and never fail the check: they have no endpoint to reach, and are not started here, so their health check would only ever report "not started". They declare this through a new optional `connector.InboundOnly` interface rather than being matched by type, since server and client are already separate types.
+
 - **Per-flow timing extremes and throughput**, over successful executions only: `mycel_flow_duration_fastest_seconds`, `mycel_flow_duration_slowest_seconds`, `mycel_flow_duration_average_seconds` and `mycel_flow_messages_per_second`.
 
   Most of this was already derivable from the `mycel_flow_duration_seconds` histogram — `rate(_count)` is the throughput and `rate(_sum)/rate(_count)` the average — and those queries remain the better instrument where a Prometheus server is available, being windowed rather than cumulative. Two things were not derivable: a histogram records which bucket a value fell into rather than the value, so the true fastest and slowest cannot be recovered from it, and the histogram is not split by status, so nothing from it can be narrowed to messages that actually succeeded. A flow failing in 1 ms would otherwise take the "fastest" spot and pull the average down.

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -575,11 +575,19 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println()
-	failed := 0
+	failed, inbound := 0, 0
 	for _, res := range results {
 		label := res.Name
 		if desc := describeConnectorKind(res.Type, res.Driver); desc != "" {
 			label = fmt.Sprintf("%s (%s)", res.Name, desc)
+		}
+
+		// A listener has no endpoint to reach. Saying so beats both a green
+		// tick it did not earn and a cross for a check that never applied.
+		if res.Inbound {
+			inbound++
+			fmt.Printf("  – %s: listens, nothing to reach\n", label)
+			continue
 		}
 
 		if res.OK() {
@@ -601,7 +609,17 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	if failed > 0 {
 		return fmt.Errorf("%d of %d connectors unreachable", failed, len(results))
 	}
-	fmt.Printf("✓ All %d connectors reachable!\n", len(results))
+	// Count only what was actually reached, so a config that is all listeners
+	// does not claim to have verified anything.
+	dialed := len(results) - inbound
+	switch {
+	case dialed == 0:
+		fmt.Printf("✓ Nothing to reach: all %d connectors listen for inbound traffic.\n", inbound)
+	case inbound > 0:
+		fmt.Printf("✓ All %d reachable connectors are up (%d listen for inbound traffic).\n", dialed, inbound)
+	default:
+		fmt.Printf("✓ All %d connectors reachable!\n", dialed)
+	}
 
 	return nil
 }

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -6,12 +6,15 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"go.uber.org/automaxprocs/maxprocs"
 
+	"github.com/matutetandil/mycel/internal/connector"
 	"github.com/matutetandil/mycel/internal/envdefaults"
 	"github.com/matutetandil/mycel/internal/export/asyncapi"
 	"github.com/matutetandil/mycel/internal/export/openapi"
@@ -173,6 +176,20 @@ Common issues detected:
 	RunE: runCheck,
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the Mycel version",
+	Long: `Print the Mycel version, build commit, Go toolchain and platform.
+
+The same information appears in the startup banner, but on a pod that has been
+running for a while that line has long rolled out of the log buffer. This
+command answers "what is actually running here?" without a restart.
+
+Examples:
+  mycel version`,
+	RunE: runVersion,
+}
+
 var exportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "Export API documentation",
@@ -239,6 +256,9 @@ var (
 	verboseFlow  bool
 	debugSuspend bool
 
+	// Check flags
+	checkTimeout time.Duration
+
 	// Export flags
 	exportOutput  string
 	exportFormat  string
@@ -258,6 +278,10 @@ func init() {
 	startCmd.Flags().BoolVar(&verboseFlow, "verbose-flow", false, "Log all flow pipeline stages per request (debug)")
 	startCmd.Flags().BoolVar(&debugSuspend, "debug-suspend", false, "Defer event-driven connector start until debugger connects")
 
+	// Check command flags
+	checkCmd.Flags().DurationVar(&checkTimeout, "timeout", runtime.DefaultConnectivityTimeout,
+		"Per-connector timeout for the connectivity check")
+
 	// Export command flags (OpenAPI)
 	exportOpenAPICmd.Flags().StringVarP(&exportOutput, "output", "o", "", "Output file (default: stdout)")
 	exportOpenAPICmd.Flags().StringVarP(&exportFormat, "format", "f", "yaml", "Output format: yaml, json")
@@ -275,6 +299,7 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(checkCmd)
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(exportCmd)
 	rootCmd.AddCommand(pluginCmd)
 
@@ -407,6 +432,12 @@ func resolveEnvironment() string {
 	return "development"
 }
 
+func runVersion(cmd *cobra.Command, args []string) error {
+	fmt.Printf("mycel %s (commit: %s, %s, %s/%s)\n",
+		version, commit, goruntime.Version(), goruntime.GOOS, goruntime.GOARCH)
+	return nil
+}
+
 func runValidate(cmd *cobra.Command, args []string) error {
 	// Load .env file if present (so env() in HCL resolves correctly)
 	loadDotEnv()
@@ -431,6 +462,21 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		return fmt.Errorf("validation failed: %d flow error(s)", len(errs))
 	}
+
+	// Attributes that parse but do nothing. Inert, so not a failure, but the
+	// config gives no hint that they are inert.
+	if warnings := runtime.InertFlowAttrs(config); len(warnings) > 0 {
+		fmt.Printf("\n⚠ Configuration with no effect (%d):\n\n", len(warnings))
+		for _, w := range warnings {
+			fmt.Printf("    - %s\n", w)
+		}
+	}
+
+	// Unset env() references are not a validation failure — `mycel validate`
+	// legitimately runs in CI, where production variables are absent. But the
+	// config alone cannot tell you that an attribute silently resolved to "",
+	// so report them rather than letting the run look entirely clean.
+	printMissingEnvWarnings(config.Connectors)
 
 	// Report success
 	fmt.Printf("\n✓ Configuration is valid!\n\n")
@@ -462,6 +508,39 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// printMissingEnvWarnings reports env() references that resolved to an empty
+// string because the variable is unset. The parser already collected these per
+// connector for the startup hint; surfacing them here means `mycel validate`
+// stops looking clean on a config that cannot actually start.
+func printMissingEnvWarnings(connectors []*connector.Config) {
+	type ref struct{ conn, attr string }
+	byVar := map[string][]ref{}
+	var order []string
+
+	for _, c := range connectors {
+		for _, m := range c.MissingEnv {
+			if _, seen := byVar[m.Name]; !seen {
+				order = append(order, m.Name)
+			}
+			byVar[m.Name] = append(byVar[m.Name], ref{c.Name, m.Attr})
+		}
+	}
+	if len(order) == 0 {
+		return
+	}
+
+	fmt.Printf("\n⚠ Unset environment variables (%d):\n\n", len(order))
+	for _, name := range order {
+		for _, r := range byVar[name] {
+			fmt.Printf("    - %s → connector %q (%s) resolves to \"\"\n", name, r.conn, r.attr)
+		}
+	}
+	fmt.Printf("\n  These are only a warning here: validate does not need the deployment\n")
+	fmt.Printf("  environment. Startup fails if the empty value leaves a required\n")
+	fmt.Printf("  attribute unset. Give env() a default — env(\"NAME\", \"fallback\") —\n")
+	fmt.Printf("  when an empty value is intended.\n")
+}
+
 func runCheck(cmd *cobra.Command, args []string) error {
 	// Load .env file if present (so env() in HCL resolves correctly)
 	loadDotEnv()
@@ -485,14 +564,59 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create runtime: %w", err)
 	}
 
-	// Try to start (this will attempt connections)
-	// For now, just validate that we can parse and create the runtime
-	fmt.Printf("\n✓ All connectors configured correctly!\n")
+	results := rt.CheckConnectivity(context.Background(), checkTimeout)
+	// Shut down after the report is printed: Shutdown writes its own banner,
+	// which would otherwise land in the middle of the results.
+	defer func() { _ = rt.Shutdown() }()
 
-	// Clean shutdown
-	_ = rt.Shutdown()
+	if len(results) == 0 {
+		fmt.Printf("\n  No connectors configured.\n")
+		return nil
+	}
+
+	fmt.Println()
+	failed := 0
+	for _, res := range results {
+		label := res.Name
+		if desc := describeConnectorKind(res.Type, res.Driver); desc != "" {
+			label = fmt.Sprintf("%s (%s)", res.Name, desc)
+		}
+
+		if res.OK() {
+			fmt.Printf("  ✓ %s: connected in %s\n", label, res.Duration.Round(time.Millisecond))
+			continue
+		}
+
+		failed++
+		if res.TimedOut {
+			// No answer at all points at a firewall or a wrong host, where a
+			// refusal points at a wrong port or a service that is down.
+			fmt.Printf("  ✗ %s: no response within %s\n", label, checkTimeout)
+			continue
+		}
+		fmt.Printf("  ✗ %s: %v\n", label, res.Err)
+	}
+
+	fmt.Println()
+	if failed > 0 {
+		return fmt.Errorf("%d of %d connectors unreachable", failed, len(results))
+	}
+	fmt.Printf("✓ All %d connectors reachable!\n", len(results))
 
 	return nil
+}
+
+// describeConnectorKind renders "type/driver", or just the type when the
+// connector has no driver.
+func describeConnectorKind(connType, driver string) string {
+	switch {
+	case connType == "":
+		return ""
+	case driver == "":
+		return connType
+	default:
+		return connType + "/" + driver
+	}
 }
 
 // loadDotEnv loads environment variables from a .env file if present.

--- a/docs/connectors/message-queues.md
+++ b/docs/connectors/message-queues.md
@@ -177,6 +177,55 @@ Configure automatic retry and dead-lettering for failed messages. Nest inside th
 | `consumer.dlq.max_retries` | int | optional | `3` | Max retry attempts before dead-lettering |
 | `consumer.dlq.retry_delay` | duration | optional | `0` | Delay before requeuing for retry |
 | `consumer.dlq.retry_header` | string | optional | `x-retry-count` | Header name to track retry count |
+| `consumer.dlq.external` | bool | optional | `false` | The dead-letter topology is declared outside Mycel; provision nothing and do not warn |
+
+#### Who declares the dead-letter exchange
+
+Mycel provisions the DLX and DLQ **only when it declared the queue itself**.
+Since 2.0.0 it does not create queues that already exist, so on a queue created
+by ops — Terraform, `rabbitmqctl`, the management UI — Mycel provisions no
+dead-letter topology at all. Retries still work: `max_retries` is enforced by
+republishing with a counter header, which needs no broker support. Only the
+final rejection depends on the queue's own configuration, and a queue with no
+dead-letter exchange discards it.
+
+Mycel cannot check this for you. AMQP has no way to read a queue's arguments
+back — `queue.declare-ok` returns the name, message count and consumer count,
+nothing else — and policies are not visible over AMQP at all. So it warns at
+startup whenever `dlq { enabled = true }` sits on a pre-existing queue:
+
+```
+WARN dlq { enabled = true } is NOT provisioned by Mycel for this queue: ...
+     queue=orders.in.q max_retries=3
+```
+
+Check the queue on the broker — the management UI shows a `DLX` badge on queues
+that carry `x-dead-letter-exchange`, and `rabbitmqctl list_queues name arguments
+policy` prints both the arguments and any policy in effect. Then:
+
+- **The DLX is there**, set by ops or a policy. Nothing is wrong; record that
+  with `external = true` and the warning stops.
+
+  ```hcl
+  consumer {
+    queue = "orders.in.q"
+
+    dlq {
+      enabled     = true
+      max_retries = 3
+      external    = true   # ops owns the DLX; Mycel provisions nothing
+    }
+  }
+  ```
+
+- **The DLX is missing.** Messages that exhaust their retries are being
+  discarded. Add the dead-lettering where the queue is declared, or let Mycel
+  own the queue (`create_if_missing = true`) so it declares the whole topology.
+
+`external = true` is an assertion, not a check: Mycel takes your word for it,
+skips provisioning, and leaves `x-dead-letter-exchange` alone — it does not know
+which exchange name ops chose, and guessing would dead-letter into an exchange
+that does not exist.
 
 ### Publisher Options
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -68,7 +68,7 @@ go build -o mycel ./cmd/mycel
 
 ```bash
 mycel version
-# mycel v1.7.0 (go1.21)
+# mycel 2.12.0 (commit: 64be3eb, go1.25.0, linux/amd64)
 ```
 
 ## Helm (Kubernetes)

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -30,8 +30,48 @@ Mycel exposes metrics in Prometheus format at `/metrics`.
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `mycel_flow_executions_total` | Counter | flow, status | Total flow executions |
-| `mycel_flow_duration_seconds` | Histogram | flow | Flow execution duration |
+| `mycel_flow_duration_seconds` | Histogram | flow | Flow execution duration (all executions) |
 | `mycel_flow_errors_total` | Counter | flow, error_type | Flow errors by type |
+| `mycel_flow_duration_fastest_seconds` | Gauge | flow | Fastest successful execution since start |
+| `mycel_flow_duration_slowest_seconds` | Gauge | flow | Slowest successful execution since start |
+| `mycel_flow_duration_average_seconds` | Gauge | flow | Mean of successful executions since start |
+| `mycel_flow_messages_per_second` | Gauge | flow | Successful executions per second, last minute |
+
+#### Throughput and timing
+
+The histogram is the primary instrument. With Prometheus you get throughput,
+average and percentiles from it directly:
+
+```promql
+rate(mycel_flow_duration_seconds_count[1m])                       # messages per second
+rate(mycel_flow_duration_seconds_sum[5m])
+  / rate(mycel_flow_duration_seconds_count[5m])                   # average duration
+histogram_quantile(0.95, sum by (flow, le)
+  (rate(mycel_flow_duration_seconds_bucket[5m])))                 # p95
+```
+
+Prefer these when you have a Prometheus server: they are windowed, so they
+follow the service instead of averaging over its whole uptime.
+
+The four gauges exist for what the histogram cannot give you:
+
+- **Exact fastest and slowest.** A histogram records which bucket a value fell
+  into, not the value, so `histogram_quantile` cannot recover the true extremes.
+- **Successful executions only.** `mycel_flow_duration_seconds` is not split by
+  status, so nothing derived from it can exclude failures. A flow that fails in
+  1 ms would otherwise take the "fastest" spot and pull the average down, making
+  a broken service look quick.
+
+They are also readable straight off `/metrics` with no query engine, which is
+often all you want when checking a single pod.
+
+Two caveats worth knowing. Fastest, slowest and average are cumulative **since
+process start**, so a single outlier pins the slowest value until the next
+restart — for trends, use the histogram. And `mycel_flow_messages_per_second` is
+already a rate, so graph it as-is; wrapping it in `rate()` is meaningless.
+
+A flow that has never completed successfully emits none of these, rather than
+reporting a fastest and slowest of zero.
 
 ### Message Queue Metrics
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -33,6 +33,48 @@ Mycel exposes metrics in Prometheus format at `/metrics`.
 | `mycel_flow_duration_seconds` | Histogram | flow | Flow execution duration |
 | `mycel_flow_errors_total` | Counter | flow, error_type | Flow errors by type |
 
+### Message Queue Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mycel_messages_undispatched_total` | Counter | connector, driver, target, key | Messages that matched no flow handler and were dropped |
+
+`target` is where the message arrived and `key` is what was matched against the
+handler patterns:
+
+| Driver | `target` | `key` | What happens to the message |
+|--------|----------|-------|------------------------------|
+| `rabbitmq` | queue | routing key | Nacked without requeue — discarded unless the queue has a dead-letter exchange |
+| `kafka` | topic | topic | Offset committed — it will not be redelivered |
+| `redis` | channel | channel | Discarded — pub/sub retains nothing |
+
+This counter should stay at zero. Anything else means the broker routed a
+message to this consumer that no flow claims. The usual cause is a
+`from { operation = "..." }` that matches no key actually delivered: on a
+message queue source `operation` reads like an operation *name* but is a
+subscription *pattern*, and an invented value matches nothing. Omit it to accept
+every message.
+
+The first occurrence per key is also logged at error level, with the patterns
+your flows registered — the difference between the two is the diagnosis:
+
+```
+ERROR message dropped: no flow handles this key
+      driver=rabbitmq target=orders.in.q key=gallery-assets
+      registered_patterns=[product.created product.updated]
+      consequence="nacked without requeue; discarded unless the queue has a dead-letter exchange"
+```
+
+Repeats only move the counter, so a misconfigured consumer does not drown the
+log. Worth an alert:
+
+```yaml
+- alert: MycelMessagesUndispatched
+  expr: increase(mycel_messages_undispatched_total[5m]) > 0
+  annotations:
+    summary: "{{ $labels.connector }} is dropping messages on {{ $labels.target }} with key {{ $labels.key }}"
+```
+
 ### Connector Metrics
 
 | Metric | Type | Labels | Description |
@@ -41,6 +83,15 @@ Mycel exposes metrics in Prometheus format at `/metrics`.
 | `mycel_connector_operations_total` | Counter | connector, type, operation, status | Operations count |
 | `mycel_connector_latency_seconds` | Histogram | connector, type, operation | Operation latency |
 
+`operation` is deliberately coarse — `read`, `write` or `call` — never the query
+or the target: a SQL statement as a label is unbounded cardinality. This answers
+"which connector is slow or failing"; `mycel_flow_duration_seconds` carries the
+per-flow breakdown.
+
+`mycel_connector_health` is refreshed whenever the health endpoint runs a check,
+so scrape `/health` on a schedule (or point a Kubernetes probe at it) if you
+want the gauge to track reality between deploys.
+
 ### Cache Metrics
 
 | Metric | Type | Labels | Description |
@@ -48,6 +99,11 @@ Mycel exposes metrics in Prometheus format at `/metrics`.
 | `mycel_cache_hits_total` | Counter | cache | Cache hits |
 | `mycel_cache_misses_total` | Counter | cache | Cache misses |
 | `mycel_cache_size` | Gauge | cache | Current cache size |
+
+`cache` is the configured storage name, falling back to the flow name when the
+`cache {}` block declares none. A cache error counts as a miss: the flow falls
+through and does the work either way, so counting it as anything else would
+overstate how often the cache saved a round trip.
 
 ### Profile Metrics
 
@@ -63,15 +119,39 @@ Mycel exposes metrics in Prometheus format at `/metrics`.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `mycel_lock_acquired_total` | Counter | key | Locks acquired |
-| `mycel_lock_released_total` | Counter | key | Locks released |
-| `mycel_lock_wait_seconds` | Histogram | key | Lock wait time |
-| `mycel_lock_timeout_total` | Counter | key | Lock timeouts |
-| `mycel_lock_held` | Gauge | key | Currently held locks |
-| `mycel_semaphore_acquired_total` | Counter | key | Semaphore permits acquired |
-| `mycel_semaphore_available` | Gauge | key | Available permits |
-| `mycel_coordinate_signal_total` | Counter | signal | Signals emitted |
-| `mycel_coordinate_wait_seconds` | Histogram | signal | Wait duration |
+| `mycel_lock_acquired_total` | Counter | flow | Locks acquired |
+| `mycel_lock_released_total` | Counter | flow | Locks released |
+| `mycel_lock_wait_seconds` | Histogram | flow | Time spent waiting for the lock |
+| `mycel_lock_timeout_total` | Counter | flow | Lock acquisitions that gave up |
+| `mycel_lock_held` | Gauge | flow | Locks currently held |
+| `mycel_semaphore_acquired_total` | Counter | flow | Semaphore permits acquired |
+| `mycel_semaphore_released_total` | Counter | flow | Semaphore permits released |
+| `mycel_semaphore_wait_seconds` | Histogram | flow | Time spent waiting for a permit |
+| `mycel_semaphore_timeout_total` | Counter | flow | Permit acquisitions that gave up |
+| `mycel_coordinate_signal_total` | Counter | flow | Signals emitted |
+| `mycel_coordinate_wait_total` | Counter | flow | Waits started |
+| `mycel_coordinate_wait_seconds` | Histogram | flow | Wait duration |
+| `mycel_coordinate_timeout_total` | Counter | flow | Waits that timed out |
+| `mycel_coordinate_active_waits` | Gauge | flow | Flows currently blocked in a wait |
+| `mycel_coordinate_preflight_hit_total` | Counter | flow | Preflight checks that skipped the wait |
+
+These are labelled by **flow, not by key**. Lock, semaphore and signal keys are
+CEL expressions evaluated per message — one per order, per SKU, per customer —
+so using them as a label would grow the time series set without bound. The flow
+is also the dimension that answers the operational question: which flow is
+contending, not which entity.
+
+`mycel_lock_wait_seconds` is the one to watch. Time a message spends waiting for
+a lock is invisible in `mycel_flow_duration_seconds`, so a consumer that looks
+fast per message can still be serialized behind a hot key:
+
+```promql
+# p95 lock wait by flow
+histogram_quantile(0.95, sum by (flow, le) (rate(mycel_lock_wait_seconds_bucket[5m])))
+
+# flows giving up on locks
+rate(mycel_lock_timeout_total[5m]) > 0
+```
 
 ### Runtime Metrics
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -29,13 +29,34 @@ Mycel exposes metrics in Prometheus format at `/metrics`.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `mycel_flow_executions_total` | Counter | flow, status | Total flow executions |
+| `mycel_flow_executions_total` | Counter | flow, status | Flow executions — `success`, `error` or `dropped` |
+| `mycel_flow_drops_total` | Counter | flow, reason | Messages a gate declined, by gate |
 | `mycel_flow_duration_seconds` | Histogram | flow | Flow execution duration (all executions) |
 | `mycel_flow_errors_total` | Counter | flow, error_type | Flow errors by type |
 | `mycel_flow_duration_fastest_seconds` | Gauge | flow | Fastest successful execution since start |
 | `mycel_flow_duration_slowest_seconds` | Gauge | flow | Slowest successful execution since start |
 | `mycel_flow_duration_average_seconds` | Gauge | flow | Mean of successful executions since start |
 | `mycel_flow_messages_per_second` | Gauge | flow | Successful executions per second, last minute |
+
+#### Deliberate drops
+
+A message a gate declines — filtered, deduplicated, superseded — is neither
+success nor failure. It gets its own status, and a counter broken down by the
+gate that declined it, with the same `reason` values as the
+[drop log line](troubleshooting.md#the-message-arrived-but-nothing-happened):
+`filter`, `accept`, `dedupe_match`, `sequence_older`, `coordinate_timeout`.
+
+```promql
+# share of incoming messages actually processed
+sum by (flow) (rate(mycel_flow_executions_total{status="success"}[5m]))
+  / sum by (flow) (rate(mycel_flow_executions_total[5m]))
+
+# what is declining them
+sum by (flow, reason) (rate(mycel_flow_drops_total[5m]))
+```
+
+Worth watching after a config change: a filter that suddenly declines
+everything looks exactly like a quiet upstream unless you graph this.
 
 #### Throughput and timing
 
@@ -58,9 +79,12 @@ The four gauges exist for what the histogram cannot give you:
 - **Exact fastest and slowest.** A histogram records which bucket a value fell
   into, not the value, so `histogram_quantile` cannot recover the true extremes.
 - **Successful executions only.** `mycel_flow_duration_seconds` is not split by
-  status, so nothing derived from it can exclude failures. A flow that fails in
-  1 ms would otherwise take the "fastest" spot and pull the average down, making
-  a broken service look quick.
+  status, so nothing derived from it can exclude failures or drops. Both are
+  fast — a failure gives up early, a drop short-circuits before the transform —
+  so either would take the "fastest" spot and pull the average down, making a
+  broken or heavily-filtered service look quick. `mycel_flow_messages_per_second`
+  likewise counts work done, not messages received; compare it against
+  `rate(mycel_flow_executions_total[1m])` to see how much is being declined.
 
 They are also readable straight off `/metrics` with no query engine, which is
 often all you want when checking a single pod.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -159,11 +159,11 @@ overstate how often the cache saved a round trip.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `mycel_lock_acquired_total` | Counter | flow | Locks acquired |
-| `mycel_lock_released_total` | Counter | flow | Locks released |
-| `mycel_lock_wait_seconds` | Histogram | flow | Time spent waiting for the lock |
-| `mycel_lock_timeout_total` | Counter | flow | Lock acquisitions that gave up |
-| `mycel_lock_held` | Gauge | flow | Locks currently held |
+| `mycel_lock_acquired_total` | Counter | flow, purpose | Locks acquired |
+| `mycel_lock_released_total` | Counter | flow, purpose | Locks released |
+| `mycel_lock_wait_seconds` | Histogram | flow, purpose | Time spent waiting for the lock |
+| `mycel_lock_timeout_total` | Counter | flow, purpose | Lock acquisitions that gave up |
+| `mycel_lock_held` | Gauge | flow, purpose | Locks currently held |
 | `mycel_semaphore_acquired_total` | Counter | flow | Semaphore permits acquired |
 | `mycel_semaphore_released_total` | Counter | flow | Semaphore permits released |
 | `mycel_semaphore_wait_seconds` | Histogram | flow | Time spent waiting for a permit |
@@ -181,13 +181,25 @@ so using them as a label would grow the time series set without bound. The flow
 is also the dimension that answers the operational question: which flow is
 contending, not which entity.
 
+Locks carry a second label, `purpose`, because Mycel takes them from two places
+and contention means something different in each:
+
+| `purpose` | What it guards | What contention means |
+|-----------|----------------|-----------------------|
+| `flow` | The flow's own `lock {}` block | A hot business key — many messages competing for the same entity |
+| `dedupe` | The critical section around the duplicate check | Duplicate deliveries piling up on one key |
+
 `mycel_lock_wait_seconds` is the one to watch. Time a message spends waiting for
 a lock is invisible in `mycel_flow_duration_seconds`, so a consumer that looks
 fast per message can still be serialized behind a hot key:
 
 ```promql
-# p95 lock wait by flow
-histogram_quantile(0.95, sum by (flow, le) (rate(mycel_lock_wait_seconds_bucket[5m])))
+# p95 lock wait, split by what the lock guards
+histogram_quantile(0.95, sum by (flow, purpose, le) (rate(mycel_lock_wait_seconds_bucket[5m])))
+
+# business-key contention only
+histogram_quantile(0.95, sum by (flow, le)
+  (rate(mycel_lock_wait_seconds_bucket{purpose="flow"}[5m])))
 
 # flows giving up on locks
 rate(mycel_lock_timeout_total[5m]) > 0

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -235,6 +235,61 @@ mysql -e "CREATE DATABASE myapp;"
 
 ## Flow Issues
 
+### "The message arrived but nothing happened"
+
+**Symptom:** the broker shows the message delivered, no error appears anywhere,
+and no row is written. A message that Mycel deliberately declines to process is
+not an error, so nothing fails — which makes it indistinguishable from a broker
+that never delivered it.
+
+**Diagnosis:** turn on debug logging. Every gate that can decline a message
+reports itself in one line, naming the gate, the HCL block behind it, and what
+that block was evaluating:
+
+```bash
+MYCEL_LOG_LEVEL=debug mycel start --config ./my-service
+```
+
+```
+DBG message dropped by policy flow=only_big_orders source=api reason=filter
+    decided_by="from { filter }" detail="input.total > 100" disposition=ack
+```
+
+`reason` is stable and also available to `on_drop` aspects as `drop.reason`:
+
+| `reason` | `decided_by` | Why the message was declined |
+|---|---|---|
+| `filter` | `from { filter }` | The CEL condition returned false |
+| `accept` | `accept { }` | The business gate returned false |
+| `dedupe_match` | `dedupe { }` | This fingerprint was already seen in the window |
+| `sequence_older` | `sequence_guard { }` | The incoming sequence was not newer than the stored one |
+| `coordinate_timeout` | `coordinate { on_timeout }` | The wait expired and `on_timeout = "ack"` |
+
+`disposition` is what the broker was told to do with it: `ack`, `reject` or
+`requeue`.
+
+To see the message itself alongside the reason, add the payload opt-in. It is
+separate because a declined message is still customer data:
+
+```bash
+MYCEL_PAYLOAD_SHOW=true MYCEL_LOG_LEVEL=debug mycel start --config ./my-service
+# MYCEL_PAYLOAD_SIZE caps it (default 4k)
+```
+
+**One case does not appear here.** If no flow's `operation` matched, the flow
+never ran, so there is no gate to report — the message is dropped at dispatch
+instead. That is logged at **error** level without needing debug, and counted in
+`mycel_messages_undispatched_total`:
+
+```
+ERR message dropped: no flow handles this key driver=rabbitmq target=orders.in.q
+    key=gallery-assets registered_patterns=[product.created product.updated]
+```
+
+See [Is `operation` required?](../reference/source-properties.md#is-operation-required) —
+on a stream source `operation` is a subscription pattern, and a value matching
+nothing discards everything.
+
 ### "Flow not being triggered"
 
 **Symptom:** You make a request but nothing happens.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,14 +79,21 @@ complete picture of what is reachable.
 
 ```bash
 mycel check --config ./my-service
+#   – api (rest): listens, nothing to reach
 #   ✓ orders_db (database/postgres): connected in 12ms
 #   ✓ cache (cache/redis): connected in 3ms
 #   ✗ payments_api (http): no response within 10s
 #
-# Error: 1 of 3 connectors unreachable
+# Error: 1 of 4 connectors unreachable
 ```
 
 Exits non-zero when any connector is unreachable, so it works as a deploy gate.
+
+Connectors that **listen** rather than dial — REST, GraphQL, gRPC, SOAP and TCP
+servers, plus SSE and WebSocket — are reported with `–` and never fail the
+check. They have no endpoint to reach, and they are not started here, so their
+health check would only ever report "not started". They are still built, which
+is where a bad port or a malformed TLS config surfaces.
 
 The distinction in the failure message matters: `connection refused` means
 something answered and said no — usually a wrong port or a service that is

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,24 +68,50 @@ mycel check [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--config`, `-c` | `.` | Path to the config directory |
+| `--timeout` | `10s` | Per-connector timeout |
+
+Every connector is built, connected and health-checked. Connectors are checked
+concurrently, each with its own timeout, so one unreachable host does not stall
+the rest. Unlike startup, a failure does not stop the sweep — the point is a
+complete picture of what is reachable.
 
 **Example:**
 
 ```bash
 mycel check --config ./my-service
-# ✓ postgres: connected
-# ✓ redis: connected
-# ✗ external_api: connection refused
+#   ✓ orders_db (database/postgres): connected in 12ms
+#   ✓ cache (cache/redis): connected in 3ms
+#   ✗ payments_api (http): no response within 10s
+#
+# Error: 1 of 3 connectors unreachable
+```
+
+Exits non-zero when any connector is unreachable, so it works as a deploy gate.
+
+The distinction in the failure message matters: `connection refused` means
+something answered and said no — usually a wrong port or a service that is
+down. `no response within <timeout>` means nothing answered at all — usually a
+firewall or a wrong host. Errors from building the connector are reported the
+same way, including the missing environment variable when an `env()` call
+resolved to nothing:
+
+```
+  ✗ products_api (http): factory failed to create connector products_api: http connector requires base_url
+      → Missing environment variable "MERCURY_PRODUCTS_URL", required by connector "products_api" (base_url)
 ```
 
 ### `mycel version`
 
-Print the Mycel version.
+Print the Mycel version, build commit, Go toolchain and platform.
 
 ```bash
 mycel version
-# mycel v1.7.0 (go1.21)
+# mycel 2.12.0 (commit: 64be3eb, go1.25.0, linux/amd64)
 ```
+
+The same information appears in the startup banner. This command exists for the
+case where the banner has already rolled out of a pod's log buffer and you need
+to know what is running without restarting it.
 
 ### `mycel export`
 

--- a/docs/reference/source-properties.md
+++ b/docs/reference/source-properties.md
@@ -26,6 +26,42 @@ flow receives everything.
 |---|---|
 | REST, GraphQL, gRPC, SOAP, TCP, SSE | RabbitMQ, Kafka, Redis Pub/Sub, MQTT, CDC, WebSocket, File watch |
 
+!!! warning "On a stream source, `operation` is a filter — and it drops what it does not match"
+
+    Optional does not mean inert. When you declare it, the value becomes the
+    key this flow's handler is registered under, and every incoming message is
+    matched against it. **A message matching no flow's pattern is dropped** —
+    nacked without requeue on RabbitMQ, offset committed on Kafka, discarded on
+    Redis. It is not an error, and without the startup notice below it is not
+    visible either.
+
+    Note this is a *second* filter. The broker has already decided what lands
+    in the queue, through the exchange and binding you configured on the
+    connector. `operation` narrows again, in-process, after that.
+
+    The failure mode is a value that reads like a name — an endpoint, a queue,
+    an entity — but matches no key the publisher actually sends. Everything is
+    then discarded silently. If you do not need to split one subscription
+    across several flows, **omit `operation`** and take the `"*"` catch-all.
+
+    Since 2.13.0 this is stated at startup, per flow:
+
+    ```
+    INF dispatch: flow only accepts matching messages connector=rabbit flow=item_create
+        operation=all.in.magento.q meaning="only deliveries whose key matches
+        \"all.in.magento.q\" reach this flow"
+    WRN dispatch: messages matching no pattern will be DROPPED connector=rabbit
+        patterns="\"all.in.magento.q\"" hint="on a message queue source
+        `operation` is a subscription pattern, not an operation name; omit it
+        to accept every message"
+    ```
+
+    The warning appears only when **every** flow on that connector is narrowed,
+    since one catch-all among them guarantees a handler for anything that
+    arrives. Drops that do happen are counted in
+    [`mycel_messages_undispatched_total`](../guides/observability.md#message-queue-metrics)
+    and the first one per key is logged at error level.
+
 A missing required `operation` is reported by `mycel validate` and fails startup:
 
 ```
@@ -206,10 +242,31 @@ from {
 | Property | Value |
 |----------|-------|
 | **Connector type** | `mq` (with `driver = "rabbitmq"`) |
-| **`operation` format** | Routing key — e.g., `"orders.created"`, `"user.*"`, `"#"` |
+| **`operation` format** | Routing-key **pattern** — e.g., `"orders.created"`, `"user.*"`, `"#"` |
 | **`operation` required?** | Optional — defaults to `"*"` (catch-all) |
 
 Supports AMQP topic exchange patterns: `*` matches one word, `#` matches zero or more.
+
+`operation` here is matched against `delivery.RoutingKey`, in this order: exact
+match, then topic-pattern match, then `"*"`, then `"#"`. **A delivery matching
+none of the registered patterns is nacked without requeue** — and discarded by
+the broker unless the queue carries a dead-letter exchange. See
+[Is `operation` required?](#is-operation-required) for what that means in
+practice.
+
+A common trap is setting `operation` to the **queue name**. That only works
+while the publisher happens to use the queue name as its routing key, and
+breaks silently the day it does not:
+
+```hcl
+from {
+  connector = "rabbit"
+  operation = "all.in.magento.q"   # ← a queue name, not a routing key
+}
+```
+
+The queue is already selected by the connector's `queue {}` and binding. If one
+flow handles everything on this queue, omit `operation`.
 
 ### `input.*` variables
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -308,3 +308,19 @@ func ExtractStatusCode(result map[string]interface{}, key string) (int, bool) {
 	}
 	return 0, false
 }
+
+// InboundOnly marks connectors that listen for inbound traffic rather than
+// dialing out: REST, GraphQL, gRPC, SOAP and TCP servers, plus SSE and
+// WebSocket.
+//
+// They have no endpoint to reach, and their Health only reports whether the
+// listener has been started. `mycel check` does not start servers, so without
+// this marker every such connector would report "server not started" and fail
+// a check that has nothing to verify — which is most configurations.
+//
+// Server and client connectors are separate types, so implementations return a
+// constant; there is no configuration to inspect.
+type InboundOnly interface {
+	// InboundOnly reports that this connector listens instead of dialing.
+	InboundOnly() bool
+}

--- a/internal/connector/graphql/server.go
+++ b/internal/connector/graphql/server.go
@@ -488,3 +488,6 @@ func writeGraphQLError(w http.ResponseWriter, message string, status int) {
 var (
 	_ connector.Connector = (*ServerConnector)(nil)
 )
+
+// InboundOnly implements connector.InboundOnly: this connector listens.
+func (c *ServerConnector) InboundOnly() bool { return true }

--- a/internal/connector/grpc/server.go
+++ b/internal/connector/grpc/server.go
@@ -607,3 +607,6 @@ func (c *ServerConnector) ListServices() []string {
 	}
 	return services
 }
+
+// InboundOnly implements connector.InboundOnly: this connector listens.
+func (c *ServerConnector) InboundOnly() bool { return true }

--- a/internal/connector/mq/factory.go
+++ b/internal/connector/mq/factory.go
@@ -171,6 +171,7 @@ func buildRabbitMQConfig(cfg *connector.Config) *rabbitmq.Config {
 				MaxRetries:  getInt(dlqCfg, "max_retries", 3),
 				RetryDelay:  getDuration(dlqCfg, "retry_delay", 0),
 				RetryHeader: getString(dlqCfg, "retry_header", "x-retry-count"),
+				External:    getBool(dlqCfg, "external", false),
 			}
 		}
 

--- a/internal/connector/mq/factory_test.go
+++ b/internal/connector/mq/factory_test.go
@@ -236,3 +236,87 @@ connector "rabbit" {
 		})
 	}
 }
+
+// TestRabbitMQDLQExternal verifies the external flag survives the parser →
+// factory pipeline. It carries no behaviour of its own in the factory, but a
+// silent drop here would put the startup warning back on every consumer whose
+// dead-letter topology is owned by ops.
+func TestRabbitMQDLQExternal(t *testing.T) {
+	hcl := `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+
+  consumer {
+    queue = "magento.system.gallery.assets.in.q"
+
+    dlq {
+      enabled     = true
+      max_retries = 3
+      external    = true
+    }
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "rabbit.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	p := parser.NewHCLParser()
+	cfg, err := p.ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	dlq := buildRabbitMQConfig(cfg.Connectors[0]).Consumer.DLQ
+	if dlq == nil {
+		t.Fatalf("Consumer.DLQ not built")
+	}
+	if !dlq.External {
+		t.Errorf("DLQ.External=false, want true")
+	}
+	// external must not disturb the rest of the DLQ config.
+	if !dlq.Enabled {
+		t.Errorf("DLQ.Enabled=false, want true")
+	}
+	if dlq.MaxRetries != 3 {
+		t.Errorf("DLQ.MaxRetries=%d, want 3", dlq.MaxRetries)
+	}
+}
+
+// Omitting external must leave it false, so existing configs keep provisioning
+// and warning exactly as before.
+func TestRabbitMQDLQExternalDefaultsFalse(t *testing.T) {
+	hcl := `
+connector "rabbit" {
+  type   = "mq"
+  driver = "rabbitmq"
+
+  consumer {
+    queue = "orders"
+
+    dlq {
+      enabled     = true
+      max_retries = 3
+    }
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "rabbit.mycel")
+	if err := os.WriteFile(tmpFile, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	p := parser.NewHCLParser()
+	cfg, err := p.ParseFile(context.Background(), tmpFile)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if dlq := buildRabbitMQConfig(cfg.Connectors[0]).Consumer.DLQ; dlq.External {
+		t.Errorf("DLQ.External=true, want false when the attribute is omitted")
+	}
+}

--- a/internal/connector/mq/kafka/connector.go
+++ b/internal/connector/mq/kafka/connector.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/matutetandil/mycel/internal/connector"
 	"github.com/matutetandil/mycel/internal/connector/mq/types"
+	"github.com/matutetandil/mycel/internal/connector/mq/undispatched"
 	"github.com/matutetandil/mycel/internal/flow"
 	"github.com/matutetandil/mycel/internal/tracing"
 )
@@ -50,6 +51,9 @@ type Connector struct {
 
 	// Debug throttling: single-message processing when debugger is connected
 	debugGate connector.DebugGate
+
+	// Reports messages no flow handler matched.
+	undispatched undispatched.Reporter
 }
 
 // NewConnector creates a new Kafka connector.

--- a/internal/connector/mq/kafka/consumer.go
+++ b/internal/connector/mq/kafka/consumer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/segmentio/kafka-go/sasl/scram"
 
 	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/connector/mq/undispatched"
 	"github.com/matutetandil/mycel/internal/flow"
 )
 
@@ -183,12 +184,21 @@ func (c *Connector) handleMessage(ctx context.Context, msg kafka.Message) error 
 	// Find handler for this topic
 	c.mu.RLock()
 	handler := c.findHandler(msg.Topic)
+	patterns := undispatched.SortedPatterns(c.handlers)
 	c.mu.RUnlock()
 
 	if handler == nil {
-		c.logger.Warn("no handler for topic",
-			"topic", msg.Topic,
-		)
+		// Returning nil lets the caller commit the offset, so the message is
+		// gone for good — worth stating, since it differs from RabbitMQ where
+		// a dead-letter exchange could still catch it.
+		c.undispatched.Report(c.logger, undispatched.Event{
+			Connector:   c.name,
+			Driver:      "kafka",
+			Target:      msg.Topic,
+			Key:         msg.Topic,
+			Patterns:    patterns,
+			Consequence: "offset committed; the message will not be redelivered",
+		})
 		return nil // Don't error, just skip
 	}
 

--- a/internal/connector/mq/kafka/consumer.go
+++ b/internal/connector/mq/kafka/consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -86,11 +87,19 @@ func (c *Connector) startConsumer(ctx context.Context) error {
 
 	c.reader = kafka.NewReader(readerConfig)
 
+	c.mu.RLock()
+	handlerCount := len(c.handlers)
+	c.mu.RUnlock()
+
 	c.logger.Info("started consumer",
 		"group_id", consumerCfg.GroupID,
 		"topics", consumerCfg.Topics,
 		"concurrency", consumerCfg.Concurrency,
 	)
+
+	if handlerCount == 0 {
+		undispatched.ReportNoHandlers(c.logger, c.name, "kafka", strings.Join(consumerCfg.Topics, ","))
+	}
 
 	// Start consumer workers
 	concurrency := consumerCfg.Concurrency

--- a/internal/connector/mq/rabbitmq/config.go
+++ b/internal/connector/mq/rabbitmq/config.go
@@ -136,6 +136,19 @@ type DLQConfig struct {
 	// RetryHeader is the header name used to track retry count
 	// Default: x-retry-count
 	RetryHeader string
+
+	// External asserts that the dead-letter topology is declared outside
+	// Mycel — by Terraform, rabbitmqctl, or a server-side policy. Mycel then
+	// provisions no DLX or DLQ, sets no x-dead-letter-exchange argument, and
+	// stays quiet about it. Retry counting is unaffected either way.
+	//
+	// This exists because AMQP offers no way to read a queue's arguments back:
+	// QueueDeclarePassive returns only name, message count and consumer count,
+	// and policies are not visible over AMQP at all. So on a pre-existing
+	// queue Mycel cannot distinguish "correctly dead-lettered by ops" from
+	// "no dead-lettering anywhere", and without this flag it has to warn about
+	// both. It is an operator assertion, not something Mycel verifies.
+	External bool
 }
 
 // PublisherConfig holds publisher options.

--- a/internal/connector/mq/rabbitmq/connector.go
+++ b/internal/connector/mq/rabbitmq/connector.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/matutetandil/mycel/internal/connector"
 	"github.com/matutetandil/mycel/internal/connector/mq/types"
+	"github.com/matutetandil/mycel/internal/connector/mq/undispatched"
 	"github.com/matutetandil/mycel/internal/flow"
 	"github.com/matutetandil/mycel/internal/tracing"
 )
@@ -43,6 +44,9 @@ type Connector struct {
 
 	// Filter rejection tracking for requeue dedup
 	requeueTracker *flow.RequeueTracker
+
+	// Reports deliveries no flow handler matched.
+	undispatched undispatched.Reporter
 
 	// Debug throttling: studio-controlled single-message processing
 	debugGate connector.DebugGate
@@ -492,7 +496,10 @@ func (c *Connector) setupTopology() error {
 			return fmt.Errorf("failed to declare queue: %w", err)
 		}
 
-		if !queueExisted && dlqConfig != nil && dlqConfig.Enabled {
+		// external = true means ops owns the dead-letter topology; Mycel
+		// declaring its own DLX alongside would create infrastructure nothing
+		// routes to.
+		if !queueExisted && dlqConfig != nil && dlqConfig.Enabled && !dlqConfig.External {
 			if err := c.setupDLQ(dlqConfig); err != nil {
 				return fmt.Errorf("failed to setup DLQ: %w", err)
 			}
@@ -555,12 +562,24 @@ func (c *Connector) declareConsumerQueue(dlqConfig *DLQConfig) (bool, error) {
 		c.logger.Info("queue exists; preserving existing topology",
 			"queue", queueCfg.Name,
 		)
-		if dlqConfig != nil && dlqConfig.Enabled {
+		if dlqConfig != nil && dlqConfig.Enabled && !dlqConfig.External {
+			// Lead with the conclusion. `dlq { enabled = true }` reads as
+			// protection that exists, and on a pre-existing queue Mycel has
+			// provisioned none of it: the queue was declared by someone else,
+			// so its dead-letter arguments are whatever they set. Retry
+			// counting (republish) is unaffected and still works; only the
+			// final rejection has nowhere to go. Mycel cannot tell from AMQP
+			// whether a server-side policy covers this queue, hence a warning
+			// rather than a hard failure — but the operator has to go check.
 			c.logger.Warn(
-				"dlq enabled but queue pre-existed without Mycel-declared DLX args; "+
-					"retry counting via republish still works, but on Reject(false) "+
-					"RabbitMQ will discard messages instead of routing to a DLQ unless "+
-					"a server-side policy with dead-letter-exchange is configured on this queue",
+				"dlq { enabled = true } is NOT provisioned by Mycel for this queue: "+
+					"the queue already existed, so Mycel declared no dead-letter exchange for it. "+
+					"Retries still work (max_retries is enforced by republish), but a message that "+
+					"exhausts them is DISCARDED unless this queue already carries "+
+					"x-dead-letter-exchange or a server-side policy sets one. "+
+					"Verify the queue's dead-letter policy on the broker, then set "+
+					"dlq { external = true } to confirm it is managed there and silence this; "+
+					"or let Mycel own the queue declaration (create_if_missing = true)",
 				"queue", queueCfg.Name,
 				"max_retries", dlqConfig.MaxRetries,
 			)
@@ -592,8 +611,11 @@ func (c *Connector) declareConsumerQueue(dlqConfig *DLQConfig) (bool, error) {
 	}
 	c.channel = newChannel
 
+	// Point the queue at the DLX Mycel is about to declare. Skipped when the
+	// dead-letter topology is external: Mycel does not know the name ops chose,
+	// so guessing one would dead-letter into an exchange that does not exist.
 	args := queueCfg.Args
-	if dlqConfig != nil && dlqConfig.Enabled {
+	if dlqConfig != nil && dlqConfig.Enabled && !dlqConfig.External {
 		if args == nil {
 			args = make(map[string]interface{})
 		}

--- a/internal/connector/mq/rabbitmq/consumer.go
+++ b/internal/connector/mq/rabbitmq/consumer.go
@@ -56,11 +56,9 @@ func (c *Connector) startConsumer(ctx context.Context) error {
 		return fmt.Errorf("failed to start consumer: %w", err)
 	}
 
-	// Spell out which routing keys this consumer will actually dispatch. An
-	// `operation` on an MQ source reads like an operation *name* but is a
-	// routing-key *pattern*, and an invented value matches nothing — every
-	// delivery is then dropped at handler lookup. Printing the effective
-	// patterns at boot makes that visible before the first message arrives.
+	// The per-flow explanation of what these patterns mean lives in the
+	// runtime's dispatch report, which knows the flow names. Here they are
+	// repeated as plain connector state.
 	c.mu.RLock()
 	patterns := c.handlerPatterns()
 	c.mu.RUnlock()

--- a/internal/connector/mq/rabbitmq/consumer.go
+++ b/internal/connector/mq/rabbitmq/consumer.go
@@ -71,13 +71,6 @@ func (c *Connector) startConsumer(ctx context.Context) error {
 		"prefetch", consumerCfg.Prefetch,
 	)
 
-	if len(patterns) == 0 {
-		c.logger.Error("consumer has no flow handlers: every message will be dropped",
-			"connector", c.name,
-			"queue", queueName,
-		)
-	}
-
 	// Start worker goroutines
 	concurrency := consumerCfg.Concurrency
 	if concurrency <= 0 {

--- a/internal/connector/mq/rabbitmq/consumer.go
+++ b/internal/connector/mq/rabbitmq/consumer.go
@@ -71,6 +71,10 @@ func (c *Connector) startConsumer(ctx context.Context) error {
 		"prefetch", consumerCfg.Prefetch,
 	)
 
+	if len(patterns) == 0 {
+		undispatched.ReportNoHandlers(c.logger, c.name, "rabbitmq", queueName)
+	}
+
 	// Start worker goroutines
 	concurrency := consumerCfg.Concurrency
 	if concurrency <= 0 {

--- a/internal/connector/mq/rabbitmq/consumer.go
+++ b/internal/connector/mq/rabbitmq/consumer.go
@@ -8,6 +8,7 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 
 	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/connector/mq/undispatched"
 	"github.com/matutetandil/mycel/internal/flow"
 )
 
@@ -55,12 +56,29 @@ func (c *Connector) startConsumer(ctx context.Context) error {
 		return fmt.Errorf("failed to start consumer: %w", err)
 	}
 
+	// Spell out which routing keys this consumer will actually dispatch. An
+	// `operation` on an MQ source reads like an operation *name* but is a
+	// routing-key *pattern*, and an invented value matches nothing — every
+	// delivery is then dropped at handler lookup. Printing the effective
+	// patterns at boot makes that visible before the first message arrives.
+	c.mu.RLock()
+	patterns := c.handlerPatterns()
+	c.mu.RUnlock()
+
 	c.logger.Info("started consuming",
 		"name", c.name,
 		"queue", queueName,
+		"routing_keys", patterns,
 		"concurrency", consumerCfg.Concurrency,
 		"prefetch", consumerCfg.Prefetch,
 	)
+
+	if len(patterns) == 0 {
+		c.logger.Error("consumer has no flow handlers: every message will be dropped",
+			"connector", c.name,
+			"queue", queueName,
+		)
+	}
 
 	// Start worker goroutines
 	concurrency := consumerCfg.Concurrency
@@ -184,19 +202,17 @@ func (c *Connector) handleDelivery(ctx context.Context, delivery amqp.Delivery) 
 	c.mu.RLock()
 	handler := c.findHandler(delivery.RoutingKey)
 	handlerCount := len(c.handlers)
+	patterns := c.handlerPatterns()
 	c.mu.RUnlock()
 
-	c.logger.Info("handleDelivery: handler lookup",
+	c.logger.Debug("handleDelivery: handler lookup",
 		"routing_key", delivery.RoutingKey,
 		"handler_found", handler != nil,
 		"registered_handlers", handlerCount,
 	)
 
 	if handler == nil {
-		c.logger.Warn("no handler for routing key",
-			"routing_key", delivery.RoutingKey,
-			"exchange", delivery.Exchange,
-		)
+		c.reportUndispatched(delivery, patterns)
 		// Nack without requeue for unhandled messages
 		return delivery.Nack(false, false)
 	}
@@ -460,6 +476,31 @@ func (c *Connector) handleRetry(delivery amqp.Delivery, handlerErr error) error 
 
 // findHandler finds a handler for the given routing key.
 // It supports exact match and wildcard patterns (for topic exchanges).
+// handlerPatterns returns the routing-key patterns flows registered, sorted so
+// the diagnostic output is stable. Callers must hold c.mu.
+func (c *Connector) handlerPatterns() []string {
+	return undispatched.SortedPatterns(c.handlers)
+}
+
+// reportUndispatched records and logs a delivery that matched no flow handler.
+// The message is about to be nacked without requeue, which a queue with no
+// dead-letter exchange discards outright.
+func (c *Connector) reportUndispatched(delivery amqp.Delivery, patterns []string) {
+	queue := ""
+	if c.config.Queue != nil {
+		queue = c.config.Queue.Name
+	}
+
+	c.undispatched.Report(c.logger, undispatched.Event{
+		Connector:   c.name,
+		Driver:      "rabbitmq",
+		Target:      queue,
+		Key:         delivery.RoutingKey,
+		Patterns:    patterns,
+		Consequence: "nacked without requeue; discarded unless the queue has a dead-letter exchange",
+	})
+}
+
 func (c *Connector) findHandler(routingKey string) HandlerFunc {
 	// Try exact match first
 	if handler, ok := c.handlers[routingKey]; ok {

--- a/internal/connector/mq/redis/connector.go
+++ b/internal/connector/mq/redis/connector.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/matutetandil/mycel/internal/connector"
 	"github.com/matutetandil/mycel/internal/connector/mq/types"
+	"github.com/matutetandil/mycel/internal/connector/mq/undispatched"
 	"github.com/matutetandil/mycel/internal/flow"
 )
 
@@ -42,6 +43,9 @@ type Connector struct {
 
 	// Debug throttling: single-message processing when debugger is connected
 	debugGate connector.DebugGate
+
+	// Reports messages no flow handler matched.
+	undispatched undispatched.Reporter
 }
 
 // NewConnector creates a new Redis Pub/Sub connector.
@@ -265,13 +269,20 @@ func (c *Connector) handleMessage(msg *redis.Message) {
 	// Find handler: try exact channel match first, then pattern match, then wildcard
 	c.mu.RLock()
 	handler := c.findHandler(msg.Channel, msg.Pattern)
+	patterns := undispatched.SortedPatterns(c.handlers)
 	c.mu.RUnlock()
 
 	if handler == nil {
-		c.logger.Warn("no handler for channel",
-			"channel", msg.Channel,
-			"pattern", msg.Pattern,
-		)
+		// Pub/sub has no acknowledgement and no redelivery: nothing retains
+		// this message once the callback returns.
+		c.undispatched.Report(c.logger, undispatched.Event{
+			Connector:   c.name,
+			Driver:      "redis",
+			Target:      msg.Channel,
+			Key:         msg.Channel,
+			Patterns:    patterns,
+			Consequence: "discarded; Redis pub/sub does not retain or redeliver messages",
+		})
 		return
 	}
 

--- a/internal/connector/mq/redis/connector.go
+++ b/internal/connector/mq/redis/connector.go
@@ -228,10 +228,19 @@ func (c *Connector) Start(ctx context.Context) error {
 	c.pubsub = pubsub
 	c.mu.Unlock()
 
+	c.mu.RLock()
+	handlerCount := len(c.handlers)
+	c.mu.RUnlock()
+
 	c.logger.Info("started Redis Pub/Sub subscriber",
 		"channels", channels,
 		"patterns", patterns,
 	)
+
+	if handlerCount == 0 {
+		undispatched.ReportNoHandlers(c.logger, c.name, "redis",
+			strings.Join(append(append([]string{}, channels...), patterns...), ","))
+	}
 
 	// Start message receive loop
 	c.wg.Add(1)

--- a/internal/connector/mq/schema.go
+++ b/internal/connector/mq/schema.go
@@ -71,6 +71,7 @@ func (RabbitMQSchema) ConnectorSchema() schema.Block {
 					{Name: "max_retries", Doc: "Max retries before DLQ", Type: schema.TypeNumber},
 					{Name: "retry_delay", Doc: "Delay between retries", Type: schema.TypeDuration},
 					{Name: "retry_header", Doc: "Header tracking retry count", Type: schema.TypeString},
+					{Name: "external", Doc: "Dead-letter topology is declared outside Mycel (Terraform, rabbitmqctl, broker policy): Mycel provisions nothing and does not warn", Type: schema.TypeBool},
 				}},
 			}},
 			{Type: "publisher", Doc: "Publisher settings", Attrs: []schema.Attr{

--- a/internal/connector/mq/undispatched/undispatched.go
+++ b/internal/connector/mq/undispatched/undispatched.go
@@ -103,3 +103,23 @@ func SortedPatterns[T any](handlers map[string]T) []string {
 	sort.Strings(patterns)
 	return patterns
 }
+
+// ReportNoHandlers logs that a consumer is starting with nothing registered to
+// receive its messages, so every delivery will be dropped at lookup.
+//
+// Called from each driver's start path rather than from configuration
+// analysis: declaring a source schema only means a connector *can* be a
+// source, and a database used purely as a write target or an MQ connector with
+// only a publisher block are indistinguishable from an unused consumer until
+// one actually starts consuming.
+func ReportNoHandlers(logger *slog.Logger, connectorName, driver, target string) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Error("consumer has no flow handlers: every message will be dropped",
+		"connector", connectorName,
+		"driver", driver,
+		"target", target,
+		"hint", "a flow needs from { connector = \""+connectorName+"\" } to receive these messages",
+	)
+}

--- a/internal/connector/mq/undispatched/undispatched.go
+++ b/internal/connector/mq/undispatched/undispatched.go
@@ -1,0 +1,105 @@
+// Package undispatched reports messages that reached a consumer and matched no
+// flow handler.
+//
+// Every message queue driver has the same hole: the broker routed a message
+// here, so something upstream expects it to be handled, but no flow claims it.
+// The message is then dropped — nacked without requeue on RabbitMQ, offset
+// committed on Kafka, discarded on Redis pub/sub — and until now that happened
+// with a WARN line and no metric, so the queue showed deliveries with no acks
+// and nothing else moved.
+//
+// The usual cause is a `from { operation = "..." }` that matches no key
+// actually delivered: on a message queue source `operation` reads like an
+// operation *name* but is a subscription *pattern*, and an invented value
+// matches nothing.
+//
+// It lives in its own package because the drivers cannot share code through
+// their parent: internal/connector/mq imports each driver to build them, so a
+// driver importing internal/connector/mq would close the cycle.
+package undispatched
+
+import (
+	"log/slog"
+	"sort"
+	"sync"
+
+	"github.com/matutetandil/mycel/internal/metrics"
+)
+
+// Event describes one dropped message.
+type Event struct {
+	// Connector is the connector name from the HCL config.
+	Connector string
+
+	// Driver is "rabbitmq", "kafka" or "redis".
+	Driver string
+
+	// Target is where the message arrived: queue, topic or channel.
+	Target string
+
+	// Key is what was matched against the registered handler patterns: the
+	// routing key on RabbitMQ, the topic on Kafka, the channel on Redis.
+	Key string
+
+	// Patterns are the handler patterns flows registered. The difference
+	// between these and Key is the diagnosis, so they are logged alongside.
+	Patterns []string
+
+	// Consequence spells out what the driver just did with the message,
+	// which differs enough between brokers to be worth stating outright
+	// (e.g. Kafka commits the offset, so it will not be redelivered).
+	Consequence string
+}
+
+// Reporter logs and counts dropped messages, at most one log line per key.
+//
+// A misconfigured consumer drops *every* message with that key, so logging each
+// one buries the rest of the log while adding nothing: the first line already
+// carries the full diagnosis. Repeats only move the counter. Safe for
+// concurrent use; embed it by value in a connector.
+type Reporter struct {
+	reported sync.Map
+}
+
+// Report records ev against the undispatched counter and, the first time a
+// given key is seen, logs it at error level.
+//
+// Error rather than warning: a message nobody handles is a misconfiguration
+// with data loss attached, not a routine event.
+func (r *Reporter) Report(logger *slog.Logger, ev Event) {
+	metrics.Default().RecordUndispatchedMessage(ev.Connector, ev.Driver, ev.Target, ev.Key)
+
+	if _, seen := r.reported.LoadOrStore(ev.Key, struct{}{}); seen {
+		return
+	}
+
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	attrs := []interface{}{
+		"connector", ev.Connector,
+		"driver", ev.Driver,
+		"target", ev.Target,
+		"key", ev.Key,
+		"registered_patterns", ev.Patterns,
+	}
+	if ev.Consequence != "" {
+		attrs = append(attrs, "consequence", ev.Consequence)
+	}
+	attrs = append(attrs, "hint",
+		"a flow's from{} operation must match the key; omit it to accept every message")
+
+	logger.Error("message dropped: no flow handles this key", attrs...)
+}
+
+// SortedPatterns returns the keys of a handler map, sorted so diagnostics are
+// stable across runs. Callers hold their own lock.
+func SortedPatterns[T any](handlers map[string]T) []string {
+	patterns := make([]string, 0, len(handlers))
+	for pattern := range handlers {
+		patterns = append(patterns, pattern)
+	}
+	sort.Strings(patterns)
+	return patterns
+}

--- a/internal/connector/mq/undispatched/undispatched_test.go
+++ b/internal/connector/mq/undispatched/undispatched_test.go
@@ -1,0 +1,170 @@
+package undispatched
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func rabbitEvent() Event {
+	return Event{
+		Connector:   "orders_mq",
+		Driver:      "rabbitmq",
+		Target:      "orders.in.q",
+		Key:         "gallery-assets",
+		Patterns:    []string{"product.created", "product.updated"},
+		Consequence: "nacked without requeue",
+	}
+}
+
+// A message no flow can handle is dropped. That has to be reported at error
+// level: it is a misconfiguration with data loss attached, not a routine event.
+func TestReport_FirstOccurrenceLogsError(t *testing.T) {
+	var buf bytes.Buffer
+	var r Reporter
+
+	r.Report(newLogger(&buf), rabbitEvent())
+
+	out := buf.String()
+	if !strings.Contains(out, "level=ERROR") {
+		t.Errorf("expected an ERROR log, got: %s", out)
+	}
+	// The dropped key and the patterns actually registered must both appear —
+	// the difference between them is the whole diagnosis.
+	for _, want := range []string{"gallery-assets", "product.updated", "orders.in.q", "orders_mq", "nacked"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log missing %q: %s", want, out)
+		}
+	}
+}
+
+// A misconfigured consumer drops every message with that key, so logging each
+// one would bury the rest of the log while adding nothing.
+func TestReport_RepeatsAreSilent(t *testing.T) {
+	var buf bytes.Buffer
+	var r Reporter
+	logger := newLogger(&buf)
+
+	for i := 0; i < 5; i++ {
+		r.Report(logger, rabbitEvent())
+	}
+
+	if got := strings.Count(buf.String(), "level=ERROR"); got != 1 {
+		t.Errorf("expected exactly 1 ERROR log across 5 drops, got %d: %s", got, buf.String())
+	}
+}
+
+// De-duplication is per key: a second bad key is its own diagnosis.
+func TestReport_DistinctKeysEachReport(t *testing.T) {
+	var buf bytes.Buffer
+	var r Reporter
+	logger := newLogger(&buf)
+
+	ev := rabbitEvent()
+	r.Report(logger, ev)
+	r.Report(logger, ev)
+	ev.Key = "style-assets"
+	r.Report(logger, ev)
+
+	if got := strings.Count(buf.String(), "level=ERROR"); got != 2 {
+		t.Errorf("expected 2 ERROR logs (one per distinct key), got %d: %s", got, buf.String())
+	}
+}
+
+// Each driver states what it just did with the message, because the outcome
+// differs: RabbitMQ may still dead-letter, Kafka commits the offset, Redis
+// pub/sub has nothing to retain.
+func TestReport_ConsequenceIsLogged(t *testing.T) {
+	cases := []struct {
+		driver      string
+		consequence string
+	}{
+		{"kafka", "offset committed; the message will not be redelivered"},
+		{"redis", "discarded; Redis pub/sub does not retain or redeliver messages"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.driver, func(t *testing.T) {
+			var buf bytes.Buffer
+			var r Reporter
+
+			r.Report(newLogger(&buf), Event{
+				Connector:   "events",
+				Driver:      tc.driver,
+				Target:      "orders",
+				Key:         "orders",
+				Consequence: tc.consequence,
+			})
+
+			out := buf.String()
+			if !strings.Contains(out, tc.driver) {
+				t.Errorf("log missing driver %q: %s", tc.driver, out)
+			}
+			if !strings.Contains(out, "offset committed") && !strings.Contains(out, "does not retain") {
+				t.Errorf("log missing consequence: %s", out)
+			}
+		})
+	}
+}
+
+// Consumers run one worker per concurrency setting, so Report is called from
+// several goroutines at once.
+func TestReport_ConcurrentIsSafeAndStillDeduplicates(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	var r Reporter
+	// slog handlers are not safe for concurrent writes to the same buffer;
+	// serialize the sink, not the Reporter under test.
+	logger := slog.New(slog.NewTextHandler(&syncWriter{w: &buf, mu: &mu}, nil))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.Report(logger, rabbitEvent())
+		}()
+	}
+	wg.Wait()
+
+	if got := strings.Count(buf.String(), "level=ERROR"); got != 1 {
+		t.Errorf("expected exactly 1 ERROR log across 50 concurrent drops, got %d", got)
+	}
+}
+
+type syncWriter struct {
+	w  *bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}
+
+func TestReport_NilLoggerDoesNotPanic(t *testing.T) {
+	var r Reporter
+	r.Report(nil, rabbitEvent())
+}
+
+func TestSortedPatterns(t *testing.T) {
+	handlers := map[string]int{"product.updated": 1, "asset.created": 2, "order.placed": 3}
+
+	got := SortedPatterns(handlers)
+	want := []string{"asset.created", "order.placed", "product.updated"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d patterns, got %v", len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pattern %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/internal/connector/rest/connector.go
+++ b/internal/connector/rest/connector.go
@@ -687,3 +687,6 @@ func convertPathParams(path string) string {
 	}
 	return result.String()
 }
+
+// InboundOnly implements connector.InboundOnly: this connector listens.
+func (c *Connector) InboundOnly() bool { return true }

--- a/internal/connector/soap/server.go
+++ b/internal/connector/soap/server.go
@@ -277,3 +277,6 @@ func (s *Server) handleWSDLRequest(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(buf.String()))
 }
+
+// InboundOnly implements connector.InboundOnly: this connector listens.
+func (s *Server) InboundOnly() bool { return true }

--- a/internal/connector/sse/connector.go
+++ b/internal/connector/sse/connector.go
@@ -43,7 +43,7 @@ type Connector struct {
 	server            *http.Server
 
 	mu       sync.RWMutex
-	clients  map[string]*Client           // clientID -> Client
+	clients  map[string]*Client            // clientID -> Client
 	rooms    map[string]map[string]*Client // room -> clientID -> Client
 	handlers map[string]HandlerFunc
 	eventID  uint64 // atomic counter for event IDs
@@ -442,3 +442,6 @@ func (c *Connector) RoomClientCount(room string) int {
 	defer c.mu.RUnlock()
 	return len(c.rooms[room])
 }
+
+// InboundOnly implements connector.InboundOnly: this connector listens.
+func (c *Connector) InboundOnly() bool { return true }

--- a/internal/connector/tcp/server.go
+++ b/internal/connector/tcp/server.go
@@ -517,3 +517,6 @@ func (s *ServerConnector) ConnectionCount() int {
 	defer s.connMu.RUnlock()
 	return len(s.conns)
 }
+
+// InboundOnly implements connector.InboundOnly: this connector listens.
+func (c *ServerConnector) InboundOnly() bool { return true }

--- a/internal/connector/websocket/connector.go
+++ b/internal/connector/websocket/connector.go
@@ -585,3 +585,6 @@ func (c *Connector) RoomClientCount(room string) int {
 	defer c.mu.RUnlock()
 	return len(c.rooms[room])
 }
+
+// InboundOnly implements connector.InboundOnly: this connector listens.
+func (c *Connector) InboundOnly() bool { return true }

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -389,7 +389,15 @@ type FilteredResultWithPolicy struct {
 	//   - "accept"             — accept { } rejected
 	//   - "coordinate_timeout" — coordinate { on_timeout = "ack" } fired
 	//   - "sequence_older"     — sequence_guard { } saw current <= stored
+	//   - "dedupe_match"       — dedupe { } saw this fingerprint already
 	Reason string
+
+	// Detail names the specific configuration that decided the drop — the CEL
+	// expression that rejected, the fingerprint that matched, the sequence
+	// numbers compared. Reason says which gate; Detail says why that gate said
+	// no, which is what you need to go and fix it. Logged with the drop; not
+	// exposed to CEL.
+	Detail string
 
 	// PendingOnDrop is the deferred dispatcher for the flow's on_drop
 	// aspects. The flow handler attaches this closure instead of firing

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/matutetandil/mycel/internal/metrics"
 )
 
 // Checker represents something that can be health-checked.
@@ -268,7 +270,21 @@ func (m *Manager) checkOne(ctx context.Context, checker Checker, timeout time.Du
 		status.Latency = timeout.String()
 	}
 
+	// mycel_connector_health was defined from the start and never set, so it
+	// was permanently absent from /metrics even though the health endpoint had
+	// the answer all along. Every checker registered today is a connector.
+	metrics.Default().SetConnectorHealth(status.Name, checkerType(checker), status.Status == "healthy")
+
 	return status
+}
+
+// checkerType reports the connector type for metric labelling. Checker itself
+// only requires Name and Health, so the type comes off an optional assertion.
+func checkerType(c Checker) string {
+	if t, ok := c.(interface{ Type() string }); ok {
+		return t.Type()
+	}
+	return "unknown"
 }
 
 // RegisterHandlers registers health check handlers on an HTTP mux.

--- a/internal/health/metrics_test.go
+++ b/internal/health/metrics_test.go
@@ -1,0 +1,76 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/metrics"
+)
+
+type fakeChecker struct {
+	name     string
+	connType string
+	err      error
+}
+
+func (f *fakeChecker) Name() string                   { return f.name }
+func (f *fakeChecker) Type() string                   { return f.connType }
+func (f *fakeChecker) Health(_ context.Context) error { return f.err }
+
+// typelessChecker implements only the Checker interface, with no Type().
+type typelessChecker struct{ name string }
+
+func (t *typelessChecker) Name() string                   { return t.name }
+func (t *typelessChecker) Health(_ context.Context) error { return nil }
+
+func scrape(t *testing.T) string {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	metrics.Default().Handler().ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	return rec.Body.String()
+}
+
+// mycel_connector_health was defined and documented from the start but never
+// set, so it never appeared at /metrics. The health endpoint had the answer all
+// along; this wires the two together.
+func TestCheckAll_RecordsConnectorHealth(t *testing.T) {
+	metrics.SetDefault(metrics.NewRegistry("test", "1", "1", "test"))
+
+	m := NewManager("1")
+	m.Register(&fakeChecker{name: "orders_db", connType: "database"})
+	m.Register(&fakeChecker{name: "payments_api", connType: "http", err: errors.New("connection refused")})
+
+	resp := m.checkAll(context.Background())
+	if resp.Status != "unhealthy" {
+		t.Errorf("overall status = %q, want unhealthy", resp.Status)
+	}
+
+	out := scrape(t)
+	for _, want := range []string{
+		`mycel_connector_health{connector="orders_db",type="database"} 1`,
+		`mycel_connector_health{connector="payments_api",type="http"} 0`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in /metrics output", want)
+		}
+	}
+}
+
+// Checker only requires Name and Health, so a checker that does not report a
+// type must still be recorded rather than dropped or labelled with an empty
+// string.
+func TestCheckAll_CheckerWithoutTypeIsStillRecorded(t *testing.T) {
+	metrics.SetDefault(metrics.NewRegistry("test", "1", "1", "test"))
+
+	m := NewManager("1")
+	m.Register(&typelessChecker{name: "plugin_thing"})
+	m.checkAll(context.Background())
+
+	if got := scrape(t); !strings.Contains(got, `mycel_connector_health{connector="plugin_thing",type="unknown"} 1`) {
+		t.Errorf("checker without Type() not recorded: %s", got)
+	}
+}

--- a/internal/metrics/flowstats.go
+++ b/internal/metrics/flowstats.go
@@ -1,0 +1,171 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// throughputWindow is the trailing window messages-per-second is measured over.
+// One minute is long enough to ride out a quiet second on a low-volume consumer
+// and short enough to still react within a scrape interval.
+const throughputWindow = 60
+
+// FlowStats tracks per-flow timing extremes and throughput over successful
+// executions only.
+//
+// Most of this is already derivable from mycel_flow_duration_seconds:
+// rate(_count) is the throughput and rate(_sum)/rate(_count) is the average.
+// Two things are not. A histogram cannot give the exact fastest and slowest
+// execution — only the buckets they fell into — and the existing histogram is
+// not split by status, so none of it can be narrowed to messages that actually
+// succeeded. A failure that returns in 2ms would otherwise flatter the average
+// and take the "fastest" spot.
+//
+// These are exported as a Collector that computes on scrape, so there is no
+// background goroutine and no staleness between the numbers and the counters
+// they are derived from.
+type FlowStats struct {
+	mu    sync.Mutex
+	flows map[string]*flowStat
+	start time.Time
+
+	fastest *prometheus.Desc
+	slowest *prometheus.Desc
+	average *prometheus.Desc
+	rate    *prometheus.Desc
+}
+
+type flowStat struct {
+	min   float64
+	max   float64
+	sum   float64
+	count uint64
+
+	// buckets counts executions per second over a trailing window, as a ring
+	// indexed by unix second. Fixed size per flow, so a long-running service
+	// does not accumulate memory the way a list of samples would.
+	buckets [throughputWindow]uint32
+	lastSec int64
+}
+
+// NewFlowStats creates the collector.
+func NewFlowStats() *FlowStats {
+	return &FlowStats{
+		flows: make(map[string]*flowStat),
+		start: time.Now(),
+		fastest: prometheus.NewDesc(
+			"mycel_flow_duration_fastest_seconds",
+			"Fastest successful flow execution since start",
+			[]string{"flow"}, nil,
+		),
+		slowest: prometheus.NewDesc(
+			"mycel_flow_duration_slowest_seconds",
+			"Slowest successful flow execution since start",
+			[]string{"flow"}, nil,
+		),
+		average: prometheus.NewDesc(
+			"mycel_flow_duration_average_seconds",
+			"Mean duration of successful flow executions since start",
+			[]string{"flow"}, nil,
+		),
+		rate: prometheus.NewDesc(
+			"mycel_flow_messages_per_second",
+			"Successful flow executions per second over the last minute",
+			[]string{"flow"}, nil,
+		),
+	}
+}
+
+// Observe records one successful execution.
+func (f *FlowStats) Observe(flow string, d time.Duration) {
+	secs := d.Seconds()
+	now := time.Now().Unix()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	st, ok := f.flows[flow]
+	if !ok {
+		st = &flowStat{min: secs, max: secs, lastSec: now}
+		f.flows[flow] = st
+	}
+
+	if secs < st.min {
+		st.min = secs
+	}
+	if secs > st.max {
+		st.max = secs
+	}
+	st.sum += secs
+	st.count++
+
+	st.advance(now)
+	st.buckets[now%throughputWindow]++
+}
+
+// advance clears the ring slots for seconds that elapsed since the last write,
+// so a flow that goes quiet decays to zero instead of reporting whatever it was
+// doing a minute ago. Callers hold f.mu.
+func (s *flowStat) advance(now int64) {
+	if now <= s.lastSec {
+		return
+	}
+	// More than a full window of silence clears everything; walking each slot
+	// would be pointless work.
+	if now-s.lastSec >= throughputWindow {
+		s.buckets = [throughputWindow]uint32{}
+		s.lastSec = now
+		return
+	}
+	for sec := s.lastSec + 1; sec <= now; sec++ {
+		s.buckets[sec%throughputWindow] = 0
+	}
+	s.lastSec = now
+}
+
+// Describe implements prometheus.Collector.
+func (f *FlowStats) Describe(ch chan<- *prometheus.Desc) {
+	ch <- f.fastest
+	ch <- f.slowest
+	ch <- f.average
+	ch <- f.rate
+}
+
+// Collect implements prometheus.Collector.
+func (f *FlowStats) Collect(ch chan<- prometheus.Metric) {
+	now := time.Now().Unix()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// A window's worth of history does not exist yet in the first minute, so
+	// divide by the time actually elapsed. Dividing by a full 60 would report
+	// a third of the real rate to anyone watching a service come up.
+	elapsed := time.Since(f.start).Seconds()
+	divisor := float64(throughputWindow)
+	if elapsed < divisor {
+		divisor = elapsed
+	}
+	if divisor < 1 {
+		divisor = 1
+	}
+
+	for name, st := range f.flows {
+		if st.count == 0 {
+			continue
+		}
+
+		st.advance(now)
+		var recent uint64
+		for _, n := range st.buckets {
+			recent += uint64(n)
+		}
+
+		ch <- prometheus.MustNewConstMetric(f.fastest, prometheus.GaugeValue, st.min, name)
+		ch <- prometheus.MustNewConstMetric(f.slowest, prometheus.GaugeValue, st.max, name)
+		ch <- prometheus.MustNewConstMetric(f.average, prometheus.GaugeValue, st.sum/float64(st.count), name)
+		ch <- prometheus.MustNewConstMetric(f.rate, prometheus.GaugeValue, float64(recent)/divisor, name)
+	}
+}

--- a/internal/metrics/flowstats_test.go
+++ b/internal/metrics/flowstats_test.go
@@ -1,0 +1,137 @@
+package metrics
+
+import (
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func scrapeText(t *testing.T, r *Registry) string {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	r.Handler().ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	return rec.Body.String()
+}
+
+// gaugeValue pulls a single labelled sample out of the exposition text.
+func gaugeValue(t *testing.T, out, metric, flow string) float64 {
+	t.Helper()
+
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(metric) + `\{flow="` + regexp.QuoteMeta(flow) + `"\} (\S+)$`)
+	m := re.FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("%s{flow=%q} not found in:\n%s", metric, flow, filterLines(out, "mycel_flow"))
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", m[1], err)
+	}
+	return v
+}
+
+func filterLines(s, sub string) string {
+	var kept []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, sub) {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+// The point of these gauges: a histogram gives buckets, not the exact fastest
+// and slowest execution.
+func TestFlowStats_FastestSlowestAverage(t *testing.T) {
+	r := NewRegistry("test", "1", "1", "test")
+
+	for _, d := range []time.Duration{7 * time.Millisecond, 3 * time.Millisecond, 200 * time.Millisecond} {
+		r.RecordFlowExecution("sync_orders", "success", d)
+	}
+
+	out := scrapeText(t, r)
+	if got := gaugeValue(t, out, "mycel_flow_duration_fastest_seconds", "sync_orders"); got != 0.003 {
+		t.Errorf("fastest = %v, want 0.003", got)
+	}
+	if got := gaugeValue(t, out, "mycel_flow_duration_slowest_seconds", "sync_orders"); got != 0.2 {
+		t.Errorf("slowest = %v, want 0.2", got)
+	}
+	want := (0.007 + 0.003 + 0.2) / 3
+	if got := gaugeValue(t, out, "mycel_flow_duration_average_seconds", "sync_orders"); got != want {
+		t.Errorf("average = %v, want %v", got, want)
+	}
+}
+
+// A flow that fails in 1ms must not take the "fastest" spot or pull the average
+// down — a broken service should not look quick.
+func TestFlowStats_IgnoresFailedExecutions(t *testing.T) {
+	r := NewRegistry("test", "1", "1", "test")
+
+	r.RecordFlowExecution("sync_orders", "success", 50*time.Millisecond)
+	r.RecordFlowExecution("sync_orders", "error", 1*time.Millisecond)
+	r.RecordFlowExecution("sync_orders", "error", 900*time.Millisecond)
+
+	out := scrapeText(t, r)
+	if got := gaugeValue(t, out, "mycel_flow_duration_fastest_seconds", "sync_orders"); got != 0.05 {
+		t.Errorf("fastest = %v, want 0.05 (the failed 1ms run must not count)", got)
+	}
+	if got := gaugeValue(t, out, "mycel_flow_duration_slowest_seconds", "sync_orders"); got != 0.05 {
+		t.Errorf("slowest = %v, want 0.05 (the failed 900ms run must not count)", got)
+	}
+
+	// The histogram still sees every execution; only these gauges are filtered.
+	if !strings.Contains(out, `mycel_flow_duration_seconds_count{flow="sync_orders"} 3`) {
+		t.Error("the existing histogram should still observe failed executions")
+	}
+}
+
+// Throughput divides by the time actually elapsed, not a flat 60, or a service
+// coming up would report a fraction of its real rate.
+func TestFlowStats_ThroughputUsesElapsedTimeOnStartup(t *testing.T) {
+	r := NewRegistry("test", "1", "1", "test")
+
+	for i := 0; i < 10; i++ {
+		r.RecordFlowExecution("sync_orders", "success", time.Millisecond)
+	}
+
+	// The registry was created moments ago, so the divisor floors at 1 second
+	// and all ten land in the window.
+	if got := gaugeValue(t, scrapeText(t, r), "mycel_flow_messages_per_second", "sync_orders"); got != 10 {
+		t.Errorf("messages per second = %v, want 10", got)
+	}
+}
+
+// A flow that goes quiet must decay to zero rather than reporting whatever it
+// was doing a minute ago.
+func TestFlowStats_QuietFlowDecays(t *testing.T) {
+	fs := NewFlowStats()
+	fs.Observe("sync_orders", time.Millisecond)
+
+	fs.mu.Lock()
+	st := fs.flows["sync_orders"]
+	// Pretend the last write was more than a full window ago.
+	st.advance(st.lastSec + throughputWindow + 5)
+	var remaining uint32
+	for _, n := range st.buckets {
+		remaining += n
+	}
+	fs.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("expected the ring to clear after a full window of silence, got %d", remaining)
+	}
+}
+
+// Flows with no successful executions must not appear at all, rather than
+// reporting a fastest and slowest of zero.
+func TestFlowStats_NoSuccessesEmitsNothing(t *testing.T) {
+	r := NewRegistry("test", "1", "1", "test")
+	r.RecordFlowExecution("always_fails", "error", time.Millisecond)
+
+	if out := scrapeText(t, r); strings.Contains(out, "mycel_flow_duration_fastest_seconds") {
+		t.Errorf("a flow with no successes should emit no timing gauges:\n%s", filterLines(out, "fastest"))
+	}
+}

--- a/internal/metrics/flowstats_test.go
+++ b/internal/metrics/flowstats_test.go
@@ -135,3 +135,54 @@ func TestFlowStats_NoSuccessesEmitsNothing(t *testing.T) {
 		t.Errorf("a flow with no successes should emit no timing gauges:\n%s", filterLines(out, "fastest"))
 	}
 }
+
+// A drop short-circuits before the transform, so it is the fastest thing a
+// flow ever does. Counting it would let a consumer that filters out most of
+// its input own the "fastest" gauge permanently and report a throughput it
+// never achieved.
+func TestFlowStats_IgnoresDroppedExecutions(t *testing.T) {
+	r := NewRegistry("test", "1", "1", "test")
+
+	r.RecordFlowExecution("sync_orders", FlowStatusSuccess, 50*time.Millisecond)
+	for i := 0; i < 8; i++ {
+		r.RecordFlowExecution("sync_orders", FlowStatusDropped, 20*time.Microsecond)
+	}
+
+	out := scrapeText(t, r)
+	if got := gaugeValue(t, out, "mycel_flow_duration_fastest_seconds", "sync_orders"); got != 0.05 {
+		t.Errorf("fastest = %v, want 0.05 (the 8 drops must not count)", got)
+	}
+	if got := gaugeValue(t, out, "mycel_flow_duration_average_seconds", "sync_orders"); got != 0.05 {
+		t.Errorf("average = %v, want 0.05", got)
+	}
+
+	// Drops are still visible, just as their own status rather than as success.
+	for _, want := range []string{
+		`mycel_flow_executions_total{flow="sync_orders",status="dropped"} 8`,
+		`mycel_flow_executions_total{flow="sync_orders",status="success"} 1`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, filterLines(out, "mycel_flow_executions"))
+		}
+	}
+}
+
+// The drop counter breaks down by gate, matching the `reason` on the log line,
+// so the two can be read together.
+func TestRecordFlowDrop_ByReason(t *testing.T) {
+	r := NewRegistry("test", "1", "1", "test")
+
+	r.RecordFlowDrop("sync_orders", "filter")
+	r.RecordFlowDrop("sync_orders", "filter")
+	r.RecordFlowDrop("sync_orders", "dedupe_match")
+
+	out := scrapeText(t, r)
+	for _, want := range []string{
+		`mycel_flow_drops_total{flow="sync_orders",reason="filter"} 2`,
+		`mycel_flow_drops_total{flow="sync_orders",reason="dedupe_match"} 1`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, filterLines(out, "mycel_flow_drops"))
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -214,14 +214,14 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Name: "mycel_lock_acquired_total",
 				Help: "Total number of locks acquired",
 			},
-			[]string{"flow"},
+			[]string{"flow", "purpose"},
 		),
 		LockReleased: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_lock_released_total",
 				Help: "Total number of locks released",
 			},
-			[]string{"flow"},
+			[]string{"flow", "purpose"},
 		),
 		LockWaitSeconds: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -229,21 +229,21 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Help:    "Time spent waiting to acquire a lock",
 				Buckets: prometheus.DefBuckets,
 			},
-			[]string{"flow"},
+			[]string{"flow", "purpose"},
 		),
 		LockTimeout: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_lock_timeout_total",
 				Help: "Total number of lock acquisition timeouts",
 			},
-			[]string{"flow"},
+			[]string{"flow", "purpose"},
 		),
 		LockHeld: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "mycel_lock_held",
 				Help: "Current number of held locks",
 			},
-			[]string{"flow"},
+			[]string{"flow", "purpose"},
 		),
 
 		// Semaphore metrics
@@ -551,22 +551,28 @@ func (r *Registry) SetCacheSize(cache string, size int64) {
 // also the one that answers the operational question: which flow is contending.
 
 // RecordLockAcquired records a successful lock acquisition.
-func (r *Registry) RecordLockAcquired(flow string, waitDuration time.Duration) {
-	r.LockAcquired.WithLabelValues(flow).Inc()
-	r.LockWaitSeconds.WithLabelValues(flow).Observe(waitDuration.Seconds())
-	r.LockHeld.WithLabelValues(flow).Inc()
+//
+// purpose separates the two places a lock is taken: "flow" for the flow's own
+// lock {} block, guarding a business key, and "dedupe" for the critical
+// section around the duplicate check. Contention means different things in
+// each — a hot business key versus duplicate deliveries piling up — so they
+// need to be distinguishable without reading it out of the flow name.
+func (r *Registry) RecordLockAcquired(flow, purpose string, waitDuration time.Duration) {
+	r.LockAcquired.WithLabelValues(flow, purpose).Inc()
+	r.LockWaitSeconds.WithLabelValues(flow, purpose).Observe(waitDuration.Seconds())
+	r.LockHeld.WithLabelValues(flow, purpose).Inc()
 }
 
 // RecordLockReleased records a lock release.
-func (r *Registry) RecordLockReleased(flow string) {
-	r.LockReleased.WithLabelValues(flow).Inc()
-	r.LockHeld.WithLabelValues(flow).Dec()
+func (r *Registry) RecordLockReleased(flow, purpose string) {
+	r.LockReleased.WithLabelValues(flow, purpose).Inc()
+	r.LockHeld.WithLabelValues(flow, purpose).Dec()
 }
 
 // RecordLockTimeout records a lock acquisition timeout.
-func (r *Registry) RecordLockTimeout(flow string, waitDuration time.Duration) {
-	r.LockTimeout.WithLabelValues(flow).Inc()
-	r.LockWaitSeconds.WithLabelValues(flow).Observe(waitDuration.Seconds())
+func (r *Registry) RecordLockTimeout(flow, purpose string, waitDuration time.Duration) {
+	r.LockTimeout.WithLabelValues(flow, purpose).Inc()
+	r.LockWaitSeconds.WithLabelValues(flow, purpose).Observe(waitDuration.Seconds())
 }
 
 // RecordSemaphoreAcquired records a successful semaphore permit acquisition.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -39,6 +39,10 @@ type Registry struct {
 	FlowDuration   *prometheus.HistogramVec
 	FlowErrors     *prometheus.CounterVec
 
+	// FlowStats derives fastest/slowest/average/throughput over successful
+	// executions only — see flowstats.go for why the histogram cannot.
+	FlowStats *FlowStats
+
 	// Cache metrics
 	CacheHits   *prometheus.CounterVec
 	CacheMisses *prometheus.CounterVec
@@ -179,6 +183,7 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 			},
 			[]string{"flow", "error_type"},
 		),
+		FlowStats: NewFlowStats(),
 
 		// Cache metrics
 		CacheHits: prometheus.NewCounterVec(
@@ -421,6 +426,7 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 		r.ConnectorOperations,
 		r.ConnectorLatency,
 		r.MessagesUndispatched,
+		r.FlowStats,
 		r.FlowExecutions,
 		r.FlowDuration,
 		r.FlowErrors,
@@ -509,6 +515,13 @@ func (r *Registry) RecordUndispatchedMessage(connector, driver, target, key stri
 func (r *Registry) RecordFlowExecution(flow, status string, duration time.Duration) {
 	r.FlowExecutions.WithLabelValues(flow, status).Inc()
 	r.FlowDuration.WithLabelValues(flow).Observe(duration.Seconds())
+
+	// Fastest/slowest/average/throughput cover successful work only: a flow
+	// that fails fast would otherwise take the "fastest" spot and pull the
+	// average down, making a broken service look quick.
+	if status == "success" {
+		r.FlowStats.Observe(flow, duration)
+	}
 }
 
 // RecordFlowError records a flow error.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -31,6 +31,9 @@ type Registry struct {
 	ConnectorOperations *prometheus.CounterVec
 	ConnectorLatency    *prometheus.HistogramVec
 
+	// Message queue metrics
+	MessagesUndispatched *prometheus.CounterVec
+
 	// Flow metrics
 	FlowExecutions *prometheus.CounterVec
 	FlowDuration   *prometheus.HistogramVec
@@ -137,6 +140,22 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 			[]string{"connector", "type", "operation"},
 		),
 
+		// Message queue metrics.
+		//
+		// target is where the message arrived (queue, topic, channel) and key
+		// is what was matched against the handler patterns — the routing key
+		// on RabbitMQ, the topic on Kafka, the channel on Redis. key is a
+		// label because "which key is being dropped" is the whole diagnostic
+		// value here; cardinality is bounded in practice, since a consumer
+		// only sees keys it is subscribed to.
+		MessagesUndispatched: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "mycel_messages_undispatched_total",
+				Help: "Messages delivered to a consumer that no flow handler matched (dropped)",
+			},
+			[]string{"connector", "driver", "target", "key"},
+		),
+
 		// Flow metrics
 		FlowExecutions: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -190,14 +209,14 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Name: "mycel_lock_acquired_total",
 				Help: "Total number of locks acquired",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		LockReleased: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_lock_released_total",
 				Help: "Total number of locks released",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		LockWaitSeconds: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -205,21 +224,21 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Help:    "Time spent waiting to acquire a lock",
 				Buckets: prometheus.DefBuckets,
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		LockTimeout: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_lock_timeout_total",
 				Help: "Total number of lock acquisition timeouts",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		LockHeld: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "mycel_lock_held",
 				Help: "Current number of held locks",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 
 		// Semaphore metrics
@@ -228,14 +247,14 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Name: "mycel_semaphore_acquired_total",
 				Help: "Total number of semaphore permits acquired",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		SemaphoreReleased: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_semaphore_released_total",
 				Help: "Total number of semaphore permits released",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		SemaphoreWaitSeconds: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -243,21 +262,21 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Help:    "Time spent waiting to acquire a semaphore permit",
 				Buckets: prometheus.DefBuckets,
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		SemaphoreTimeout: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_semaphore_timeout_total",
 				Help: "Total number of semaphore acquisition timeouts",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 		SemaphoreAvailable: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "mycel_semaphore_available",
 				Help: "Current number of available semaphore permits",
 			},
-			[]string{"key"},
+			[]string{"flow"},
 		),
 
 		// Coordinate metrics
@@ -266,14 +285,14 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Name: "mycel_coordinate_signal_total",
 				Help: "Total number of signals emitted",
 			},
-			[]string{"signal"},
+			[]string{"flow"},
 		),
 		CoordinateWait: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_coordinate_wait_total",
 				Help: "Total number of waits started",
 			},
-			[]string{"signal"},
+			[]string{"flow"},
 		),
 		CoordinateWaitSeconds: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -281,14 +300,14 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Help:    "Time spent waiting for a signal",
 				Buckets: prometheus.DefBuckets,
 			},
-			[]string{"signal"},
+			[]string{"flow"},
 		),
 		CoordinateTimeout: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "mycel_coordinate_timeout_total",
 				Help: "Total number of coordinate wait timeouts",
 			},
-			[]string{"signal"},
+			[]string{"flow"},
 		),
 		CoordinatePreflightHit: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -302,7 +321,7 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Name: "mycel_coordinate_active_waits",
 				Help: "Current number of active waits",
 			},
-			[]string{"signal"},
+			[]string{"flow"},
 		),
 
 		// Scheduler metrics
@@ -401,6 +420,7 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 		r.ConnectorHealth,
 		r.ConnectorOperations,
 		r.ConnectorLatency,
+		r.MessagesUndispatched,
 		r.FlowExecutions,
 		r.FlowDuration,
 		r.FlowErrors,
@@ -479,6 +499,12 @@ func (r *Registry) RecordConnectorOperation(connector, connType, operation, stat
 	r.ConnectorLatency.WithLabelValues(connector, connType, operation).Observe(duration.Seconds())
 }
 
+// RecordUndispatchedMessage records a message that reached a consumer but
+// matched no flow handler, and was therefore dropped.
+func (r *Registry) RecordUndispatchedMessage(connector, driver, target, key string) {
+	r.MessagesUndispatched.WithLabelValues(connector, driver, target, key).Inc()
+}
+
 // RecordFlowExecution records a flow execution.
 func (r *Registry) RecordFlowExecution(flow, status string, duration time.Duration) {
 	r.FlowExecutions.WithLabelValues(flow, status).Inc()
@@ -505,64 +531,70 @@ func (r *Registry) SetCacheSize(cache string, size int64) {
 	r.CacheSize.WithLabelValues(cache).Set(float64(size))
 }
 
+// Sync metrics are labelled by flow, not by the lock/semaphore/signal key.
+// Those keys are evaluated per message — one per order, per SKU, per customer —
+// so using them as a label would grow the time series set without bound and
+// take Prometheus down with it. The flow is the bounded dimension, and it is
+// also the one that answers the operational question: which flow is contending.
+
 // RecordLockAcquired records a successful lock acquisition.
-func (r *Registry) RecordLockAcquired(key string, waitDuration time.Duration) {
-	r.LockAcquired.WithLabelValues(key).Inc()
-	r.LockWaitSeconds.WithLabelValues(key).Observe(waitDuration.Seconds())
-	r.LockHeld.WithLabelValues(key).Inc()
+func (r *Registry) RecordLockAcquired(flow string, waitDuration time.Duration) {
+	r.LockAcquired.WithLabelValues(flow).Inc()
+	r.LockWaitSeconds.WithLabelValues(flow).Observe(waitDuration.Seconds())
+	r.LockHeld.WithLabelValues(flow).Inc()
 }
 
 // RecordLockReleased records a lock release.
-func (r *Registry) RecordLockReleased(key string) {
-	r.LockReleased.WithLabelValues(key).Inc()
-	r.LockHeld.WithLabelValues(key).Dec()
+func (r *Registry) RecordLockReleased(flow string) {
+	r.LockReleased.WithLabelValues(flow).Inc()
+	r.LockHeld.WithLabelValues(flow).Dec()
 }
 
 // RecordLockTimeout records a lock acquisition timeout.
-func (r *Registry) RecordLockTimeout(key string, waitDuration time.Duration) {
-	r.LockTimeout.WithLabelValues(key).Inc()
-	r.LockWaitSeconds.WithLabelValues(key).Observe(waitDuration.Seconds())
+func (r *Registry) RecordLockTimeout(flow string, waitDuration time.Duration) {
+	r.LockTimeout.WithLabelValues(flow).Inc()
+	r.LockWaitSeconds.WithLabelValues(flow).Observe(waitDuration.Seconds())
 }
 
 // RecordSemaphoreAcquired records a successful semaphore permit acquisition.
-func (r *Registry) RecordSemaphoreAcquired(key string, waitDuration time.Duration) {
-	r.SemaphoreAcquired.WithLabelValues(key).Inc()
-	r.SemaphoreWaitSeconds.WithLabelValues(key).Observe(waitDuration.Seconds())
+func (r *Registry) RecordSemaphoreAcquired(flow string, waitDuration time.Duration) {
+	r.SemaphoreAcquired.WithLabelValues(flow).Inc()
+	r.SemaphoreWaitSeconds.WithLabelValues(flow).Observe(waitDuration.Seconds())
 }
 
 // RecordSemaphoreReleased records a semaphore permit release.
-func (r *Registry) RecordSemaphoreReleased(key string) {
-	r.SemaphoreReleased.WithLabelValues(key).Inc()
+func (r *Registry) RecordSemaphoreReleased(flow string) {
+	r.SemaphoreReleased.WithLabelValues(flow).Inc()
 }
 
 // RecordSemaphoreTimeout records a semaphore acquisition timeout.
-func (r *Registry) RecordSemaphoreTimeout(key string, waitDuration time.Duration) {
-	r.SemaphoreTimeout.WithLabelValues(key).Inc()
-	r.SemaphoreWaitSeconds.WithLabelValues(key).Observe(waitDuration.Seconds())
+func (r *Registry) RecordSemaphoreTimeout(flow string, waitDuration time.Duration) {
+	r.SemaphoreTimeout.WithLabelValues(flow).Inc()
+	r.SemaphoreWaitSeconds.WithLabelValues(flow).Observe(waitDuration.Seconds())
 }
 
 // SetSemaphoreAvailable sets the current available semaphore permits.
-func (r *Registry) SetSemaphoreAvailable(key string, available int) {
-	r.SemaphoreAvailable.WithLabelValues(key).Set(float64(available))
+func (r *Registry) SetSemaphoreAvailable(flow string, available int) {
+	r.SemaphoreAvailable.WithLabelValues(flow).Set(float64(available))
 }
 
 // RecordCoordinateSignal records a signal emission.
-func (r *Registry) RecordCoordinateSignal(signal string) {
-	r.CoordinateSignal.WithLabelValues(signal).Inc()
+func (r *Registry) RecordCoordinateSignal(flow string) {
+	r.CoordinateSignal.WithLabelValues(flow).Inc()
 }
 
 // RecordCoordinateWait records a wait initiation.
-func (r *Registry) RecordCoordinateWait(signal string) {
-	r.CoordinateWait.WithLabelValues(signal).Inc()
-	r.CoordinateActiveWaits.WithLabelValues(signal).Inc()
+func (r *Registry) RecordCoordinateWait(flow string) {
+	r.CoordinateWait.WithLabelValues(flow).Inc()
+	r.CoordinateActiveWaits.WithLabelValues(flow).Inc()
 }
 
 // RecordCoordinateWaitComplete records a wait completion.
-func (r *Registry) RecordCoordinateWaitComplete(signal string, waitDuration time.Duration, timedOut bool) {
-	r.CoordinateWaitSeconds.WithLabelValues(signal).Observe(waitDuration.Seconds())
-	r.CoordinateActiveWaits.WithLabelValues(signal).Dec()
+func (r *Registry) RecordCoordinateWaitComplete(flow string, waitDuration time.Duration, timedOut bool) {
+	r.CoordinateWaitSeconds.WithLabelValues(flow).Observe(waitDuration.Seconds())
+	r.CoordinateActiveWaits.WithLabelValues(flow).Dec()
 	if timedOut {
-		r.CoordinateTimeout.WithLabelValues(signal).Inc()
+		r.CoordinateTimeout.WithLabelValues(flow).Inc()
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -39,6 +39,8 @@ type Registry struct {
 	FlowDuration   *prometheus.HistogramVec
 	FlowErrors     *prometheus.CounterVec
 
+	FlowDrops *prometheus.CounterVec
+
 	// FlowStats derives fastest/slowest/average/throughput over successful
 	// executions only — see flowstats.go for why the histogram cannot.
 	FlowStats *FlowStats
@@ -182,6 +184,17 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 				Help: "Total number of flow execution errors",
 			},
 			[]string{"flow", "error_type"},
+		),
+		// Deliberate drops, by the gate that declined the message. The
+		// matching log line (reason + decided_by + detail) says why one
+		// message was dropped; this says how many, and is what you graph
+		// and alert on. reason is a closed set, so cardinality is bounded.
+		FlowDrops: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "mycel_flow_drops_total",
+				Help: "Messages a flow deliberately declined to process, by gate",
+			},
+			[]string{"flow", "reason"},
 		),
 		FlowStats: NewFlowStats(),
 
@@ -426,6 +439,7 @@ func NewRegistry(serviceName, version, mycelVersion, environment string) *Regist
 		r.ConnectorOperations,
 		r.ConnectorLatency,
 		r.MessagesUndispatched,
+		r.FlowDrops,
 		r.FlowStats,
 		r.FlowExecutions,
 		r.FlowDuration,
@@ -511,17 +525,35 @@ func (r *Registry) RecordUndispatchedMessage(connector, driver, target, key stri
 	r.MessagesUndispatched.WithLabelValues(connector, driver, target, key).Inc()
 }
 
+// Flow execution statuses.
+const (
+	FlowStatusSuccess = "success"
+	FlowStatusError   = "error"
+	// FlowStatusDropped is a message a gate declined to process — filtered,
+	// deduplicated, superseded. Not an error: the flow did exactly what it was
+	// configured to do. But not work either, which is why it is neither.
+	FlowStatusDropped = "dropped"
+)
+
 // RecordFlowExecution records a flow execution.
 func (r *Registry) RecordFlowExecution(flow, status string, duration time.Duration) {
 	r.FlowExecutions.WithLabelValues(flow, status).Inc()
 	r.FlowDuration.WithLabelValues(flow).Observe(duration.Seconds())
 
-	// Fastest/slowest/average/throughput cover successful work only: a flow
-	// that fails fast would otherwise take the "fastest" spot and pull the
-	// average down, making a broken service look quick.
-	if status == "success" {
+	// Fastest/slowest/average/throughput describe work actually done. A flow
+	// that fails fast, or drops a message before the transform, would
+	// otherwise own the "fastest" gauge permanently and pull the average
+	// down — a consumer filtering out 90% of its input would look quick while
+	// doing almost nothing.
+	if status == FlowStatusSuccess {
 		r.FlowStats.Observe(flow, duration)
 	}
+}
+
+// RecordFlowDrop records a message declined by a gate. reason matches the
+// `reason` field on the corresponding log line.
+func (r *Registry) RecordFlowDrop(flow, reason string) {
+	r.FlowDrops.WithLabelValues(flow, reason).Inc()
 }
 
 // RecordFlowError records a flow error.

--- a/internal/runtime/connectivity.go
+++ b/internal/runtime/connectivity.go
@@ -1,0 +1,135 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/matutetandil/mycel/internal/connector"
+)
+
+// DefaultConnectivityTimeout bounds each individual connector check. Without
+// it an unreachable host can hang for the driver's own connect timeout, which
+// for some databases is minutes.
+const DefaultConnectivityTimeout = 10 * time.Second
+
+// ConnectivityResult is the outcome of checking one connector.
+type ConnectivityResult struct {
+	Name   string
+	Type   string
+	Driver string
+
+	// Err is nil when the connector was built, connected and reported healthy.
+	Err error
+
+	// TimedOut reports that the check hit the timeout rather than failing
+	// outright, which usually means a firewall dropping packets rather than a
+	// host actively refusing.
+	TimedOut bool
+
+	// Duration is how long the check took.
+	Duration time.Duration
+}
+
+// OK reports whether the connector connected and is healthy.
+func (r ConnectivityResult) OK() bool { return r.Err == nil }
+
+// CheckConnectivity builds every configured connector, connects to it and runs
+// its health check, returning one result per connector sorted by name.
+//
+// This is what `mycel check` is for, and it deliberately does the work itself
+// rather than reusing the startup path. Creating the runtime proves only that
+// the configuration parses; connectors are not even constructed until Start, so
+// a config pointing at an unreachable database or a broker with wrong
+// credentials looked perfectly healthy until the service actually started.
+//
+// Unlike startup, a failure here is recorded and the sweep continues: the point
+// of the command is a complete picture of what is reachable, not the first
+// thing that broke. Each connector gets its own timeout and they run
+// concurrently, so one unreachable host does not stall the rest.
+func (r *Runtime) CheckConnectivity(ctx context.Context, timeout time.Duration) []ConnectivityResult {
+	if timeout <= 0 {
+		timeout = DefaultConnectivityTimeout
+	}
+
+	configs := r.config.Connectors
+	results := make([]ConnectivityResult, len(configs))
+
+	var wg sync.WaitGroup
+	for i, cfg := range configs {
+		if cfg == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, cfg *connector.Config) {
+			defer wg.Done()
+			results[i] = r.checkOne(ctx, cfg, timeout)
+		}(i, cfg)
+	}
+	wg.Wait()
+
+	// Drop the placeholder entries left by nil configs.
+	checked := results[:0]
+	for _, res := range results {
+		if res.Name != "" {
+			checked = append(checked, res)
+		}
+	}
+
+	sort.Slice(checked, func(i, j int) bool { return checked[i].Name < checked[j].Name })
+	return checked
+}
+
+// checkOne builds a single connector, connects it and reports its health.
+func (r *Runtime) checkOne(ctx context.Context, cfg *connector.Config, timeout time.Duration) ConnectivityResult {
+	res := ConnectivityResult{Name: cfg.Name, Type: cfg.Type, Driver: cfg.Driver}
+
+	cfg.Environment = r.environment
+
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	defer func() { res.Duration = time.Since(start) }()
+
+	// Registering runs the factory, which is where a bad driver, a malformed
+	// URL or an env() that resolved to nothing surfaces. Append the missing-env
+	// hint for the same reason startup does: the factory error alone
+	// ("http connector requires base_url") does not name the cause.
+	if err := r.connectors.Register(checkCtx, cfg); err != nil {
+		res.Err = fmt.Errorf("%w%s", err, missingEnvHint(cfg))
+		return res
+	}
+
+	conn, err := r.connectors.Get(cfg.Name)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	res.Err = connectAndPing(checkCtx, conn)
+
+	// A driver that ignores context cancellation reports its own error; treat
+	// the deadline as authoritative either way. The distinction between
+	// "refused" and "no answer at all" is what tells you whether you are
+	// looking at a wrong port or a firewall.
+	if checkCtx.Err() != nil {
+		res.TimedOut = true
+		if res.Err == nil {
+			res.Err = checkCtx.Err()
+		}
+	}
+	return res
+}
+
+// connectAndPing opens the connection and verifies it. Connect surfaces bad
+// credentials and unreachable hosts; Health catches a connector that connects
+// lazily and only notices on first use.
+func connectAndPing(ctx context.Context, conn connector.Connector) error {
+	if err := conn.Connect(ctx); err != nil {
+		return err
+	}
+	return conn.Health(ctx)
+}

--- a/internal/runtime/connectivity.go
+++ b/internal/runtime/connectivity.go
@@ -24,6 +24,10 @@ type ConnectivityResult struct {
 	// Err is nil when the connector was built, connected and reported healthy.
 	Err error
 
+	// Inbound reports a connector that listens rather than dials, so there was
+	// nothing to reach and no verdict to give.
+	Inbound bool
+
 	// TimedOut reports that the check hit the timeout rather than failing
 	// outright, which usually means a firewall dropping packets rather than a
 	// host actively refusing.
@@ -33,7 +37,8 @@ type ConnectivityResult struct {
 	Duration time.Duration
 }
 
-// OK reports whether the connector connected and is healthy.
+// OK reports whether the connector connected and is healthy. Listeners are OK
+// by definition: there is nothing they could fail to reach.
 func (r ConnectivityResult) OK() bool { return r.Err == nil }
 
 // CheckConnectivity builds every configured connector, connects to it and runs
@@ -106,6 +111,15 @@ func (r *Runtime) checkOne(ctx context.Context, cfg *connector.Config, timeout t
 	conn, err := r.connectors.Get(cfg.Name)
 	if err != nil {
 		res.Err = err
+		return res
+	}
+
+	// A listener has no endpoint to reach, and its health check only reports
+	// whether it has been started — which check deliberately does not do. It
+	// was still worth building, since that is where a bad port or a malformed
+	// TLS config surfaces.
+	if inbound, ok := conn.(connector.InboundOnly); ok && inbound.InboundOnly() {
+		res.Inbound = true
 		return res
 	}
 

--- a/internal/runtime/connectivity_test.go
+++ b/internal/runtime/connectivity_test.go
@@ -1,0 +1,162 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newCheckRuntime writes cfg to a temp dir and builds a runtime from it.
+func newCheckRuntime(t *testing.T, cfg string) *Runtime {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "service.mycel"), []byte(cfg), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rt, err := New(Options{ConfigDir: dir, Environment: "development"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Shutdown() })
+	return rt
+}
+
+// The regression this guards: check used to create the runtime and report
+// success without opening a single connection, so a database on an
+// unroutable address passed.
+func TestCheckConnectivity_ReachableConnectorPasses(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "check.db")
+	rt := newCheckRuntime(t, `
+service { name = "t" }
+
+connector "local_sqlite" {
+  type   = "database"
+  driver = "sqlite"
+  path   = "`+dbPath+`"
+}
+`)
+
+	results := rt.CheckConnectivity(context.Background(), 5*time.Second)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].OK() {
+		t.Errorf("expected sqlite to be reachable, got: %v", results[0].Err)
+	}
+	if results[0].Name != "local_sqlite" {
+		t.Errorf("Name=%q, want local_sqlite", results[0].Name)
+	}
+	if results[0].Type != "database" || results[0].Driver != "sqlite" {
+		t.Errorf("kind=%s/%s, want database/sqlite", results[0].Type, results[0].Driver)
+	}
+}
+
+// A port nothing listens on is refused outright — distinct from a timeout,
+// and the distinction is what tells you whether to look at the port or the
+// firewall.
+func TestCheckConnectivity_RefusedConnectionFails(t *testing.T) {
+	rt := newCheckRuntime(t, `
+service { name = "t" }
+
+connector "refused" {
+  type     = "database"
+  driver   = "postgres"
+  host     = "127.0.0.1"
+  port     = 59999
+  database = "nope"
+  user     = "nobody"
+  password = "wrong"
+}
+`)
+
+	results := rt.CheckConnectivity(context.Background(), 5*time.Second)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].OK() {
+		t.Fatal("expected an unreachable postgres to fail the check")
+	}
+	if results[0].TimedOut {
+		t.Errorf("a refused connection should not be reported as a timeout: %v", results[0].Err)
+	}
+}
+
+// Building the connector is part of the check, and its failure must be
+// reported per connector rather than aborting the sweep — with the missing
+// env var named, same as at startup.
+func TestCheckConnectivity_FactoryFailureNamesMissingEnv(t *testing.T) {
+	const varName = "MYCEL_TEST_UNSET_BASE_URL"
+	os.Unsetenv(varName)
+
+	rt := newCheckRuntime(t, `
+service { name = "t" }
+
+connector "api" {
+  type     = "http"
+  base_url = env("`+varName+`")
+}
+`)
+
+	results := rt.CheckConnectivity(context.Background(), 5*time.Second)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].OK() {
+		t.Fatal("expected a connector with an empty base_url to fail")
+	}
+	if !strings.Contains(results[0].Err.Error(), varName) {
+		t.Errorf("error should name the missing variable, got: %v", results[0].Err)
+	}
+}
+
+// One broken connector must not hide the others: the command reports the whole
+// picture, so results come back for every connector, sorted by name.
+func TestCheckConnectivity_ReportsEveryConnectorSorted(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "check.db")
+	rt := newCheckRuntime(t, `
+service { name = "t" }
+
+connector "zeta_ok" {
+  type   = "database"
+  driver = "sqlite"
+  path   = "`+dbPath+`"
+}
+
+connector "alpha_broken" {
+  type     = "database"
+  driver   = "postgres"
+  host     = "127.0.0.1"
+  port     = 59999
+  database = "nope"
+  user     = "nobody"
+  password = "wrong"
+}
+`)
+
+	results := rt.CheckConnectivity(context.Background(), 5*time.Second)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Name != "alpha_broken" || results[1].Name != "zeta_ok" {
+		t.Errorf("expected results sorted by name, got %q then %q", results[0].Name, results[1].Name)
+	}
+	if results[0].OK() {
+		t.Error("alpha_broken should have failed")
+	}
+	if !results[1].OK() {
+		t.Errorf("zeta_ok should have passed, got: %v", results[1].Err)
+	}
+}
+
+func TestCheckConnectivity_NoConnectors(t *testing.T) {
+	rt := newCheckRuntime(t, `service { name = "t" }`)
+
+	if results := rt.CheckConnectivity(context.Background(), time.Second); len(results) != 0 {
+		t.Fatalf("expected no results, got %d", len(results))
+	}
+}

--- a/internal/runtime/connectivity_test.go
+++ b/internal/runtime/connectivity_test.go
@@ -160,3 +160,65 @@ func TestCheckConnectivity_NoConnectors(t *testing.T) {
 		t.Fatalf("expected no results, got %d", len(results))
 	}
 }
+
+// The regression this guards: a rest connector is a server. It has no endpoint
+// to reach, and its Health only reports whether the listener has started —
+// which check deliberately does not do. Reporting that as unreachable failed
+// the check on essentially every configuration that serves HTTP.
+func TestCheckConnectivity_ListenerIsNotAFailure(t *testing.T) {
+	rt := newCheckRuntime(t, `
+service { name = "t" }
+
+connector "api" {
+  type = "rest"
+  port = 18799
+}
+`)
+
+	results := rt.CheckConnectivity(context.Background(), 5*time.Second)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Inbound {
+		t.Error("a rest connector should be reported as inbound")
+	}
+	if !results[0].OK() {
+		t.Errorf("a listener must not fail the check, got: %v", results[0].Err)
+	}
+}
+
+// Listeners must not mask a real failure sitting next to them.
+func TestCheckConnectivity_ListenerAlongsideUnreachable(t *testing.T) {
+	rt := newCheckRuntime(t, `
+service { name = "t" }
+
+connector "api" {
+  type = "rest"
+  port = 18798
+}
+
+connector "broken" {
+  type     = "database"
+  driver   = "postgres"
+  host     = "127.0.0.1"
+  port     = 59999
+  database = "nope"
+  user     = "nobody"
+  password = "wrong"
+}
+`)
+
+	results := rt.CheckConnectivity(context.Background(), 5*time.Second)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].Inbound || !results[0].OK() {
+		t.Errorf("api should be an inbound pass, got inbound=%v err=%v", results[0].Inbound, results[0].Err)
+	}
+	if results[1].Inbound {
+		t.Error("a database connector is not inbound")
+	}
+	if results[1].OK() {
+		t.Error("the unreachable database should still fail")
+	}
+}

--- a/internal/runtime/connector_metrics.go
+++ b/internal/runtime/connector_metrics.go
@@ -1,0 +1,68 @@
+package runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/metrics"
+)
+
+// The connector metrics were defined from the start and never recorded, so
+// mycel_connector_operations_total and mycel_connector_latency_seconds were
+// documented but permanently absent from /metrics.
+//
+// They are recorded through these wrappers rather than at each call site
+// because the flow pipeline reads and writes from a dozen places (the main
+// read/write path, per-destination writes, steps, enrich), and threading
+// timing through each one by hand is how call sites get missed.
+//
+// The operation label is deliberately coarse — read, write, call — and never
+// the query or target. A SQL statement or a per-entity target as a Prometheus
+// label is unbounded cardinality; what you actually want from this metric is
+// "which connector is slow or failing", and the flow metrics already carry the
+// per-flow breakdown.
+
+// meteredRead runs a connector read and records its outcome and latency.
+func meteredRead(ctx context.Context, r connector.Reader, q connector.Query) (*connector.Result, error) {
+	start := time.Now()
+	res, err := r.Read(ctx, q)
+	recordConnectorOp(r, "read", start, err)
+	return res, err
+}
+
+// meteredWrite runs a connector write and records its outcome and latency.
+func meteredWrite(ctx context.Context, w connector.Writer, data *connector.Data) (*connector.Result, error) {
+	start := time.Now()
+	res, err := w.Write(ctx, data)
+	recordConnectorOp(w, "write", start, err)
+	return res, err
+}
+
+// meteredCall runs a connector call and records its outcome and latency.
+func meteredCall(ctx context.Context, c Caller, operation string, params map[string]interface{}) (interface{}, error) {
+	start := time.Now()
+	res, err := c.Call(ctx, operation, params)
+	recordConnectorOp(c, "call", start, err)
+	return res, err
+}
+
+// recordConnectorOp records one connector operation. The value arrives as a
+// Reader/Writer/Caller, which are narrow interfaces, so the identity comes off
+// an optional assertion: a connector that does not report its own name is
+// skipped rather than recorded under an empty label.
+func recordConnectorOp(v interface{}, operation string, start time.Time, err error) {
+	named, ok := v.(interface {
+		Name() string
+		Type() string
+	})
+	if !ok {
+		return
+	}
+
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	metrics.Default().RecordConnectorOperation(named.Name(), named.Type(), operation, status, time.Since(start))
+}

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -102,10 +102,11 @@ func (h *FlowHandler) dedupeAwareWrite(
 	lockCfg := &msync.FlowLockConfig{
 		Storage: nil, // memory backend
 		Key:     lockKey,
-		// Distinct from the flow's own lock {} metrics: this one is the
-		// dedupe critical section, so contention here means duplicate
-		// deliveries piling up, not business-key contention.
-		Flow:    h.Config.Name + " (dedupe)",
+		Flow:    h.Config.Name,
+		// Separated from the flow's own lock {} in the metrics: contention
+		// here means duplicate deliveries piling up, not business-key
+		// contention, and the two want different responses.
+		Purpose: msync.LockPurposeDedupe,
 		Timeout: "5m",
 		Wait:    true,
 	}

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -102,6 +102,10 @@ func (h *FlowHandler) dedupeAwareWrite(
 	lockCfg := &msync.FlowLockConfig{
 		Storage: nil, // memory backend
 		Key:     lockKey,
+		// Distinct from the flow's own lock {} metrics: this one is the
+		// dedupe critical section, so contention here means duplicate
+		// deliveries piling up, not business-key contention.
+		Flow:    h.Config.Name + " (dedupe)",
 		Timeout: "5m",
 		Wait:    true,
 	}

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -130,6 +130,7 @@ func (h *FlowHandler) dedupeAwareWrite(
 				Filtered: true,
 				Policy:   cfg.OnDuplicate,
 				Reason:   "dedupe_match",
+				Detail:   fmt.Sprintf("key %q already seen within the dedupe window", key),
 			}, nil
 		}
 

--- a/internal/runtime/dispatch_report.go
+++ b/internal/runtime/dispatch_report.go
@@ -1,0 +1,143 @@
+package runtime
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/matutetandil/mycel/pkg/schema"
+)
+
+// catchAllPatterns accept every delivery. "*" is Mycel's own default; "#" is
+// the AMQP topic wildcard, which users reach for by habit.
+var catchAllPatterns = map[string]bool{"*": true, "#": true, "": true}
+
+// reportDispatch explains, at startup, which deliveries each flow on a
+// subscription source will actually receive.
+//
+// On a message queue source, `operation` reads like an operation *name* but is
+// a subscription *pattern*: a second, in-process filter applied after the
+// broker has already decided what lands in the queue. A value matching nothing
+// silently discards every delivery — two engineers on the same project hit
+// this independently in the same week, which is a design smell rather than
+// user error. Spelling it out before the first message arrives is the cheapest
+// place to catch it.
+//
+// Only sources whose connector declares `operation` optional are reported.
+// That is exactly the set where it means "narrow what I receive" (message
+// queues, MQTT, CDC, WebSocket, file watch); where it is required it addresses
+// a specific endpoint and there is nothing to warn about.
+func (r *Runtime) reportDispatch(logger *slog.Logger, reg *schema.Registry) {
+	if logger == nil || r.config == nil {
+		return
+	}
+
+	byName := make(map[string]*connectorRef, len(r.config.Connectors))
+	for _, c := range r.config.Connectors {
+		if c != nil {
+			byName[c.Name] = &connectorRef{Type: c.Type, Driver: c.Driver}
+		}
+	}
+
+	// Group by connector so one line per flow sits under a shared subject.
+	perConnector := map[string][]dispatchBinding{}
+
+	for _, f := range r.config.Flows {
+		if f == nil || f.From == nil || f.From.Connector == "" {
+			continue
+		}
+		ref, ok := byName[f.From.Connector]
+		if !ok || !isSubscriptionSource(reg, ref) {
+			continue
+		}
+		perConnector[f.From.Connector] = append(perConnector[f.From.Connector],
+			dispatchBinding{flow: f.Name, pattern: f.From.GetOperation()})
+	}
+
+	names := make([]string, 0, len(perConnector))
+	for name := range perConnector {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		bindings := perConnector[name]
+		sort.Slice(bindings, func(i, j int) bool { return bindings[i].flow < bindings[j].flow })
+
+		anyCatchAll := false
+		for _, b := range bindings {
+			if catchAllPatterns[b.pattern] {
+				anyCatchAll = true
+			}
+		}
+
+		for _, b := range bindings {
+			if catchAllPatterns[b.pattern] {
+				logger.Info("dispatch: flow accepts every message",
+					"connector", name,
+					"flow", b.flow,
+					"operation", "(catch-all)",
+				)
+				continue
+			}
+			logger.Info("dispatch: flow only accepts matching messages",
+				"connector", name,
+				"flow", b.flow,
+				"operation", b.pattern,
+				"meaning", fmt.Sprintf("only deliveries whose key matches %q reach this flow", b.pattern),
+			)
+		}
+
+		// The dangerous shape: every flow on the connector is narrowed, so a
+		// delivery matching none is dropped with nothing to catch it. With a
+		// catch-all present there is always a handler, so this cannot happen.
+		if !anyCatchAll {
+			logger.Warn("dispatch: messages matching no pattern will be DROPPED",
+				"connector", name,
+				"patterns", patternList(bindings),
+				"hint", "on a message queue source `operation` is a subscription pattern, not an operation name; omit it to accept every message",
+			)
+		}
+	}
+}
+
+// dispatchBinding pairs a flow with the pattern it registered.
+type dispatchBinding struct{ flow, pattern string }
+
+// patternList renders the declared patterns for the warning.
+func patternList(bindings []dispatchBinding) string {
+	seen := map[string]bool{}
+	var out []string
+	for _, b := range bindings {
+		if !seen[b.pattern] {
+			seen[b.pattern] = true
+			out = append(out, fmt.Sprintf("%q", b.pattern))
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+// isSubscriptionSource reports whether this connector treats `operation` as a
+// pattern that narrows what it receives, rather than as an endpoint it must
+// address. The connector's own schema is the authority: it declares operation
+// optional exactly when it defaults to the catch-all.
+func isSubscriptionSource(reg *schema.Registry, ref *connectorRef) bool {
+	if reg == nil || ref == nil {
+		return false
+	}
+	provider := reg.Lookup(ref.Type, ref.Driver)
+	if provider == nil {
+		return false
+	}
+	src := provider.SourceSchema()
+	if src == nil {
+		return false
+	}
+	for _, attr := range src.Attrs {
+		if attr.Name == "operation" {
+			return !attr.Required
+		}
+	}
+	return false
+}

--- a/internal/runtime/dispatch_report.go
+++ b/internal/runtime/dispatch_report.go
@@ -55,6 +55,23 @@ func (r *Runtime) reportDispatch(logger *slog.Logger, reg *schema.Registry) {
 			dispatchBinding{flow: f.Name, pattern: f.From.GetOperation()})
 	}
 
+	// A subscription source no flow reads from will consume and discard
+	// everything. Previously only the RabbitMQ driver said so; reporting it
+	// here covers Kafka, Redis, MQTT, CDC and the rest for free.
+	var orphans []string
+	for name, ref := range byName {
+		if isSubscriptionSource(reg, ref) && len(perConnector[name]) == 0 {
+			orphans = append(orphans, name)
+		}
+	}
+	sort.Strings(orphans)
+	for _, name := range orphans {
+		logger.Error("dispatch: no flow reads from this source; every message will be dropped",
+			"connector", name,
+			"hint", "a flow needs from { connector = \""+name+"\" } to receive anything",
+		)
+	}
+
 	names := make([]string, 0, len(perConnector))
 	for name := range perConnector {
 		names = append(names, name)

--- a/internal/runtime/dispatch_report.go
+++ b/internal/runtime/dispatch_report.go
@@ -55,22 +55,12 @@ func (r *Runtime) reportDispatch(logger *slog.Logger, reg *schema.Registry) {
 			dispatchBinding{flow: f.Name, pattern: f.From.GetOperation()})
 	}
 
-	// A subscription source no flow reads from will consume and discard
-	// everything. Previously only the RabbitMQ driver said so; reporting it
-	// here covers Kafka, Redis, MQTT, CDC and the rest for free.
-	var orphans []string
-	for name, ref := range byName {
-		if isSubscriptionSource(reg, ref) && len(perConnector[name]) == 0 {
-			orphans = append(orphans, name)
-		}
-	}
-	sort.Strings(orphans)
-	for _, name := range orphans {
-		logger.Error("dispatch: no flow reads from this source; every message will be dropped",
-			"connector", name,
-			"hint", "a flow needs from { connector = \""+name+"\" } to receive anything",
-		)
-	}
+	// Deliberately no "connector with no flows" check here. Declaring a
+	// SourceSchema means a connector *can* be a source, not that it is
+	// configured as one: a database used only as a write target, or an MQ
+	// connector with just a publisher block, both look identical from the
+	// config. Whether a connector will actually consume is only knowable
+	// where it starts consuming, so the drivers report that themselves.
 
 	names := make([]string, 0, len(perConnector))
 	for name := range perConnector {

--- a/internal/runtime/dispatch_report_test.go
+++ b/internal/runtime/dispatch_report_test.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/connector"
+	"github.com/matutetandil/mycel/internal/flow"
+	"github.com/matutetandil/mycel/internal/parser"
+)
+
+// dispatchReport runs the report over a config and returns what was logged.
+func dispatchReport(t *testing.T, connectors []*connector.Config, flows []*flow.Config) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	rt := &Runtime{
+		config:         &parser.Configuration{Connectors: connectors, Flows: flows},
+		schemaRegistry: NewSchemaRegistry(),
+	}
+	rt.reportDispatch(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), rt.schemaRegistry)
+	return buf.String()
+}
+
+func mqConnector(name string) *connector.Config {
+	return &connector.Config{Name: name, Type: "mq", Driver: "rabbitmq"}
+}
+
+func mqFlow(name, conn, operation string) *flow.Config {
+	params := map[string]interface{}{}
+	if operation != "" {
+		params["operation"] = operation
+	}
+	return &flow.Config{
+		Name: name,
+		From: &flow.FromConfig{Connector: conn, ConnectorParams: params},
+	}
+}
+
+// The shape that bit the project twice: every flow on the connector declares a
+// narrowing pattern, so a delivery matching none is dropped with nothing to
+// catch it.
+func TestReportDispatch_WarnsWhenEveryFlowIsNarrowed(t *testing.T) {
+	out := dispatchReport(t,
+		[]*connector.Config{mqConnector("rabbit")},
+		[]*flow.Config{
+			mqFlow("item_create", "rabbit", "all.in.magento.q"),
+			mqFlow("item_update", "rabbit", "all.in.magento.q"),
+		},
+	)
+
+	if !strings.Contains(out, "will be DROPPED") {
+		t.Errorf("expected a drop warning, got:\n%s", out)
+	}
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("the drop notice must be a warning, got:\n%s", out)
+	}
+	// Both flows named, and the pattern spelled out.
+	for _, want := range []string{"item_create", "item_update", "all.in.magento.q"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A catch-all always has a handler, so nothing can be dropped at lookup and
+// there is nothing to warn about.
+func TestReportDispatch_CatchAllIsSilent(t *testing.T) {
+	out := dispatchReport(t,
+		[]*connector.Config{mqConnector("rabbit")},
+		[]*flow.Config{mqFlow("asset_upsert", "rabbit", "")},
+	)
+
+	if strings.Contains(out, "DROPPED") {
+		t.Errorf("a catch-all flow must not warn about drops:\n%s", out)
+	}
+	if !strings.Contains(out, "accepts every message") {
+		t.Errorf("expected the catch-all to be stated explicitly:\n%s", out)
+	}
+}
+
+// One catch-all among narrowed flows is enough: every delivery still reaches a
+// handler.
+func TestReportDispatch_CatchAllAlongsideNarrowedIsSilent(t *testing.T) {
+	out := dispatchReport(t,
+		[]*connector.Config{mqConnector("rabbit")},
+		[]*flow.Config{
+			mqFlow("specific", "rabbit", "orders.created"),
+			mqFlow("everything_else", "rabbit", "#"),
+		},
+	)
+
+	if strings.Contains(out, "DROPPED") {
+		t.Errorf("a catch-all sibling means nothing is dropped at lookup:\n%s", out)
+	}
+}
+
+// On a REST source `operation` addresses an endpoint rather than narrowing a
+// subscription, so there is nothing to report.
+func TestReportDispatch_IgnoresRequestStyleSources(t *testing.T) {
+	out := dispatchReport(t,
+		[]*connector.Config{{Name: "api", Type: "rest"}},
+		[]*flow.Config{mqFlow("get_users", "api", "GET /users")},
+	)
+
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("a rest source should produce no dispatch report:\n%s", out)
+	}
+}
+
+// Each connector is judged on its own flows: a safe one must not silence a
+// risky one.
+func TestReportDispatch_PerConnector(t *testing.T) {
+	out := dispatchReport(t,
+		[]*connector.Config{mqConnector("risky"), mqConnector("safe")},
+		[]*flow.Config{
+			mqFlow("narrowed", "risky", "all.in.magento.q"),
+			mqFlow("catch_all", "safe", ""),
+		},
+	)
+
+	if !strings.Contains(out, "DROPPED") {
+		t.Errorf("the narrowed connector should still warn:\n%s", out)
+	}
+	if strings.Count(out, "DROPPED") != 1 {
+		t.Errorf("only the narrowed connector should warn, got %d:\n%s", strings.Count(out, "DROPPED"), out)
+	}
+}

--- a/internal/runtime/dispatch_report_test.go
+++ b/internal/runtime/dispatch_report_test.go
@@ -128,3 +128,29 @@ func TestReportDispatch_PerConnector(t *testing.T) {
 		t.Errorf("only the narrowed connector should warn, got %d:\n%s", strings.Count(out, "DROPPED"), out)
 	}
 }
+
+// The regression this guards: an earlier version reported "no flow reads from
+// this source" for any connector whose schema allows it to be a source. A
+// database used only as a write target, and an MQ connector with only a
+// publisher block, both matched — so every real consumer logged errors about
+// connectors that were working exactly as configured. Whether a connector will
+// consume is only knowable where it starts consuming; the drivers report it.
+func TestReportDispatch_NoOrphanWarningForNonSourceConnectors(t *testing.T) {
+	out := dispatchReport(t,
+		[]*connector.Config{
+			mqConnector("rabbit"),                                   // consumed
+			mqConnector("rabbit_returns"),                           // publisher only
+			{Name: "magento_db", Type: "database", Driver: "mysql"}, // write target
+		},
+		[]*flow.Config{mqFlow("item_update", "rabbit", "")},
+	)
+
+	for _, unwanted := range []string{"magento_db", "rabbit_returns", "no flow reads"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("connectors that are not configured as sources must not be reported (%q):\n%s", unwanted, out)
+		}
+	}
+	if !strings.Contains(out, "accepts every message") {
+		t.Errorf("the consumed connector should still be reported:\n%s", out)
+	}
+}

--- a/internal/runtime/drop_log_test.go
+++ b/internal/runtime/drop_log_test.go
@@ -1,0 +1,128 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/flow"
+)
+
+func dropLogger(buf *bytes.Buffer, level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: level}))
+}
+
+func dropHandler(buf *bytes.Buffer, showPayload bool) *FlowHandler {
+	return &FlowHandler{
+		Config: &flow.Config{
+			Name: "sync_orders",
+			From: &flow.FromConfig{Connector: "rabbit"},
+		},
+		Logger:          dropLogger(buf, slog.LevelDebug),
+		ShowPayload:     showPayload,
+		PayloadMaxBytes: 4096,
+	}
+}
+
+var sampleInput = map[string]interface{}{"body": map[string]interface{}{"sku": "ABC-123"}}
+
+// A drop must name the gate, the block behind it, and what that block was
+// evaluating — the label alone does not tell you where to go and fix it.
+func TestLogDroppedMessage_NamesGateAndDecidingConfig(t *testing.T) {
+	var buf bytes.Buffer
+	h := dropHandler(&buf, false)
+
+	h.logDroppedMessage(context.Background(), sampleInput, &flow.FilteredResultWithPolicy{
+		Filtered: true,
+		Reason:   "filter",
+		Detail:   "input.body.total > 100",
+		Policy:   "ack",
+	})
+
+	out := buf.String()
+	for _, want := range []string{
+		"message dropped by policy",
+		"sync_orders",
+		"reason=filter",
+		"from { filter }",
+		"input.body.total > 100",
+		"disposition=ack",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A dropped message is still customer data, so the payload rides on the same
+// explicit opt-in as the incoming-payload log rather than appearing by default.
+func TestLogDroppedMessage_PayloadRequiresOptIn(t *testing.T) {
+	drop := &flow.FilteredResultWithPolicy{Filtered: true, Reason: "accept", Detail: "x"}
+
+	var off bytes.Buffer
+	dropHandler(&off, false).logDroppedMessage(context.Background(), sampleInput, drop)
+	if strings.Contains(off.String(), "ABC-123") {
+		t.Errorf("payload logged without MYCEL_PAYLOAD_SHOW:\n%s", off.String())
+	}
+	if !strings.Contains(off.String(), "reason=accept") {
+		t.Errorf("the reason must be logged regardless of the payload opt-in:\n%s", off.String())
+	}
+
+	var on bytes.Buffer
+	dropHandler(&on, true).logDroppedMessage(context.Background(), sampleInput, drop)
+	if !strings.Contains(on.String(), "ABC-123") {
+		t.Errorf("payload missing with MYCEL_PAYLOAD_SHOW on:\n%s", on.String())
+	}
+}
+
+// Every gate maps to the HCL block a user would go and edit.
+func TestDropDecidedBy_CoversEveryReason(t *testing.T) {
+	cases := map[string]string{
+		"filter":             "from { filter }",
+		"accept":             "accept { }",
+		"dedupe_match":       "dedupe { }",
+		"sequence_older":     "sequence_guard { }",
+		"coordinate_timeout": "coordinate { on_timeout }",
+	}
+	for reason, want := range cases {
+		if got := dropDecidedBy(reason); got != want {
+			t.Errorf("dropDecidedBy(%q) = %q, want %q", reason, got, want)
+		}
+	}
+
+	// An unknown reason falls back to itself rather than to an empty label.
+	if got := dropDecidedBy("something_new"); got != "something_new" {
+		t.Errorf("unknown reason should pass through, got %q", got)
+	}
+}
+
+// A result that is not a drop, and a nil result, must log nothing.
+func TestLogDroppedMessage_IgnoresNonDrops(t *testing.T) {
+	var buf bytes.Buffer
+	h := dropHandler(&buf, true)
+
+	h.logDroppedMessage(context.Background(), sampleInput, nil)
+	h.logDroppedMessage(context.Background(), sampleInput, &flow.FilteredResultWithPolicy{Filtered: false})
+
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Errorf("expected no output for non-drops:\n%s", buf.String())
+	}
+}
+
+// Below debug the line is skipped entirely, so the payload is never marshalled
+// on a hot path.
+func TestLogDroppedMessage_SkippedAboveDebug(t *testing.T) {
+	var buf bytes.Buffer
+	h := dropHandler(&buf, true)
+	h.Logger = dropLogger(&buf, slog.LevelInfo)
+
+	h.logDroppedMessage(context.Background(), sampleInput, &flow.FilteredResultWithPolicy{
+		Filtered: true, Reason: "filter",
+	})
+
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Errorf("expected nothing at info level:\n%s", buf.String())
+	}
+}

--- a/internal/runtime/flow_inert_attrs.go
+++ b/internal/runtime/flow_inert_attrs.go
@@ -1,0 +1,63 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/matutetandil/mycel/internal/parser"
+)
+
+// InertFlowAttrs reports flow attributes that parse cleanly and then do
+// nothing at all.
+//
+// These are worse than a syntax error: the config reads as if it configures
+// something, `mycel validate` passes, the service starts, and the behaviour is
+// simply absent. They are warnings rather than errors because rejecting them
+// would break configs that run correctly today (the attribute is inert, not
+// harmful), so this only makes the no-op visible.
+//
+// Returns one message per offending flow, sorted for stable output.
+func InertFlowAttrs(config *parser.Configuration) []string {
+	if config == nil {
+		return nil
+	}
+
+	var warnings []string
+	for _, f := range config.Flows {
+		if f == nil {
+			continue
+		}
+
+		// `params` on a `to` block is never read. ToConfig.GetParams() exists
+		// but has no call site: a write takes its payload from the transform
+		// output (or the raw input when there is no transform). The attribute
+		// is real on `step`, on `enrich`, and on `exec` inside a
+		// `transaction`, which is exactly why it gets copied onto `to`.
+		if f.To != nil {
+			if _, ok := f.To.ConnectorParams["params"]; ok {
+				warnings = append(warnings, fmt.Sprintf(
+					"flow %q: `params` on a to block is ignored — a write sends the transform "+
+						"output (or the raw input when the flow has no transform). Shape the "+
+						"payload in transform {}, or use step {} / transaction { exec {} }, "+
+						"where params is read",
+					f.Name))
+			}
+		}
+		for i, to := range f.MultiTo {
+			if to == nil {
+				continue
+			}
+			if _, ok := to.ConnectorParams["params"]; ok {
+				warnings = append(warnings, fmt.Sprintf(
+					"flow %q: `params` on to block #%d (connector %q) is ignored — a write sends "+
+						"the transform output (or the raw input when the flow has no transform). "+
+						"Shape the payload in transform {}, or use step {} / "+
+						"transaction { exec {} }, where params is read",
+					f.Name, i+1, to.Connector))
+			}
+		}
+	}
+
+	sort.Strings(warnings)
+	return warnings
+}

--- a/internal/runtime/flow_inert_attrs_test.go
+++ b/internal/runtime/flow_inert_attrs_test.go
@@ -1,0 +1,96 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/flow"
+	"github.com/matutetandil/mycel/internal/parser"
+)
+
+func TestInertFlowAttrs_ParamsOnToBlock(t *testing.T) {
+	cfg := &parser.Configuration{
+		Flows: []*flow.Config{{
+			Name: "write_order",
+			To: &flow.ToConfig{
+				Connector: "db",
+				ConnectorParams: map[string]interface{}{
+					"target": "orders",
+					"params": map[string]interface{}{"id": "input.id"},
+				},
+			},
+		}},
+	}
+
+	warnings := InertFlowAttrs(cfg)
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	for _, want := range []string{"write_order", "params", "transform"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("warning missing %q: %s", want, warnings[0])
+		}
+	}
+}
+
+func TestInertFlowAttrs_ParamsOnMultiTo(t *testing.T) {
+	cfg := &parser.Configuration{
+		Flows: []*flow.Config{{
+			Name: "fanout",
+			MultiTo: []*flow.ToConfig{
+				{Connector: "db", ConnectorParams: map[string]interface{}{"target": "orders"}},
+				{Connector: "api", ConnectorParams: map[string]interface{}{
+					"params": map[string]interface{}{"id": "input.id"},
+				}},
+			},
+		}},
+	}
+
+	warnings := InertFlowAttrs(cfg)
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	// The message must point at the offending destination, not just the flow.
+	for _, want := range []string{"fanout", "#2", `"api"`} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("warning missing %q: %s", want, warnings[0])
+		}
+	}
+}
+
+// params is a real attribute on step and inside transaction { exec }; only the
+// to block ignores it. Nothing else should trip the warning.
+func TestInertFlowAttrs_CleanFlowIsSilent(t *testing.T) {
+	cfg := &parser.Configuration{
+		Flows: []*flow.Config{{
+			Name: "clean",
+			From: &flow.FromConfig{Connector: "queue"},
+			Steps: []*flow.StepConfig{{
+				Connector: "db",
+				ConnectorParams: map[string]interface{}{
+					"query":  "SELECT * FROM t WHERE id = :id",
+					"params": map[string]interface{}{"id": "input.id"},
+				},
+			}},
+			To: &flow.ToConfig{
+				Connector:       "db",
+				ConnectorParams: map[string]interface{}{"target": "orders"},
+			},
+		}},
+	}
+
+	if warnings := InertFlowAttrs(cfg); len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got: %v", warnings)
+	}
+}
+
+func TestInertFlowAttrs_NilSafe(t *testing.T) {
+	if warnings := InertFlowAttrs(nil); warnings != nil {
+		t.Fatalf("expected nil for nil config, got: %v", warnings)
+	}
+
+	cfg := &parser.Configuration{Flows: []*flow.Config{nil, {Name: "no_to"}}}
+	if warnings := InertFlowAttrs(cfg); len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got: %v", warnings)
+	}
+}

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -1385,6 +1385,7 @@ func (h *FlowHandler) executeFlowCore(ctx context.Context, input map[string]inte
 			Storage: mapSyncStorage(h.Config.Lock.Storage),
 			Key:     h.Config.Lock.Key,
 			Flow:    h.Config.Name,
+			Purpose: msync.LockPurposeFlow,
 			Timeout: h.Config.Lock.Timeout,
 			Wait:    h.Config.Lock.Wait,
 			Retry:   h.Config.Lock.Retry,

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -1479,7 +1479,7 @@ func (h *FlowHandler) buildPreflightFn(input map[string]interface{}) msync.FlowP
 			"connector", pf.Connector,
 			"if_exists", pf.IfExists)
 
-		result, err := reader.Read(ctx, connector.Query{
+		result, err := meteredRead(ctx, reader, connector.Query{
 			RawSQL:  pf.Query,
 			Filters: params,
 		})

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -375,17 +375,28 @@ func (h *FlowHandler) HandleRequest(ctx context.Context, input map[string]interf
 		// Explain a deliberate drop. Sits beside the metrics rather than at
 		// each gate so every reason is reported identically, whichever
 		// connector delivered the message.
-		if drop, ok := result.(*flow.FilteredResultWithPolicy); ok {
+		drop, dropped := result.(*flow.FilteredResultWithPolicy)
+		dropped = dropped && drop.Filtered
+		if dropped {
 			h.logDroppedMessage(ctx, input, drop)
 		}
 
 		// Record flow execution metrics. Runs regardless of logger
 		// availability so mycel_flow_* series populate for MQ-driven
 		// services that have no REST connector emitting request metrics.
-		status := "success"
-		if err != nil {
-			status = "error"
+		//
+		// A drop is its own status. Counting it as success made a consumer
+		// that filters out most of its input look fully productive, and let
+		// drops — which short-circuit before the transform — own the fastest
+		// and average timing gauges.
+		status := metrics.FlowStatusSuccess
+		switch {
+		case err != nil:
+			status = metrics.FlowStatusError
 			metrics.Default().RecordFlowError(h.Config.Name, classifyFlowError(err))
+		case dropped:
+			status = metrics.FlowStatusDropped
+			metrics.Default().RecordFlowDrop(h.Config.Name, drop.Reason)
 		}
 		metrics.Default().RecordFlowExecution(h.Config.Name, status, duration)
 

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -196,6 +196,62 @@ type FlowHandler struct {
 // Used for backwards compatibility when no rejection policy is configured.
 var FilteredResult = &struct{ Filtered bool }{Filtered: true}
 
+// logDroppedMessage explains, at debug level, why a message was deliberately
+// not processed.
+//
+// Every gate that can drop a message — filter, accept, dedupe, sequence_guard,
+// coordinate timeout — already reports a stable Reason, but until now that only
+// reached `on_drop` aspects. Anyone without one saw a message vanish with no
+// error and nothing in the log: indistinguishable from a broker that never
+// delivered it. This is the single place every source funnels through, so one
+// line here covers them all.
+//
+// The reason and the deciding configuration are always logged. The payload is
+// only included when MYCEL_PAYLOAD_SHOW opted in, under the same size cap as
+// the incoming-payload log, because a dropped message is still customer data.
+func (h *FlowHandler) logDroppedMessage(ctx context.Context, input map[string]interface{}, drop *flow.FilteredResultWithPolicy) {
+	if drop == nil || !drop.Filtered || h.Logger == nil || !h.Logger.Enabled(ctx, slog.LevelDebug) {
+		return
+	}
+
+	attrs := []slog.Attr{
+		slog.String("flow", h.Config.Name),
+		slog.String("source", h.Config.From.Connector),
+		slog.String("reason", drop.Reason),
+		slog.String("decided_by", dropDecidedBy(drop.Reason)),
+	}
+	if drop.Detail != "" {
+		attrs = append(attrs, slog.String("detail", drop.Detail))
+	}
+	if drop.Policy != "" {
+		attrs = append(attrs, slog.String("disposition", drop.Policy))
+	}
+	if h.ShowPayload {
+		attrs = append(attrs, slog.String("payload", formatPayload(input, h.PayloadMaxBytes)))
+	}
+
+	h.Logger.LogAttrs(ctx, slog.LevelDebug, "message dropped by policy", attrs...)
+}
+
+// dropDecidedBy names the HCL block behind each Reason, so the log points at
+// what to go and edit rather than at an internal label.
+func dropDecidedBy(reason string) string {
+	switch reason {
+	case "filter":
+		return "from { filter }"
+	case "accept":
+		return "accept { }"
+	case "dedupe_match":
+		return "dedupe { }"
+	case "sequence_older":
+		return "sequence_guard { }"
+	case "coordinate_timeout":
+		return "coordinate { on_timeout }"
+	default:
+		return reason
+	}
+}
+
 // logIncomingPayload emits the raw incoming payload at debug level when
 // MYCEL_PAYLOAD_SHOW opted in. The Enabled() guard skips the JSON marshal
 // entirely unless debug logging is actually active.
@@ -316,6 +372,13 @@ func (h *FlowHandler) HandleRequest(ctx context.Context, input map[string]interf
 			debugCollector.BroadcastFlowEnd(result, duration, err)
 		}
 
+		// Explain a deliberate drop. Sits beside the metrics rather than at
+		// each gate so every reason is reported identically, whichever
+		// connector delivered the message.
+		if drop, ok := result.(*flow.FilteredResultWithPolicy); ok {
+			h.logDroppedMessage(ctx, input, drop)
+		}
+
 		// Record flow execution metrics. Runs regardless of logger
 		// availability so mycel_flow_* series populate for MQ-driven
 		// services that have no REST connector emitting request metrics.
@@ -381,6 +444,7 @@ func (h *FlowHandler) HandleRequest(ctx context.Context, input map[string]interf
 					Policy:     h.Config.From.FilterConfig.OnReject,
 					MaxRequeue: h.Config.From.FilterConfig.MaxRequeue,
 					Reason:     "filter",
+					Detail:     h.Config.From.FilterConfig.Condition,
 				}
 				// Evaluate ID field if configured (for requeue dedup)
 				if h.Config.From.FilterConfig.IDField != "" && h.Config.From.FilterConfig.OnReject == "requeue" {
@@ -409,6 +473,7 @@ func (h *FlowHandler) HandleRequest(ctx context.Context, input map[string]interf
 				Filtered: true,
 				Policy:   h.Config.Accept.OnReject,
 				Reason:   "accept",
+				Detail:   h.Config.Accept.When,
 			}
 			return h.prepareDropResult(ctx, input, result)
 		}
@@ -1250,6 +1315,8 @@ func (h *FlowHandler) executeFlowCore(ctx context.Context, input map[string]inte
 					Filtered: true,
 					Policy:   string(skipped.Policy),
 					Reason:   "sequence_older",
+					Detail: fmt.Sprintf("key %q: incoming sequence %d is not newer than the stored one",
+						key, current),
 				}, nil
 			}
 			return result, err
@@ -1357,6 +1424,8 @@ func (h *FlowHandler) executeFlowCore(ctx context.Context, input map[string]inte
 					Filtered: true,
 					Policy:   "ack",
 					Reason:   "coordinate_timeout",
+					Detail: fmt.Sprintf("waited %s for signal %q, on_timeout = ack",
+						h.Config.Coordinate.Timeout, waitKey),
 				}, nil
 			}
 			return result, err

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -707,7 +707,7 @@ func (h *FlowHandler) sendToFallback(ctx context.Context, input map[string]inter
 		Payload:   message,
 	}
 
-	_, err := writer.Write(ctx, data)
+	_, err := meteredWrite(ctx, writer, data)
 	return err
 }
 
@@ -1331,6 +1331,7 @@ func (h *FlowHandler) executeFlowCore(ctx context.Context, input map[string]inte
 
 		coordCfg := &msync.FlowCoordinateConfig{
 			Storage:            mapSyncStorage(h.Config.Coordinate.Storage),
+			Flow:               h.Config.Name,
 			Wait:               waitCfg,
 			Signal:             signalFlowCfg,
 			Timeout:            h.Config.Coordinate.Timeout,
@@ -1367,6 +1368,7 @@ func (h *FlowHandler) executeFlowCore(ctx context.Context, input map[string]inte
 		semCfg := &msync.FlowSemaphoreConfig{
 			Storage:    mapSyncStorage(h.Config.Semaphore.Storage),
 			Key:        h.Config.Semaphore.Key,
+			Flow:       h.Config.Name,
 			MaxPermits: h.Config.Semaphore.MaxPermits,
 			Timeout:    h.Config.Semaphore.Timeout,
 			Lease:      h.Config.Semaphore.Lease,
@@ -1382,6 +1384,7 @@ func (h *FlowHandler) executeFlowCore(ctx context.Context, input map[string]inte
 		lockCfg := &msync.FlowLockConfig{
 			Storage: mapSyncStorage(h.Config.Lock.Storage),
 			Key:     h.Config.Lock.Key,
+			Flow:    h.Config.Name,
 			Timeout: h.Config.Lock.Timeout,
 			Wait:    h.Config.Lock.Wait,
 			Retry:   h.Config.Lock.Retry,
@@ -1893,7 +1896,7 @@ func (h *FlowHandler) executeBatch(ctx context.Context, input map[string]interfa
 		}
 
 		// Read a chunk
-		readResult, err := reader.Read(ctx, query)
+		readResult, err := meteredRead(ctx, reader, query)
 		if err != nil {
 			if batch.OnError == "continue" {
 				batchResult.Errors = append(batchResult.Errors, fmt.Sprintf("chunk at offset %d read error: %v", offset, err))
@@ -1942,7 +1945,7 @@ func (h *FlowHandler) executeBatch(ctx context.Context, input map[string]interfa
 				Payload:   flow.WrapPayload(row, batch.To.Envelope),
 			}
 
-			_, err := writer.Write(ctx, writeData)
+			_, err := meteredWrite(ctx, writer, writeData)
 			if err != nil {
 				if batch.OnError == "continue" {
 					batchResult.Failed++
@@ -2062,7 +2065,7 @@ func (h *FlowHandler) handleRead(ctx context.Context, input map[string]interface
 	}
 
 	readResult, readErr := trace.RecordStage(ctx, trace.StageRead, h.Config.To.GetTarget(), query.Filters, func() (interface{}, error) {
-		result, err := dest.Read(ctx, query)
+		result, err := meteredRead(ctx, dest, query)
 		if err != nil {
 			return nil, err
 		}
@@ -2210,7 +2213,7 @@ func (h *FlowHandler) handleCreate(ctx context.Context, input map[string]interfa
 
 	writeResult, writeErr := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
 		return trace.RecordStage(ctx, trace.StageWrite, data.Target, trace.Snapshot(data.Payload), func() (interface{}, error) {
-			return dest.Write(ctx, data)
+			return meteredWrite(ctx, dest, data)
 		})
 	})
 	if writeErr != nil {
@@ -2242,7 +2245,7 @@ func (h *FlowHandler) handleCreate(ctx context.Context, input map[string]interfa
 				Operation: "SELECT",
 				Filters:   map[string]interface{}{"id": result.LastID},
 			}
-			readResult, err := reader.Read(ctx, query)
+			readResult, err := meteredRead(ctx, reader, query)
 			if err == nil && len(readResult.Rows) > 0 {
 				return readResult.Rows[0], nil
 			}
@@ -2319,7 +2322,7 @@ func (h *FlowHandler) handleUpdate(ctx context.Context, input map[string]interfa
 	}
 
 	writeResult, err := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
-		return dest.Write(ctx, data)
+		return meteredWrite(ctx, dest, data)
 	})
 	if err != nil {
 		return nil, err
@@ -2381,7 +2384,7 @@ func (h *FlowHandler) handleDelete(ctx context.Context, input map[string]interfa
 		}, nil
 	}
 
-	result, err := dest.Write(ctx, data)
+	result, err := meteredWrite(ctx, dest, data)
 	if err != nil {
 		return nil, err
 	}
@@ -2634,7 +2637,7 @@ func (h *FlowHandler) writeToDestination(ctx context.Context, input, basePayload
 	// Child span around the connector write so the trace shows downstream calls;
 	// the span context is what the connector (e.g. HTTP) propagates outbound.
 	ctx, span := tracing.StartConnectorSpan(ctx, destConfig.Connector, data.Operation, data.Target)
-	writeResult, err := writer.Write(ctx, data)
+	writeResult, err := meteredWrite(ctx, writer, data)
 	tracing.End(span, err)
 	if err != nil {
 		return nil, err
@@ -2938,7 +2941,7 @@ func (h *FlowHandler) executeSteps(ctx context.Context, input map[string]interfa
 					RawSQL:    step.GetQuery(),
 					Filters:   params,
 				}
-				readResult, err := reader.Read(ctx, query)
+				readResult, err := meteredRead(ctx, reader, query)
 				if err != nil {
 					if step.OnError == "skip" {
 						if step.Default != nil {
@@ -2969,7 +2972,7 @@ func (h *FlowHandler) executeSteps(ctx context.Context, input map[string]interfa
 				if len(step.GetBody()) > 0 {
 					callParams = step.GetBody()
 				}
-				callResult, err := caller.Call(ctx, step.GetOperation(), callParams)
+				callResult, err := meteredCall(ctx, caller, step.GetOperation(), callParams)
 				if err != nil {
 					if step.OnError == "skip" {
 						if step.Default != nil {
@@ -2993,7 +2996,7 @@ func (h *FlowHandler) executeSteps(ctx context.Context, input map[string]interfa
 					Operation: step.GetOperation(),
 					Filters:   params,
 				}
-				readResult, err := reader.Read(ctx, query)
+				readResult, err := meteredRead(ctx, reader, query)
 				if err != nil {
 					if step.OnError == "skip" {
 						if step.Default != nil {
@@ -3022,7 +3025,7 @@ func (h *FlowHandler) executeSteps(ctx context.Context, input map[string]interfa
 					Payload:   flow.WrapPayload(step.GetBody(), step.Envelope),
 					Filters:   params,
 				}
-				writeResult, err := writer.Write(ctx, data)
+				writeResult, err := meteredWrite(ctx, writer, data)
 				if err != nil {
 					if step.OnError == "skip" {
 						if step.Default != nil {
@@ -3055,7 +3058,7 @@ func (h *FlowHandler) executeSteps(ctx context.Context, input map[string]interfa
 					Operation: "SELECT",
 					Filters:   params,
 				}
-				readResult, err := reader.Read(ctx, query)
+				readResult, err := meteredRead(ctx, reader, query)
 				if err != nil {
 					if step.OnError == "skip" {
 						if step.Default != nil {
@@ -3156,7 +3159,7 @@ func (h *FlowHandler) executeEnrichments(ctx context.Context, input map[string]i
 				Operation: "SELECT",
 				Filters:   params,
 			}
-			readResult, err := reader.Read(ctx, query)
+			readResult, err := meteredRead(ctx, reader, query)
 			if err != nil {
 				return nil, fmt.Errorf("enrich %s: read failed: %w", enrich.Name, err)
 			}
@@ -3168,7 +3171,7 @@ func (h *FlowHandler) executeEnrichments(ctx context.Context, input map[string]i
 			}
 		} else if caller, ok := conn.(Caller); ok {
 			// Try as a Caller (for TCP, HTTP, etc.)
-			callResult, err := caller.Call(ctx, enrich.GetOperation(), params)
+			callResult, err := meteredCall(ctx, caller, enrich.GetOperation(), params)
 			if err != nil {
 				return nil, fmt.Errorf("enrich %s: call failed: %w", enrich.Name, err)
 			}
@@ -3631,8 +3634,13 @@ func (h *FlowHandler) checkCache(ctx context.Context, key string) (interface{}, 
 
 	data, found, err := cacheConn.Get(ctx, key)
 	if err != nil || !found {
+		// A cache error is a miss as far as the flow is concerned: it falls
+		// through and does the work. Counting it as one keeps the hit rate
+		// honest about how often the cache actually saved a round trip.
+		metrics.Default().RecordCacheMiss(h.cacheMetricName())
 		return nil, false, err
 	}
+	metrics.Default().RecordCacheHit(h.cacheMetricName())
 
 	// Deserialize from JSON
 	var result interface{}
@@ -3660,6 +3668,23 @@ func (h *FlowHandler) storeInCache(ctx context.Context, key string, value interf
 	ttl := h.getCacheTTL()
 
 	return cacheConn.Set(ctx, key, data, ttl)
+}
+
+// cacheMetricName labels the cache metrics. It is the configured storage name
+// where there is one, falling back to the flow name — both bounded, unlike the
+// cache key, which is evaluated per message.
+func (h *FlowHandler) cacheMetricName() string {
+	if h.Config.Cache != nil {
+		if h.Config.Cache.Storage != "" {
+			return h.Config.Cache.Storage
+		}
+		if h.Config.Cache.Use != "" {
+			if named, ok := h.NamedCaches[h.Config.Cache.Use]; ok && named.Storage != "" {
+				return named.Storage
+			}
+		}
+	}
+	return h.Config.Name
 }
 
 // getCacheConnector returns the cache connector for this flow.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -77,6 +77,7 @@ import (
 	"github.com/matutetandil/mycel/internal/validate"
 	"github.com/matutetandil/mycel/internal/validator"
 	"github.com/matutetandil/mycel/internal/workflow"
+	"github.com/matutetandil/mycel/pkg/schema"
 	goredis "github.com/redis/go-redis/v9"
 )
 
@@ -93,6 +94,7 @@ type Runtime struct {
 	transforms        map[string]*transform.Config
 	types             map[string]*validate.TypeSchema
 	namedCaches       map[string]*flow.NamedCacheConfig
+	schemaRegistry    *schema.Registry
 	health            *health.Manager
 	metrics           *metrics.Registry
 	rateLimiter       *ratelimit.Limiter
@@ -525,6 +527,7 @@ func New(opts Options) (*Runtime, error) {
 		transforms:        transforms,
 		types:             types,
 		namedCaches:       namedCaches,
+		schemaRegistry:    schemaReg,
 		health:            healthMgr,
 		metrics:           metricsReg,
 		traceShutdown:     traceShutdown,
@@ -690,6 +693,14 @@ func (r *Runtime) Start(ctx context.Context) error {
 		}
 	}
 	banner.PrintServiceInfo(serviceName, serviceVersion, r.environment, r.getRESTPort())
+
+	// Spell out which deliveries each flow will actually receive, before the
+	// first message arrives. On a subscription source `operation` silently
+	// filters, so a pattern matching nothing is indistinguishable from a
+	// broker that is simply quiet. This reads configuration only, so it runs
+	// before connecting: the dispatch shape is worth knowing even when the
+	// broker is down and startup is about to fail.
+	r.reportDispatch(r.logger, r.schemaRegistry)
 
 	// Propagate service version to health responses
 	r.health.SetServiceVersion(serviceVersion)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -254,6 +254,13 @@ func New(opts Options) (*Runtime, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", errors.Join(errs...))
 	}
 
+	// Attributes that parse but do nothing. Not fatal — they are inert, and
+	// failing here would break configs that work today — but the whole point
+	// is that nobody can tell they are inert by reading the file.
+	for _, w := range InertFlowAttrs(config) {
+		opts.Logger.Warn("configuration has no effect", "detail", w)
+	}
+
 	// Create connector registry
 	registry := connector.NewRegistry()
 
@@ -2204,18 +2211,14 @@ func getString(props map[string]interface{}, key, defaultVal string) string {
 	return defaultVal
 }
 
+// getInt reads an int property for the startup banner.
+//
+// It delegates so that a string survives: env() returns a string, so
+// `port = env("PORT")` used to fall through to the default here and the banner
+// announced a port the service was not listening on. The connector factories
+// have coerced since 1.19.1; this is the display path catching up.
 func getInt(props map[string]interface{}, key string, defaultVal int) int {
-	if v, ok := props[key]; ok {
-		switch n := v.(type) {
-		case int:
-			return n
-		case int64:
-			return int(n)
-		case float64:
-			return int(n)
-		}
-	}
-	return defaultVal
+	return connector.IntFromProps(props, key, defaultVal)
 }
 
 func getBool(props map[string]interface{}, key string, defaultVal bool) bool {

--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	"github.com/matutetandil/mycel/internal/metrics"
 )
 
 // SyncStorageConfig defines inline storage configuration for sync primitives.
@@ -255,6 +257,9 @@ func (m *Manager) Close() error {
 type FlowLockConfig struct {
 	Storage *SyncStorageConfig
 	Key     string
+	// Flow labels the metrics. The evaluated lock key is per message, so it
+	// cannot be a Prometheus label; the flow name is the bounded dimension.
+	Flow    string
 	Timeout string
 	Wait    bool
 	Retry   string
@@ -262,8 +267,10 @@ type FlowLockConfig struct {
 
 // FlowSemaphoreConfig is the flow-level semaphore configuration.
 type FlowSemaphoreConfig struct {
-	Storage    *SyncStorageConfig
-	Key        string
+	Storage *SyncStorageConfig
+	Key     string
+	// Flow labels the metrics — see FlowLockConfig.Flow.
+	Flow       string
 	MaxPermits int
 	Timeout    string
 	Lease      string
@@ -271,7 +278,9 @@ type FlowSemaphoreConfig struct {
 
 // FlowCoordinateConfig is the flow-level coordinate configuration.
 type FlowCoordinateConfig struct {
-	Storage            *SyncStorageConfig
+	Storage *SyncStorageConfig
+	// Flow labels the metrics — see FlowLockConfig.Flow.
+	Flow               string
 	Wait               *FlowWaitConfig
 	Signal             *FlowSignalConfig
 	Timeout            string
@@ -344,16 +353,23 @@ func (m *Manager) ExecuteWithLock(ctx context.Context, cfg *FlowLockConfig, key 
 		Retry:   retry,
 	}
 
-	// Acquire lock
+	// Acquire lock. The wait is timed either way: contention shows up as the
+	// gap between a message arriving and its flow starting, and without this
+	// there is no way to see it short of a tracing backend.
+	waitStart := time.Now()
 	acquired, err := AcquireWithRetry(ctx, lock, key, lockCfg)
+	waited := time.Since(waitStart)
 	if err != nil {
+		metrics.Default().RecordLockTimeout(cfg.Flow, waited)
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
 	if !acquired {
+		metrics.Default().RecordLockTimeout(cfg.Flow, waited)
 		return nil, ErrLockTimeout
 	}
+	metrics.Default().RecordLockAcquired(cfg.Flow, waited)
 
-	slog.Info("lock acquired", "key", key, "timeout", timeout)
+	slog.Info("lock acquired", "key", key, "timeout", timeout, "waited", waited)
 
 	// Heartbeat: extend the lock TTL while fn() runs. Without this, a
 	// flow that takes longer than `timeout` lets the lock auto-expire
@@ -414,6 +430,10 @@ func (m *Manager) ExecuteWithLock(ctx context.Context, cfg *FlowLockConfig, key 
 	defer func() {
 		hbCancel()
 		<-hbDone // wait for the heartbeat goroutine to exit before release
+		// Decrement the held gauge regardless of whether the release call
+		// succeeds: this process is no longer holding the lock either way,
+		// and a failed release leaves it to the TTL, not to us.
+		metrics.Default().RecordLockReleased(cfg.Flow)
 		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := lock.Release(releaseCtx, key); err != nil {
@@ -468,15 +488,20 @@ func (m *Manager) ExecuteWithSemaphore(ctx context.Context, cfg *FlowSemaphoreCo
 	}
 
 	// Acquire permit
+	waitStart := time.Now()
 	permitID, err := AcquireSemaphoreWithRetry(ctx, sem, key, semCfg)
+	waited := time.Since(waitStart)
 	if err != nil {
+		metrics.Default().RecordSemaphoreTimeout(cfg.Flow, waited)
 		return nil, fmt.Errorf("failed to acquire semaphore permit: %w", err)
 	}
+	metrics.Default().RecordSemaphoreAcquired(cfg.Flow, waited)
 
 	// Ensure permit is released even when parent ctx is cancelled. Same
 	// rationale as ExecuteWithLock — without a detached context, releases
 	// silently no-op and the semaphore leaks permits.
 	defer func() {
+		metrics.Default().RecordSemaphoreReleased(cfg.Flow)
 		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = sem.Release(releaseCtx, key, permitID)
@@ -620,6 +645,7 @@ func (m *Manager) ExecuteWithCoordinate(ctx context.Context, cfg *FlowCoordinate
 			return result, nil
 		}
 
+		metrics.Default().RecordCoordinateSignal(cfg.Flow)
 		slog.Info("coordinate signal emitted", "key", signalKey, "ttl", ttl)
 		return result, nil
 	}
@@ -647,6 +673,7 @@ func (m *Manager) ExecuteWithCoordinate(ctx context.Context, cfg *FlowCoordinate
 				slog.Warn("coordinate preflight error, falling through to wait",
 					"error", pfErr)
 			case skip:
+				metrics.Default().RecordCoordinatePreflightHit(cfg.Flow)
 				slog.Info("coordinate preflight passed, skipping wait",
 					"key", waitKey,
 					"action", "skip_wait")
@@ -666,7 +693,13 @@ func (m *Manager) ExecuteWithCoordinate(ctx context.Context, cfg *FlowCoordinate
 			}
 		}
 
+		// The wait is the interesting part operationally: how long flows sit
+		// blocked, and how often they give up. Both are recorded whatever the
+		// outcome, so the active-waits gauge always comes back down.
+		metrics.Default().RecordCoordinateWait(cfg.Flow)
+		waitStart := time.Now()
 		received, err := coord.Wait(ctx, waitKey, timeout)
+		metrics.Default().RecordCoordinateWaitComplete(cfg.Flow, time.Since(waitStart), !received)
 		if err != nil {
 			return nil, fmt.Errorf("coordinate wait failed: %w", err)
 		}

--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -253,13 +253,26 @@ func (m *Manager) Close() error {
 	return nil
 }
 
+// Lock purposes, used as the `purpose` metric label.
+const (
+	// LockPurposeFlow is the flow's own lock {} block, guarding a business key.
+	LockPurposeFlow = "flow"
+	// LockPurposeDedupe is the critical section around the duplicate check.
+	LockPurposeDedupe = "dedupe"
+)
+
 // FlowLockConfig is the flow-level lock configuration.
 type FlowLockConfig struct {
 	Storage *SyncStorageConfig
 	Key     string
 	// Flow labels the metrics. The evaluated lock key is per message, so it
 	// cannot be a Prometheus label; the flow name is the bounded dimension.
-	Flow    string
+	Flow string
+	// Purpose distinguishes what the lock guards: LockPurposeFlow for the
+	// flow's own lock {} block, LockPurposeDedupe for the duplicate-check
+	// critical section. Defaults to LockPurposeFlow when empty, so the label
+	// is never blank.
+	Purpose string
 	Timeout string
 	Wait    bool
 	Retry   string
@@ -356,18 +369,23 @@ func (m *Manager) ExecuteWithLock(ctx context.Context, cfg *FlowLockConfig, key 
 	// Acquire lock. The wait is timed either way: contention shows up as the
 	// gap between a message arriving and its flow starting, and without this
 	// there is no way to see it short of a tracing backend.
+	purpose := cfg.Purpose
+	if purpose == "" {
+		purpose = LockPurposeFlow
+	}
+
 	waitStart := time.Now()
 	acquired, err := AcquireWithRetry(ctx, lock, key, lockCfg)
 	waited := time.Since(waitStart)
 	if err != nil {
-		metrics.Default().RecordLockTimeout(cfg.Flow, waited)
+		metrics.Default().RecordLockTimeout(cfg.Flow, purpose, waited)
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
 	if !acquired {
-		metrics.Default().RecordLockTimeout(cfg.Flow, waited)
+		metrics.Default().RecordLockTimeout(cfg.Flow, purpose, waited)
 		return nil, ErrLockTimeout
 	}
-	metrics.Default().RecordLockAcquired(cfg.Flow, waited)
+	metrics.Default().RecordLockAcquired(cfg.Flow, purpose, waited)
 
 	slog.Info("lock acquired", "key", key, "timeout", timeout, "waited", waited)
 
@@ -433,7 +451,7 @@ func (m *Manager) ExecuteWithLock(ctx context.Context, cfg *FlowLockConfig, key 
 		// Decrement the held gauge regardless of whether the release call
 		// succeeds: this process is no longer holding the lock either way,
 		// and a failed release leaves it to the TTL, not to us.
-		metrics.Default().RecordLockReleased(cfg.Flow)
+		metrics.Default().RecordLockReleased(cfg.Flow, purpose)
 		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := lock.Release(releaseCtx, key); err != nil {

--- a/internal/sync/metrics_test.go
+++ b/internal/sync/metrics_test.go
@@ -1,0 +1,128 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/internal/metrics"
+)
+
+// scrape runs the real Prometheus handler and returns the exposition text, so
+// these tests fail if a metric is recorded but never registered — the exact
+// gap that left every sync metric permanently absent from /metrics.
+func scrape(t *testing.T) string {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	metrics.Default().Handler().ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	return rec.Body.String()
+}
+
+func TestExecuteWithLock_RecordsAcquireAndRelease(t *testing.T) {
+	metrics.SetDefault(metrics.NewRegistry("test", "1", "1", "test"))
+
+	mgr := NewManager()
+	defer mgr.Close()
+
+	cfg := &FlowLockConfig{Flow: "sync_inventory", Timeout: "5s", Wait: true}
+	if _, err := mgr.ExecuteWithLock(context.Background(), cfg, "sku:12345", func() (interface{}, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatalf("ExecuteWithLock: %v", err)
+	}
+
+	out := scrape(t)
+	for _, want := range []string{
+		`mycel_lock_acquired_total{flow="sync_inventory"} 1`,
+		`mycel_lock_released_total{flow="sync_inventory"} 1`,
+		`mycel_lock_held{flow="sync_inventory"} 0`,
+		`mycel_lock_wait_seconds_count{flow="sync_inventory"} 1`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in /metrics output", want)
+		}
+	}
+
+	// The evaluated key is per entity — one series per SKU would grow without
+	// bound, so it must never reach a label.
+	if strings.Contains(out, "sku:12345") {
+		t.Error("the lock key leaked into a metric label; cardinality is unbounded")
+	}
+}
+
+func TestExecuteWithLock_RecordsTimeout(t *testing.T) {
+	metrics.SetDefault(metrics.NewRegistry("test", "1", "1", "test"))
+
+	mgr := NewManager()
+	defer mgr.Close()
+
+	// Hold the key, then have a second caller give up on it. held is closed
+	// from inside the critical section, so the contended acquire below cannot
+	// start before the lock is actually taken.
+	holder := &FlowLockConfig{Flow: "holder", Timeout: "5s", Wait: true}
+	held := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = mgr.ExecuteWithLock(context.Background(), holder, "contended", func() (interface{}, error) {
+			close(held)
+			<-release
+			return nil, nil
+		})
+	}()
+	<-held
+
+	waiting := &FlowLockConfig{Flow: "sync_inventory", Timeout: "50ms", Wait: false}
+	_, err := mgr.ExecuteWithLock(context.Background(), waiting, "contended", func() (interface{}, error) {
+		return nil, errors.New("should not run while the lock is held")
+	})
+	close(release)
+	<-done
+
+	if err == nil {
+		t.Fatal("expected the contended acquire to fail")
+	}
+	if got := scrape(t); !strings.Contains(got, `mycel_lock_timeout_total{flow="sync_inventory"} 1`) {
+		t.Errorf("timeout not recorded: %s", filterLines(got, "mycel_lock"))
+	}
+}
+
+func TestExecuteWithSemaphore_RecordsAcquireAndRelease(t *testing.T) {
+	metrics.SetDefault(metrics.NewRegistry("test", "1", "1", "test"))
+
+	mgr := NewManager()
+	defer mgr.Close()
+
+	cfg := &FlowSemaphoreConfig{Flow: "call_erp", MaxPermits: 2, Timeout: "5s", Lease: "30s"}
+	if _, err := mgr.ExecuteWithSemaphore(context.Background(), cfg, "erp", func() (interface{}, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatalf("ExecuteWithSemaphore: %v", err)
+	}
+
+	out := scrape(t)
+	for _, want := range []string{
+		`mycel_semaphore_acquired_total{flow="call_erp"} 1`,
+		`mycel_semaphore_released_total{flow="call_erp"} 1`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in /metrics output", want)
+		}
+	}
+}
+
+// filterLines keeps only the lines containing sub, to keep failure output
+// readable against a full exposition dump.
+func filterLines(s, sub string) string {
+	var kept []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, sub) {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}

--- a/internal/sync/metrics_test.go
+++ b/internal/sync/metrics_test.go
@@ -27,6 +27,8 @@ func TestExecuteWithLock_RecordsAcquireAndRelease(t *testing.T) {
 	mgr := NewManager()
 	defer mgr.Close()
 
+	// Purpose left empty on purpose: it must default to "flow" rather than
+	// emitting an empty label.
 	cfg := &FlowLockConfig{Flow: "sync_inventory", Timeout: "5s", Wait: true}
 	if _, err := mgr.ExecuteWithLock(context.Background(), cfg, "sku:12345", func() (interface{}, error) {
 		return "ok", nil
@@ -36,10 +38,10 @@ func TestExecuteWithLock_RecordsAcquireAndRelease(t *testing.T) {
 
 	out := scrape(t)
 	for _, want := range []string{
-		`mycel_lock_acquired_total{flow="sync_inventory"} 1`,
-		`mycel_lock_released_total{flow="sync_inventory"} 1`,
-		`mycel_lock_held{flow="sync_inventory"} 0`,
-		`mycel_lock_wait_seconds_count{flow="sync_inventory"} 1`,
+		`mycel_lock_acquired_total{flow="sync_inventory",purpose="flow"} 1`,
+		`mycel_lock_released_total{flow="sync_inventory",purpose="flow"} 1`,
+		`mycel_lock_held{flow="sync_inventory",purpose="flow"} 0`,
+		`mycel_lock_wait_seconds_count{flow="sync_inventory",purpose="flow"} 1`,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in /metrics output", want)
@@ -86,7 +88,7 @@ func TestExecuteWithLock_RecordsTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected the contended acquire to fail")
 	}
-	if got := scrape(t); !strings.Contains(got, `mycel_lock_timeout_total{flow="sync_inventory"} 1`) {
+	if got := scrape(t); !strings.Contains(got, `mycel_lock_timeout_total{flow="sync_inventory",purpose="flow"} 1`) {
 		t.Errorf("timeout not recorded: %s", filterLines(got, "mycel_lock"))
 	}
 }
@@ -125,4 +127,41 @@ func filterLines(s, sub string) string {
 		}
 	}
 	return strings.Join(kept, "\n")
+}
+
+// The dedupe critical section and the flow's own lock {} are separate series
+// on the same flow. Contention in one means a hot business key; in the other,
+// duplicate deliveries piling up.
+func TestExecuteWithLock_PurposeSeparatesDedupeFromFlowLock(t *testing.T) {
+	metrics.SetDefault(metrics.NewRegistry("test", "1", "1", "test"))
+
+	mgr := NewManager()
+	defer mgr.Close()
+
+	run := func(purpose string) {
+		cfg := &FlowLockConfig{Flow: "sync_inventory", Purpose: purpose, Timeout: "5s", Wait: true}
+		if _, err := mgr.ExecuteWithLock(context.Background(), cfg, "sku:1", func() (interface{}, error) {
+			return nil, nil
+		}); err != nil {
+			t.Fatalf("ExecuteWithLock(%s): %v", purpose, err)
+		}
+	}
+	run(LockPurposeFlow)
+	run(LockPurposeDedupe)
+	run(LockPurposeDedupe)
+
+	out := scrape(t)
+	for _, want := range []string{
+		`mycel_lock_acquired_total{flow="sync_inventory",purpose="flow"} 1`,
+		`mycel_lock_acquired_total{flow="sync_inventory",purpose="dedupe"} 2`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, filterLines(out, "mycel_lock_acquired"))
+		}
+	}
+
+	// The flow name must stay clean — the purpose belongs in its own label.
+	if strings.Contains(out, "(dedupe)") {
+		t.Error(`the purpose leaked into the flow label`)
+	}
 }


### PR DESCRIPTION
Every item here has the same shape: a misconfiguration that produced no error, just an absence of behaviour. Motivated by [`IMPROVEMENTS.md`](https://github.com/matutetandil/mycel/blob/main/README.md) — a report from running six Mycel consumers in production across ~1.5M messages — plus three defects found while building the fixes.

Nothing changes what a correct configuration does.

## Silent drops are now loud

- **A message no flow can handle is an error, not a warning** — across **RabbitMQ, Kafka and Redis**, which all had the same hole: WARN, no metric, message gone. Each states what it just did, because the outcome differs: RabbitMQ nacks without requeue (a DLX may still catch it), Kafka commits the offset, Redis pub/sub discards. First occurrence per key at ERROR with the registered patterns alongside; repeats only move `mycel_messages_undispatched_total`.

- **Startup states which messages each flow will actually receive.** On a stream source `operation` is optional, which reads as inert — it is not. Declaring it filters every delivery against it, a *second* filter after the broker's own exchange and binding. It warns when every flow on a connector is narrowed, since one catch-all sibling guarantees a handler. Driver-agnostic: which connectors treat `operation` as a subscription pattern comes from their own `SourceSchema`.

- **Every deliberate drop explains itself at debug level.** Each gate already reported a stable reason, but only `on_drop` aspects ever saw it.

  ```
  DBG message dropped by policy flow=only_big_orders source=api reason=filter
      decided_by="from { filter }" detail="input.total > 100" disposition=ack
  ```

  `decided_by` names the block to go and edit, `detail` what it was judging. Payload rides on the existing `MYCEL_PAYLOAD_SHOW` opt-in.

- **`dlq { external = true }`.** Mycel provisions the DLX only when it declared the queue; on a pre-existing queue it provisions nothing, so exhausted retries are discarded. AMQP cannot tell whether a server-side policy covers the queue, so this records the answer once the operator has checked. Deliberately not defaulted on: a wrong `false` costs a log line, a wrong `true` costs messages.

## Commands that told the truth

- **`mycel check` actually connects.** It created the runtime and exited zero without opening a socket — a database on an unroutable address passed. Now builds, connects and health-checks every connector concurrently with `--timeout`, reporting all of them, and exits non-zero so it works as a deploy gate. Distinguishes `connection refused` from `no response within <timeout>`.
- **`mycel version` exists.** Documented in four places, never registered.
- **`mycel validate`** reports unset `env()` references and configuration with no effect (`params` on a `to` block is the first case).

## Metrics that were never emitted

`mycel_lock_*`, `mycel_semaphore_*`, `mycel_coordinate_*`, `mycel_cache_*`, `mycel_connector_health|operations|latency` were defined, registered and documented from the start with **zero call sites** — including a Grafana panel for cache hit rate that could never render.

New: per-flow timing extremes and throughput (`_fastest_`, `_slowest_`, `_average_`, `messages_per_second`) for what the histogram cannot give — exact extremes, and successful executions only.

## ⚠️ Corrects existing series

- **Sync metrics relabelled `key` → `flow`.** Lock keys are CEL expressions evaluated per message — one series per SKU. Recording them as declared would have grown the series set without bound. Lock metrics also gain `purpose` (`flow` / `dedupe`). None had ever been emitted, so no dashboard breaks.
- **Drops get `status="dropped"` on `mycel_flow_executions_total`,** plus `mycel_flow_drops_total{flow,reason}`. A declined message counted as success, so a consumer filtering out most of its input reported full productivity. **Flows with a gate will see `status="success"` fall.** This also fixed the timing gauges: on a flow dropping 8 of 9 messages, `fastest` reported 14µs of a filter short-circuiting instead of 1.9ms of real work.

## Verification

`go vet` clean · `go test ./...` green · `-race` clean on touched packages · **integration suite 146/0** via `run.sh` with real brokers · `mkdocs build --strict` exit 0 · 81 example configs validate.

Checked against the six production Mercury consumers (static analysis only, no connections): zero regressions A/B against a `main` binary, and zero false positives from the new startup diagnostics.

Docs updated: `observability.md`, `troubleshooting.md`, `source-properties.md`, `message-queues.md`, `cli.md`, `installation.md`, CHANGELOG.