### PR TITLE
chore: bump version to 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.14.0] - 2026-08-08
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -35,7 +35,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "2.13.0"
+	version = "2.14.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Release bump for **2.14.0**, on top of #40, #41, #42 and #43.

| File | Change |
|---|---|
| `CHANGELOG.md` | `## [Unreleased]` → `## [2.14.0] - 2026-08-08` |
| `cmd/mycel/main.go` | `version = "2.13.0"` → `"2.14.0"` |

**Minor.** New commands (`mycel init`, `mycel add`) and the readability advice in `validate` are additive; nothing in the HCL surface changed meaning.

Not a major despite the module path moving to `/v2`: nobody could have been importing v2, because Go refused those tags. Anyone importing the library was resolving to v1.22.0 and is unaffected.

### What this release unblocks

`go install github.com/matutetandil/mycel/v2/cmd/mycel@latest` starts working **at this tag**. Every existing tag carries the old `go.mod` forever, so until 2.14.0 is published the Go install path still hands people v1.22.0 from April.

### Pre-tag check

`go.mod` is on `go 1.25.0` and both Dockerfiles on `golang:1.25-alpine` — verified by hand, and now also by CI: this is the first release where the `docker` job builds the runtime image *before* the tag rather than after. That gap is what broke the v2.10.0 release and forced a re-tag.

`mycel version` reports `2.14.0` from this branch.