### PR TITLE
Add a temporary check that the tap token works

### DIFF
--- a/.github/workflows/verify-tap-token.yml
+++ b/.github/workflows/verify-tap-token.yml
@@ -1,0 +1,51 @@
+# Temporary. Proves HOMEBREW_TAP_TOKEN can do what the release job needs before
+# a release depends on it, then gets deleted.
+#
+# Checking that the secret exists only rules out a typo. The permissions are the
+# part that silently goes wrong — a token scoped to the wrong repository, or
+# granted Contents: Read instead of Read and write, looks identical from the
+# outside and fails at the worst moment.
+name: Verify tap token
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout tap
+        uses: actions/checkout@v6
+        with:
+          repository: matutetandil/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Report what the token can see
+        working-directory: tap
+        run: |
+          set -euo pipefail
+          echo "Read access confirmed. Formula currently points at:"
+          grep -E '^  (url|sha256)' Formula/mycel.rb
+
+      - name: Prove write access
+        working-directory: tap
+        run: |
+          set -euo pipefail
+
+          # A real push, which is what the release job does — anything less
+          # would confirm read access and call it a day. Pushed to a throwaway
+          # branch and deleted immediately, so the tap is untouched either way.
+          branch="token-check-${GITHUB_RUN_ID}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git commit --allow-empty -m "Verify HOMEBREW_TAP_TOKEN write access"
+
+          git push origin "$branch"
+          echo "Write access confirmed."
+
+          git push origin --delete "$branch"
+          echo "Throwaway branch removed. Tap is unchanged."


### PR DESCRIPTION
`HOMEBREW_TAP_TOKEN` is set and named correctly. That rules out a typo and nothing else.

The permissions are the part that goes wrong quietly: a token scoped to the wrong repository, or granted **Contents: Read** rather than **Read and write**, looks identical from the outside and fails when a release depends on it.

This is a `workflow_dispatch`-only job that:

1. Checks out the tap with the token — proves read access
2. Pushes an empty commit to a throwaway branch and deletes it — proves **write** access, which is what the release job actually needs

A checkout alone would confirm the half that was never in doubt.

**To be deleted once it has run.** It exists to answer one question before the next release, not to live in the repository.