### PR TITLE
chore: bump version to 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.15.0] - 2026-08-10
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -35,7 +35,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "2.14.0"
+	version = "2.15.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Release bump for **2.15.0**, on top of #45, #46, #47 and #48.

| File | Change |
|---|---|
| `CHANGELOG.md` | `## [Unreleased]` → `## [2.15.0] - 2026-08-10` |
| `cmd/mycel/main.go` | `version = "2.14.0"` → `"2.15.0"` |

**Minor.** Homebrew, Linux packages, prebuilt binaries and an install script are all additive; nothing in the HCL surface or the runtime changed.

### What this release makes real

Until now the only release artifact was the Helm chart. This is the first tag that publishes:

- `tar.gz` archives for linux and darwin, amd64 and arm64
- `.deb`, `.rpm` and `.apk` packages carrying a systemd unit, an unprivileged user and `/etc/mycel`
- checksums

It is also the first release where `install.sh` can complete: it resolves the latest tag and downloads an archive that, before this, did not exist.

The Homebrew tap will be updated automatically by the `homebrew` job — its token was verified against the tap in [run 31341711478](https://github.com/matutetandil/mycel/actions/runs/31341711478) rather than assumed.

### Pre-tag check

`go.mod` on `go 1.25.0`, both Dockerfiles on `golang:1.25-alpine`. Verified by hand and by the `docker` job on this pull request.