### PR TITLE
Update the Homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,3 +126,70 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+
+  # Keeps the Homebrew tap pointing at the release just published.
+  #
+  # Runs after create-release rather than alongside it, so a failure here — a
+  # missing or expired token being the likely one — leaves the image, the chart
+  # and the GitHub release already published. A red mark on this job then means
+  # exactly one thing: the tap was not updated. It is deliberately not skipped
+  # when the secret is absent; a step that quietly does nothing is how a tap
+  # ends up months behind without anyone noticing.
+  homebrew:
+    runs-on: ubuntu-latest
+    needs: create-release
+
+    steps:
+      - name: Resolve version and source checksum
+        id: src
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
+
+          # GitHub generates this tarball per tag; it is what the formula
+          # builds from, so no release artifact is needed beyond it.
+          sha=$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "url=$url"         >> "$GITHUB_OUTPUT"
+          echo "sha256=$sha"      >> "$GITHUB_OUTPUT"
+          echo "Formula will point at $version ($sha)"
+
+      - name: Checkout tap
+        uses: actions/checkout@v6
+        with:
+          repository: matutetandil/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Update formula
+        working-directory: tap
+        run: |
+          set -euo pipefail
+          formula=Formula/mycel.rb
+
+          sed -i -E "s|^  url \".*\"|  url \"${{ steps.src.outputs.url }}\"|"       "$formula"
+          sed -i -E "s|^  sha256 \".*\"|  sha256 \"${{ steps.src.outputs.sha256 }}\"|" "$formula"
+
+          # Fail rather than commit a formula the edit did not actually land in:
+          # a sed that silently matches nothing would leave the tap on the old
+          # version while reporting success.
+          grep -q "${GITHUB_REF_NAME}.tar.gz"          "$formula"
+          grep -q "${{ steps.src.outputs.sha256 }}"    "$formula"
+
+          git diff --stat
+
+      - name: Commit and push
+        working-directory: tap
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "Formula already at ${{ steps.src.outputs.version }}; nothing to do."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "mycel ${{ steps.src.outputs.version }}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Homebrew install.** `brew install matutetandil/tap/mycel`, from a new [tap](https://github.com/matutetandil/homebrew-tap). The formula builds from the source tarball GitHub generates for each tag, so it needs no release artifact that did not already exist.
+
+  No code signing or notarization is involved. Homebrew requires both for **casks**, and makes them mandatory for the official cask tap from September 2026, but a command-line **formula** is exempt — and a Go binary is ad-hoc signed, which cannot be notarized at all. Verified on the installed binary: `Signature=adhoc`, `TeamIdentifier=not set`, and it runs without Gatekeeper intervening.
+
+  The release workflow updates the formula's version and checksum when a tag is published, so the tap cannot drift behind. It runs after the release is complete, so a failure there leaves the image, chart and GitHub release published and means only that the tap needs attention.
+
 ## [2.14.0] - 2026-08-08
 
 ### Added


### PR DESCRIPTION
`brew install matutetandil/tap/mycel` works now — the [tap](https://github.com/matutetandil/homebrew-tap) is published and the formula installs, builds and passes `brew test`.

This keeps it current. The formula pins an exact tag, so without automation it would be stale one release after being created.

## What the job does

Recomputes the source tarball checksum from the tag being released, rewrites the formula's `url` and `sha256`, and pushes to the tap.

The edit is **verified before committing** — a `sed` that matched nothing would otherwise leave the tap on the old version while the job reported success, which is the exact failure this exists to prevent. Simulated locally against a fake `v2.99.0` tag: url and checksum rewritten, both guards pass, formula still parses as Ruby.

## Two deliberate choices

**Runs after `create-release`, not beside it.** A failure here leaves the image, the chart and the GitHub release already published, so a red mark means exactly one thing: the tap needs attention.

**Not skipped when the token is missing.** A step that quietly does nothing is how a tap ends up months behind with a green pipeline.

## ⚠️ Needs a secret before the next release

`GITHUB_TOKEN` is scoped to this repository and cannot push to another one. This needs:

- **`HOMEBREW_TAP_TOKEN`** — a fine-grained PAT with **Contents: read and write** on `matutetandil/homebrew-tap` only.

Without it the job fails on the checkout step. Everything else in the release still completes.

## On signing

Worth recording, since it came up: Homebrew now requires code signing and notarization for **casks**, mandatory for the official tap from September 2026. A command-line **formula** is exempt, and a Go binary is ad-hoc signed — which cannot be notarized, since notarization requires a Developer ID signature. Verified on the installed binary: `Signature=adhoc`, `TeamIdentifier=not set`, runs without Gatekeeper intervening. No Apple Developer account is needed.