### PR TITLE
Publish binaries and Linux packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,3 +193,44 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "mycel ${{ steps.src.outputs.version }}"
           git push
+
+  # Binaries and Linux packages, attached to the release create-release just
+  # made. goreleaser only builds here — the release itself, its notes and the
+  # Helm chart are owned by the jobs above.
+  #
+  # The packages carry more than the binary: a systemd unit, an unprivileged
+  # user and /etc/mycel. Installing on a VM otherwise leaves the operator to
+  # invent all three.
+  packages:
+    runs-on: ubuntu-latest
+    needs: create-release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build archives and packages
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+
+      - name: Attach to release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/*.deb
+            dist/*.rpm
+            dist/*.apk
+            dist/checksums.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,87 @@
+version: 2
+
+project_name: mycel
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: mycel
+    main: ./cmd/mycel
+    binary: mycel
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    # The binary reads its version from build metadata when there is any, and
+    # falls back to these. A release archive is built from a checkout rather
+    # than `go install`, so the module version is absent and these are what
+    # `mycel version` reports.
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .ShortCommit }}
+
+archives:
+  - id: mycel
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+# Packages carry more than the binary: without the unit file, the config
+# directory and an unprivileged user, installing on a VM leaves the operator to
+# invent all three.
+nfpms:
+  - id: mycel
+    package_name: mycel
+    vendor: Matias Denda
+    homepage: https://github.com/matutetandil/mycel
+    maintainer: Matias Denda <matutetandil@gmail.com>
+    description: |-
+      Declarative microservice runtime.
+      Describe what connects to what in HCL, and Mycel runs the service.
+    license: MIT
+    formats: [deb, rpm, apk]
+    bindir: /usr/bin
+
+    contents:
+      - src: packaging/mycel.service
+        dst: /lib/systemd/system/mycel.service
+        packager: deb
+      - src: packaging/mycel.service
+        dst: /usr/lib/systemd/system/mycel.service
+        packager: rpm
+
+      # Config lives here and survives removal — it is the operator's, not the
+      # package's.
+      - dst: /etc/mycel
+        type: dir
+        file_info:
+          mode: 0755
+          owner: mycel
+          group: mycel
+
+      - dst: /var/lib/mycel
+        type: dir
+        file_info:
+          mode: 0750
+          owner: mycel
+          group: mycel
+
+    scripts:
+      preinstall: packaging/preinstall.sh
+      postremove: packaging/postremove.sh
+
+checksum:
+  name_template: checksums.txt
+
+# The release is created by the workflow, which also attaches the Helm chart.
+# goreleaser only builds here; the artifacts are uploaded alongside it.
+release:
+  disable: true
+
+changelog:
+  disable: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Linux packages and prebuilt binaries.** Every release now attaches `.deb`, `.rpm`, `.apk` and `tar.gz` archives for linux and darwin on amd64 and arm64, with checksums. Until now the only artifact was the Helm chart, so installing without Docker or a Go toolchain was not possible.
+
+  The packages carry more than the binary — a systemd unit, an unprivileged `mycel` user, `/etc/mycel` and `/var/lib/mycel` — so a server install is a service rather than a loose executable:
+
+  ```bash
+  sudo dpkg -i mycel_2.15.0_linux_amd64.deb
+  sudo systemctl enable --now mycel
+  ```
+
+  Verified by installing into Debian 12 and Rocky Linux 9 containers: the binary runs, the `mycel` user exists, the unit lands in the right place per packager, and a scaffolded project validates.
+
+  There is no apt or yum repository, so `apt install` and `apt upgrade` still do not apply — that needs hosting, repository metadata and a GPG signing key, and is worth doing only if the demand appears.
+
+- **`install.sh`** for `curl -fsSL … | sh`. Detects platform and architecture, resolves the latest release, and installs to `/usr/local/bin`, reaching for `sudo` only when that directory is not already writable. `MYCEL_VERSION` pins a version and `MYCEL_INSTALL_DIR` relocates it.
+
+- **Homebrew is documented in the installation guide**, which it was not when the tap was published.
+
 - **Homebrew install.** `brew install matutetandil/tap/mycel`, from a new [tap](https://github.com/matutetandil/homebrew-tap). The formula builds from the source tarball GitHub generates for each tag, so it needs no release artifact that did not already exist.
 
   No code signing or notarization is involved. Homebrew requires both for **casks**, and makes them mandatory for the official cask tap from September 2026, but a command-line **formula** is exempt — and a Go binary is ad-hoc signed, which cannot be notarized at all. Verified on the installed binary: `Signature=adhoc`, `TeamIdentifier=not set`, and it runs without Gatekeeper intervening.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -125,6 +125,68 @@ what you are actually running: the module version for a `go install` binary,
 and the git revision — with a `-dirty` suffix for uncommitted changes — for a
 build from a checkout.
 
+## Homebrew
+
+```bash
+brew install matutetandil/tap/mycel
+```
+
+The [formula](https://github.com/matutetandil/homebrew-tap) builds from source,
+so Homebrew installs Go as a build dependency and compiles — expect about a
+minute the first time. No Apple Developer account or code signing is involved:
+those apply to Homebrew *casks*, not to command-line formulae.
+
+Update with `brew upgrade mycel`.
+
+## Linux packages
+
+`.deb`, `.rpm` and `.apk` are attached to every
+[release](https://github.com/matutetandil/mycel/releases). They carry more than
+the binary — a systemd unit, an unprivileged `mycel` user, `/etc/mycel` and
+`/var/lib/mycel` — so a server install is a service rather than a loose
+executable:
+
+```bash
+# Debian, Ubuntu
+curl -LO https://github.com/matutetandil/mycel/releases/latest/download/mycel_2.15.0_linux_amd64.deb
+sudo dpkg -i mycel_2.15.0_linux_amd64.deb
+
+# RHEL, Fedora, Rocky, Alma
+sudo rpm -i mycel_2.15.0_linux_amd64.rpm
+
+# Alpine
+sudo apk add --allow-untrusted mycel_2.15.0_linux_amd64.apk
+```
+
+Then:
+
+```bash
+sudo systemctl enable --now mycel
+sudo systemctl status mycel
+```
+
+The service reads `/etc/mycel`, runs as the `mycel` user, and writes only to
+`/var/lib/mycel`. Put your `.mycel` files in `/etc/mycel` and restart it.
+
+There is **no apt or yum repository yet**, so `apt install mycel` and
+`apt upgrade` do not work — installing and upgrading are the commands above.
+
+## Install script
+
+For a plain binary with no service wrapper:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/matutetandil/mycel/main/install.sh | sh
+```
+
+Detects your platform, downloads the latest release into `/usr/local/bin`, and
+reaches for `sudo` only if that directory is not already writable. Set
+`MYCEL_VERSION` to pin a version and `MYCEL_INSTALL_DIR` to install elsewhere —
+`MYCEL_INSTALL_DIR="$HOME/.local/bin"` needs no elevation at all.
+
+On a server, prefer the packages above: this gives you the binary and nothing
+else.
+
 ## Helm (Kubernetes)
 
 The official Helm chart installs Mycel on any Kubernetes cluster:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Install Mycel — the declarative microservice runtime.
+#
+#   curl -fsSL https://raw.githubusercontent.com/matutetandil/mycel/main/install.sh | sh
+#
+# Installs the latest release for this platform into /usr/local/bin, or into
+# $MYCEL_INSTALL_DIR. Set MYCEL_VERSION to pin a version.
+#
+# On a server you probably want the .deb or .rpm instead: they carry a systemd
+# unit, an unprivileged user and /etc/mycel, none of which a loose binary does.
+# See https://github.com/matutetandil/mycel/releases
+
+set -eu
+
+REPO="matutetandil/mycel"
+INSTALL_DIR="${MYCEL_INSTALL_DIR:-/usr/local/bin}"
+
+fail() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || fail "$1 is required"; }
+need uname
+need tar
+
+if command -v curl >/dev/null 2>&1; then
+    fetch() { curl -fsSL "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+    fetch() { wget -qO- "$1"; }
+else
+    fail "curl or wget is required"
+fi
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$os" in
+    linux|darwin) ;;
+    *) fail "unsupported OS: $os — Mycel publishes linux and darwin builds" ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+    x86_64|amd64)  arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *) fail "unsupported architecture: $arch — Mycel publishes amd64 and arm64 builds" ;;
+esac
+
+version="${MYCEL_VERSION:-}"
+if [ -z "$version" ]; then
+    # Resolve the latest tag without needing jq.
+    version=$(fetch "https://api.github.com/repos/$REPO/releases/latest" \
+        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+    [ -n "$version" ] || fail "could not resolve the latest release"
+fi
+version="${version#v}"
+
+archive="mycel_${version}_${os}_${arch}.tar.gz"
+url="https://github.com/$REPO/releases/download/v${version}/${archive}"
+
+printf 'Installing mycel %s (%s/%s) into %s\n' "$version" "$os" "$arch" "$INSTALL_DIR"
+
+tmp=$(mktemp -d)
+# Leave nothing behind, including on a failed download.
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+fetch "$url" > "$tmp/$archive" || fail "download failed: $url"
+tar -xzf "$tmp/$archive" -C "$tmp" || fail "could not extract $archive"
+[ -f "$tmp/mycel" ] || fail "archive did not contain a mycel binary"
+
+# Only reach for sudo when the target is not already writable, so the script
+# stays usable for a per-user install.
+if [ -w "$INSTALL_DIR" ] || [ ! -e "$INSTALL_DIR" ] && mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+    install -m 0755 "$tmp/mycel" "$INSTALL_DIR/mycel"
+elif command -v sudo >/dev/null 2>&1; then
+    printf 'Elevating with sudo to write to %s\n' "$INSTALL_DIR"
+    sudo install -m 0755 "$tmp/mycel" "$INSTALL_DIR/mycel"
+else
+    fail "$INSTALL_DIR is not writable and sudo is unavailable — set MYCEL_INSTALL_DIR"
+fi
+
+printf '\n%s\n\n' "$("$INSTALL_DIR/mycel" version)"
+printf 'Next:\n'
+printf '  mycel init my-service && cd my-service\n'
+printf '  mycel start\n'
+
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *) printf '\nNote: %s is not on your PATH.\n' "$INSTALL_DIR" ;;
+esac

--- a/packaging/mycel.service
+++ b/packaging/mycel.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Mycel — declarative microservice runtime
+Documentation=https://matutetandil.github.io/mycel/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=mycel
+Group=mycel
+
+# Mycel reads every .mycel file under this directory, recursively.
+Environment=MYCEL_ENV=production
+Environment=MYCEL_LOG_FORMAT=json
+ExecStart=/usr/bin/mycel start --config /etc/mycel
+
+Restart=on-failure
+RestartSec=5s
+
+# The runtime needs nothing but its config and the network. Everything below
+# is what it does not need, denied explicitly.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+ReadOnlyPaths=/etc/mycel
+# SQLite databases and file connectors write here; nothing else is writable.
+StateDirectory=mycel
+WorkingDirectory=/var/lib/mycel
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/postremove.sh
+++ b/packaging/postremove.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# Only on a real removal, not on the remove half of an upgrade.
+case "${1:-}" in
+    purge|0)
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl daemon-reload >/dev/null 2>&1 || true
+        fi
+        # The user is left in place: files under /etc/mycel and /var/lib/mycel
+        # may still belong to it, and removing it would orphan them.
+        ;;
+esac

--- a/packaging/preinstall.sh
+++ b/packaging/preinstall.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# The service runs unprivileged. Created before the files land so ownership can
+# be set, and left alone on upgrade.
+if ! id -u mycel >/dev/null 2>&1; then
+    if command -v useradd >/dev/null 2>&1; then
+        useradd --system --no-create-home --shell /usr/sbin/nologin \
+                --home-dir /var/lib/mycel mycel
+    elif command -v adduser >/dev/null 2>&1; then
+        # Alpine
+        adduser -S -D -H -h /var/lib/mycel -s /sbin/nologin mycel
+    fi
+fi


### PR DESCRIPTION
The only release artifact was the Helm chart. Installing Mycel without Docker or a Go toolchain was not possible — which also left the Homebrew formula compiling from source, and nothing at all for a plain VM.

## What every release now carries

`tar.gz` archives and `.deb`, `.rpm`, `.apk` packages, for linux and darwin on amd64 and arm64, with checksums.

```bash
sudo dpkg -i mycel_2.15.0_linux_amd64.deb
sudo systemctl enable --now mycel
```

goreleaser does not own the release here: the notes and the Helm chart stay with the jobs that already produce them, and this job only attaches files.

## The packages are a service, not a binary drop

They install a systemd unit, an unprivileged `mycel` user, `/etc/mycel` and `/var/lib/mycel`. A package that drops a binary in `/usr/bin` and leaves the operator to invent the service, the user and the config directory is barely better than a tarball — and this is precisely the case a tarball cannot serve.

The unit denies what the runtime does not need: `NoNewPrivileges`, `ProtectSystem=strict`, config mounted read-only, writes confined to its state directory.

## Verified, not assumed

Installed into real containers rather than inspected:

| | Debian 12 | Rocky Linux 9 |
|---|---|---|
| `dpkg -i` / `rpm -i` | ✅ | ✅ |
| `mycel version` | ✅ | ✅ |
| `mycel` user (uid 999) | ✅ | ✅ |
| Unit path | `/lib/systemd/system` | `/usr/lib/systemd/system` |
| `mycel init` + `validate` | ✅ | — |

The `.deb` contents are exactly the four things intended, nothing more:

```
./etc/mycel/
./lib/systemd/system/mycel.service
./usr/bin/mycel
./var/lib/mycel/
```

## `install.sh`

```bash
curl -fsSL https://raw.githubusercontent.com/matutetandil/mycel/main/install.sh | sh
```

Reaches for `sudo` only when the target is not already writable, so `MYCEL_INSTALL_DIR="$HOME/.local/bin"` needs no elevation. POSIX `sh`, no `jq`.

Tested on a clean Debian image for platform detection and version resolution — it resolved 2.14.0 and failed cleanly on the download, since that release predates these artifacts — and against a real archive for the extract-and-install half. The download itself only becomes testable once a release carries them.

## Still not covered

**No apt or yum repository**, so `apt install mycel` and `apt upgrade` do not work. That needs hosting, repository metadata and a GPG signing key to maintain, and it is worth doing when someone asks for it rather than on principle. Said plainly in the installation guide instead of left to be discovered.

Homebrew is also documented there now, which it was not when the tap was published.