### PR TITLE
chore: bump version to 2.13.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,3 +45,8 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          # Pages occasionally takes longer than the action's 10-minute default
+          # to confirm a deployment that has in fact succeeded, failing the run
+          # over a site that is already live (see the 2.13.0 docs deploy).
+          timeout: 1200000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.13.0] - 2026-08-06
 
 Every item here has the same shape: a misconfiguration that produced no error, just an absence of behaviour. Nothing in this release changes what a correct configuration does.
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	// Version information (set at build time)
-	version = "2.12.0"
+	version = "2.13.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Release bump for **2.13.0**, on top of #38.

| File | Change |
|---|---|
| `CHANGELOG.md` | `## [Unreleased]` → `## [2.13.0] - 2026-08-06` |
| `cmd/mycel/main.go` | `version = "2.12.0"` → `"2.13.0"` |
| `.github/workflows/docs.yml` | Pages deploy timeout 10 min → 20 min |

**Minor, not major.** Everything in #38 is additive at the configuration level — `dlq { external }` is optional and its absence preserves the previous behaviour exactly, and no HCL block, attribute or connector type changed meaning. `docs/reference/source-properties.md` already documents the dispatch report as landing "since 2.13.0", so the number was fixed before this PR.

Two changes do alter existing *metric* series, called out in the changelog: sync metrics relabelled `key` → `flow` (never emitted before, so nothing can break), and drops moving from `status="success"` to `status="dropped"`, which will lower success counts on any flow with a gate. Both are corrections to numbers that were previously wrong.

### The extra file

The docs deploy for this release failed. The site built in 25s and published fine — every page verified live — but `actions/deploy-pages@v5` timed out at its 10-minute default waiting for Pages to confirm, and reported a failure over a deployment that had succeeded. Re-running the job completed in 14s. The timeout goes to 20 minutes so a slow confirmation stops painting a red X on a working deploy. Folded in here rather than spending its own PR; drop the commit if you would rather keep the bump to two files.

### Pre-tag check

`go.mod` is on `go 1.25.0` and both Dockerfiles are on `golang:1.25-alpine` — they agree, so the mismatch that broke the v2.10.0 release build will not recur here. This is still verified by hand: the image is not built until the tag, which remains the one gap in the three-step release flow.

Verified: `mycel version` reports `2.13.0`, workflow YAML parses, `go build ./...` clean.