### PR TITLE
Describe the remaining blocks, and generate them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The saga, state machine, validator and transform blocks are described in the schema.** They were declared `Open`, meaning "any attribute goes", so completions offered nothing inside them and a generator had nothing to read. Each is now transcribed from its parser, which remains the authority. `transform` keeps `Open` — its attributes are CEL mappings named by the author — but gains the `enrich` child block.
 - **`mycel validate` reports sagas, state machines, validators and transforms.** It listed connectors, flows and types only, so a project whose saga had just been added got no acknowledgement that the file was read.
 
+- **Every root block is now checked against the parser.** The parity test covers all fifteen, not the four that were rewritten, so a schema that stops matching its parser fails the build.
+
 ### Fixed
 
+- **The schema advertised an `environment` block that does not exist.** No such block type is accepted anywhere, so a document containing one fails to parse — but completions offered it, and a test asserted it was there. Per-environment configuration is connector profiles and `env()`, selected with `--env`.
+- **`auth`, `security`, `service.rate_limit`, `functions` and the aspect's `rate_limit` and `circuit_breaker` were declared `Open`,** meaning any attribute is valid. Their parsers accept a fixed set and reject the rest, so nothing inside them was ever checked or completed. Each is now described; `auth`'s fourteen nested blocks are named, with `storage` and `audit` described in full.
 - **A named `transform` holding an `enrich` block never parsed.** The runtime reads those enrichments when a flow references the transform, and the documentation shows one, but `hcl.Body.JustAttributes` refuses a body containing any block — including the `enrich` blocks the parser had just consumed itself. Found by the new schema parity test on its first run.
 - **A saga with no `from` block was skipped at registration in silence.** Nothing else triggers a saga, so it loaded, validated and never ran. It now says so by name at startup, and `mycel add saga` requires `--from` rather than generating one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`mycel add saga`, `add state-machine`, `add validator` and `add transform`.** The four blocks that were left out of the scaffolding in 2.14.0, now that their schemas describe them. As with the other generators, the shape, the allowed values and the comments come from `pkg/schema` — nothing is a template, so nothing can drift from the parser.
+- **The saga, state machine, validator and transform blocks are described in the schema.** They were declared `Open`, meaning "any attribute goes", so completions offered nothing inside them and a generator had nothing to read. Each is now transcribed from its parser, which remains the authority. `transform` keeps `Open` — its attributes are CEL mappings named by the author — but gains the `enrich` child block.
+- **`mycel validate` reports sagas, state machines, validators and transforms.** It listed connectors, flows and types only, so a project whose saga had just been added got no acknowledgement that the file was read.
+
+### Fixed
+
+- **A named `transform` holding an `enrich` block never parsed.** The runtime reads those enrichments when a flow references the transform, and the documentation shows one, but `hcl.Body.JustAttributes` refuses a body containing any block — including the `enrich` blocks the parser had just consumed itself. Found by the new schema parity test on its first run.
+- **A saga with no `from` block was skipped at registration in silence.** Nothing else triggers a saga, so it loaded, validated and never ran. It now says so by name at startup, and `mycel add saga` requires `--from` rather than generating one.
+
+### Changed
+
+- **`mycel add validator` requires the rule for the type chosen** (`--pattern`, `--expr` or `--wasm`). The parser rejects an empty one by name, so generating a placeholder there produced a file that could not be parsed.
+
 ## [2.15.0] - 2026-08-10
 
 ### Added

--- a/cmd/mycel/add.go
+++ b/cmd/mycel/add.go
@@ -276,6 +276,30 @@ func ensureNameIsFree(name, kind string) error {
 				return fmt.Errorf("a flow named %q already exists — names are global across every .mycel file", name)
 			}
 		}
+	case "saga":
+		for _, s := range cfg.Sagas {
+			if s != nil && s.Name == name {
+				return fmt.Errorf("a saga named %q already exists — names are global across every .mycel file", name)
+			}
+		}
+	case "state_machine":
+		for _, m := range cfg.StateMachines {
+			if m != nil && m.Name == name {
+				return fmt.Errorf("a state machine named %q already exists — names are global across every .mycel file", name)
+			}
+		}
+	case "validator":
+		for _, v := range cfg.Validators {
+			if v != nil && v.Name == name {
+				return fmt.Errorf("a validator named %q already exists — names are global across every .mycel file", name)
+			}
+		}
+	case "transform":
+		for _, tr := range cfg.Transforms {
+			if tr != nil && tr.Name == name {
+				return fmt.Errorf("a transform named %q already exists — names are global across every .mycel file", name)
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/mycel/add_roundtrip_test.go
+++ b/cmd/mycel/add_roundtrip_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/v2/internal/parser"
+	"github.com/matutetandil/mycel/v2/internal/runtime"
+	"github.com/matutetandil/mycel/v2/pkg/schema"
+)
+
+// If we describe every block in the schema, then what we generate from it has
+// to be valid. That is the whole claim, and it is only worth making if
+// something checks it: each generator's output is written to disk and put
+// through the real parser, the same one `mycel validate` uses.
+//
+// Generated files carry TODOs, so they are not finished services — but they
+// must parse. A skeleton that does not is worse than no skeleton, because the
+// first thing anyone does with it is run validate.
+func TestGeneratedDeclarationsParse(t *testing.T) {
+	cases := []struct {
+		kind string
+		body string
+	}{
+		{"saga", renderSaga("place_order", "orders", []string{"reserve", "charge"}, schema.SagaSchema())},
+		{"saga_one_step", renderSaga("place_order", "orders", []string{"reserve"}, schema.SagaSchema())},
+		{"state_machine", renderStateMachine("order", "pending",
+			[]string{"pending", "paid", "shipped"}, schema.StateMachineSchema())},
+		{"state_machine_single", renderStateMachine("toggle", "on",
+			[]string{"on"}, schema.StateMachineSchema())},
+		{"validator_regex", renderValidator("nz_phone", "regex", `^\+64[0-9]{8,9}$`, schema.ValidatorSchema())},
+		{"validator_cel", renderValidator("adult", "cel", "input.age >= 18", schema.ValidatorSchema())},
+		{"validator_wasm", renderValidator("tax_id", "wasm", "./tax_id.wasm", schema.ValidatorSchema())},
+		{"transform", renderTransform("normalize", []string{"id", "email"}, schema.TransformSchema())},
+		{"transform_empty", renderTransform("passthrough", nil, schema.TransformSchema())},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			if err := parseGenerated(t, tc.body); err != nil {
+				t.Fatalf("`mycel add` generated something that does not parse: %v\n\n%s", err, tc.body)
+			}
+		})
+	}
+}
+
+// A validator carries its rule in one of three attributes, and the parser
+// rejects an empty one by name. Generating a TODO there would produce a file
+// that fails to parse, so the flag is demanded instead — the same call made for
+// an aspect with no action.
+func TestAddValidator_DemandsItsRule(t *testing.T) {
+	for _, tc := range []struct{ vType, flag string }{
+		{"regex", "--pattern"}, {"cel", "--expr"}, {"wasm", "--wasm"},
+	} {
+		addValidatorType = tc.vType
+		addPattern, addExpr, addWASM = "", "", ""
+
+		err := runAddValidator(nil, []string{"pending"})
+		if err == nil {
+			t.Errorf("a %s validator with no rule should be refused, not written", tc.vType)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.flag) {
+			t.Errorf("the error should name %s, got: %v", tc.flag, err)
+		}
+	}
+	addValidatorType = ""
+}
+
+// The saga parser refuses one with no steps, and a step with no action, delay
+// or await. The generator must therefore never emit either, whatever flags it
+// was given.
+func TestGeneratedSagaAlwaysHasAStepWithAnAction(t *testing.T) {
+	body := renderSaga("empty", "orders", nil, schema.SagaSchema())
+
+	if !strings.Contains(body, "step ") {
+		t.Fatalf("a saga with no steps is rejected by the parser:\n%s", body)
+	}
+	if !strings.Contains(body, "action {") {
+		t.Errorf("a step with no action is rejected by the parser:\n%s", body)
+	}
+	if !strings.Contains(body, "compensate {") {
+		t.Errorf("compensation is the reason a saga exists; it should be generated:\n%s", body)
+	}
+}
+
+// Every state final means every transition is refused, which reads as a bug in
+// the runtime rather than an unfinished file.
+func TestGeneratedStateMachineCanActuallyTransition(t *testing.T) {
+	body := renderStateMachine("order", "pending", []string{"pending", "paid"}, schema.StateMachineSchema())
+
+	if !strings.Contains(body, "transition_to") {
+		t.Errorf("a machine with no transition can never leave its initial state:\n%s", body)
+	}
+	if !strings.Contains(body, "final = true") {
+		t.Errorf("the last state should be terminal:\n%s", body)
+	}
+}
+
+// The comments come from the schema's own documentation, so they cannot
+// contradict what the schema declares.
+func TestGeneratedCommentsComeFromTheSchema(t *testing.T) {
+	body := renderValidator("x", "wasm", "", schema.ValidatorSchema())
+
+	want := docFor(schema.ValidatorSchema(), "entrypoint")
+	if want == "" {
+		t.Fatal("the schema documents no entrypoint, so this test is checking nothing")
+	}
+	if !strings.Contains(body, want) {
+		t.Errorf("generated comment does not use the schema's wording (%q):\n%s", want, body)
+	}
+}
+
+// parseGenerated writes the declaration into a project and parses it the way
+// mycel validate does.
+func parseGenerated(t *testing.T, body string) error {
+	t.Helper()
+
+	dir := t.TempDir()
+	// A minimal host project, so the declaration is parsed in the context it
+	// would really live in.
+	mustWrite(t, filepath.Join(dir, "config.mycel"), `
+service {
+  name = "generated"
+}
+
+connector "orders" {
+  type   = "database"
+  driver = "sqlite"
+
+  database = ":memory:"
+}
+`)
+	mustWrite(t, filepath.Join(dir, "generated.mycel"), body)
+
+	p := parser.NewHCLParserWithRegistry(runtime.NewSchemaRegistry())
+	_, err := p.Parse(context.Background(), dir)
+	return err
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/cmd/mycel/add_workflow.go
+++ b/cmd/mycel/add_workflow.go
@@ -1,0 +1,395 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/matutetandil/mycel/v2/pkg/schema"
+)
+
+// The generators for the blocks that describe work rather than wiring: sagas,
+// state machines, validators and named transforms.
+//
+// Same rule as the connector and flow generators — the shape comes from
+// pkg/schema, never from a literal here. A template drifts the day the parser
+// changes; a schema cannot, because the parity test parses what it describes.
+
+var (
+	addSagaFrom        string
+	addSagaSteps       string
+	addStates          string
+	addInitialState    string
+	addValidatorType   string
+	addPattern         string
+	addExpr            string
+	addWASM            string
+	addTransformFields string
+)
+
+var addSagaCmd = &cobra.Command{
+	Use:   "saga <name>",
+	Short: "Add a saga in sagas/<name>.mycel",
+	Long: `Generate a saga: a sequence of steps, each with the call that undoes it.
+
+A saga is for work that spans services and cannot be one database transaction.
+When a step fails, the steps already done are compensated in reverse order.
+
+Examples:
+  mycel add saga place_order --steps reserve_stock,charge_card,ship
+  mycel add saga place_order --from orders_queue --steps reserve,charge`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAddSaga,
+}
+
+func runAddSaga(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := ensureNameIsFree(name, "saga"); err != nil {
+		return err
+	}
+
+	// A saga with no from block is skipped at registration and never runs.
+	// There is no other way to trigger one — nothing invokes a saga from a
+	// flow — so generating one without a source produces a file that loads,
+	// validates, and does nothing.
+	if addSagaFrom == "" {
+		return fmt.Errorf("a saga needs something to trigger it: pass --from <connector>")
+	}
+	if err := ensureConnectorExists(addSagaFrom); err != nil {
+		return err
+	}
+
+	return writeDeclaration(filepath.Join("sagas", name+".mycel"),
+		renderSaga(name, addSagaFrom, splitList(addSagaSteps), schema.SagaSchema()))
+}
+
+func renderSaga(name, from string, steps []string, blk schema.Block) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "// %s\n", blk.Doc)
+	fmt.Fprintf(&b, "saga %q {\n", name)
+
+	// The from block is what triggers the saga, and a saga without one never
+	// registers, so it is always written.
+	b.WriteString("  from {\n")
+	fmt.Fprintf(&b, "    connector = %q\n", from)
+	fmt.Fprintf(&b, "    operation = \"\" // TODO — %s\n", docFor(childOf(blk, "from"), "operation"))
+	b.WriteString("  }\n\n")
+
+	// The parser rejects a saga with no steps, and a step with no action. The
+	// default lives here rather than in the caller so that no way of reaching
+	// this function can produce a saga that fails to parse. Two named steps
+	// also make the compensation order visible, which is the reason to reach
+	// for a saga at all.
+	if len(steps) == 0 {
+		steps = []string{"first_step", "second_step"}
+	}
+
+	step := childOf(blk, "step")
+	for i, s := range steps {
+		fmt.Fprintf(&b, "  step %q {\n", s)
+		b.WriteString("    action {\n")
+		b.WriteString("      connector = \"\" // TODO — a connector declared in connectors/\n")
+		b.WriteString("      operation = \"\"\n")
+		b.WriteString("    }\n")
+
+		// The compensate block is the reason a saga exists, so it is generated
+		// rather than mentioned. The last step has nothing after it to fail,
+		// but a later step added below it would have — leaving it out invites
+		// exactly that mistake.
+		b.WriteString("\n    // Undoes this step when a later one fails.\n")
+		b.WriteString("    compensate {\n")
+		b.WriteString("      connector = \"\" // TODO\n")
+		b.WriteString("      operation = \"\"\n")
+		b.WriteString("    }\n")
+
+		if i == 0 {
+			fmt.Fprintf(&b, "\n    // Optional: %s\n", attrHints(step, "timeout", "on_error", "delay", "await"))
+		}
+		b.WriteString("  }\n\n")
+	}
+
+	b.WriteString("  // Runs once every step has succeeded.\n")
+	b.WriteString("  // on_complete { connector = \"notifications\" }\n")
+	b.WriteString("\n  // Runs after compensation has unwound the saga.\n")
+	b.WriteString("  // on_failure { connector = \"notifications\" }\n")
+	b.WriteString("}\n")
+
+	return b.String()
+}
+
+var addStateMachineCmd = &cobra.Command{
+	Use:     "state-machine <name>",
+	Aliases: []string{"state_machine"},
+	Short:   "Add a state machine in state_machines/<name>.mycel",
+	Long: `Generate a state machine: the states an entity may be in, and the
+events that move it between them.
+
+A transition that is not declared cannot happen, which is the point — it is how
+an order gets refunded only after it was paid.
+
+Examples:
+  mycel add state-machine order --states pending,paid,shipped,delivered
+  mycel add state-machine order --states draft,live --initial draft`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAddStateMachine,
+}
+
+func runAddStateMachine(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := ensureNameIsFree(name, "state_machine"); err != nil {
+		return err
+	}
+
+	states := splitList(addStates)
+	if len(states) == 0 {
+		states = []string{"pending", "active", "done"}
+	}
+
+	initial := addInitialState
+	if initial == "" {
+		initial = states[0]
+	}
+	if !contains(states, initial) {
+		return fmt.Errorf("initial state %q is not in --states (%s)", initial, strings.Join(states, ", "))
+	}
+
+	return writeDeclaration(filepath.Join("state_machines", name+".mycel"),
+		renderStateMachine(name, initial, states, schema.StateMachineSchema()))
+}
+
+func renderStateMachine(name, initial string, states []string, blk schema.Block) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "// %s\n", blk.Doc)
+	fmt.Fprintf(&b, "state_machine %q {\n", name)
+	fmt.Fprintf(&b, "  initial = %q\n", initial)
+
+	for i, s := range states {
+		b.WriteString("\n")
+		fmt.Fprintf(&b, "  state %q {\n", s)
+
+		// Chain each state to the next, so the generated machine is a working
+		// one. A machine whose states are all terminal parses and then refuses
+		// every transition, which reads as a runtime bug rather than a
+		// half-written file.
+		if i+1 < len(states) {
+			next := states[i+1]
+			fmt.Fprintf(&b, "    on %q {\n", "to_"+next)
+			fmt.Fprintf(&b, "      transition_to = %q\n", next)
+			if i == 0 {
+				b.WriteString("      // guard = \"input.amount > 0\" // CEL; refuses the transition when false\n")
+			}
+			b.WriteString("\n      // action {\n")
+			b.WriteString("      //   connector = \"notifications\"\n")
+			b.WriteString("      // }\n")
+			b.WriteString("    }\n")
+		} else {
+			b.WriteString("    final = true\n")
+		}
+		b.WriteString("  }\n")
+	}
+
+	b.WriteString("}\n")
+	return b.String()
+}
+
+var addValidatorCmd = &cobra.Command{
+	Use:   "validator <name>",
+	Short: "Add a validator in validators/<name>.mycel",
+	Long: `Generate a custom validation rule.
+
+A validator is referenced from a type field or a flow's validate block. It is a
+regular expression, a CEL expression, or a WASM module for anything those two
+cannot express.
+
+Examples:
+  mycel add validator nz_phone --type regex --pattern '^\+64[0-9]{8,9}$'
+  mycel add validator adult --type cel --expr "input.age >= 18"
+  mycel add validator tax_id --type wasm --wasm ./validators/tax_id.wasm`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAddValidator,
+}
+
+func runAddValidator(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := ensureNameIsFree(name, "validator"); err != nil {
+		return err
+	}
+
+	blk := schema.ValidatorSchema()
+	vType := addValidatorType
+	if vType == "" {
+		vType = "regex"
+	}
+	if err := validateAgainstSchema(blk, "type", vType); err != nil {
+		return err
+	}
+
+	// Each type has one attribute it cannot work without, and the parser
+	// rejects an empty one by name. Generating a TODO there would produce a
+	// file that fails to parse — the one thing a skeleton must not do — so the
+	// flag is required, and the message says which.
+	carrier := map[string]struct {
+		flag  string
+		value string
+	}{
+		"regex": {"--pattern", addPattern},
+		"cel":   {"--expr", addExpr},
+		"wasm":  {"--wasm", addWASM},
+	}[vType]
+	if carrier.value == "" {
+		return fmt.Errorf("a %s validator needs its rule: pass %s", vType, carrier.flag)
+	}
+
+	return writeDeclaration(filepath.Join("validators", name+".mycel"),
+		renderValidator(name, vType, carrier.value, blk))
+}
+
+func renderValidator(name, vType, carrier string, blk schema.Block) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "// %s\n", blk.Doc)
+	fmt.Fprintf(&b, "validator %q {\n", name)
+	fmt.Fprintf(&b, "  type = %q\n", vType)
+
+	attr := map[string]string{"regex": "pattern", "cel": "expr", "wasm": "wasm"}[vType]
+	fmt.Fprintf(&b, "  %s = %q // %s\n", attr, carrier, docFor(blk, attr))
+
+	if vType == "wasm" {
+		fmt.Fprintf(&b, "  // entrypoint = \"validate\" // %s\n", docFor(blk, "entrypoint"))
+	}
+
+	fmt.Fprintf(&b, "\n  message = \"\" // %s\n", docFor(blk, "message"))
+	b.WriteString("}\n")
+
+	return b.String()
+}
+
+var addTransformCmd = &cobra.Command{
+	Use:   "transform <name>",
+	Short: "Add a named transform in transforms/<name>.mycel",
+	Long: `Generate a reusable transform.
+
+Every attribute is an output field and a CEL expression producing it. Naming it
+here lets several flows share one shaping rule via use = "transform.<name>".
+
+Examples:
+  mycel add transform normalize_user --fields id,email,created_at
+  mycel add transform order_summary`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAddTransform,
+}
+
+func runAddTransform(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	if err := ensureNameIsFree(name, "transform"); err != nil {
+		return err
+	}
+
+	return writeDeclaration(filepath.Join("transforms", name+".mycel"),
+		renderTransform(name, splitList(addTransformFields), schema.TransformSchema()))
+}
+
+func renderTransform(name string, fields []string, blk schema.Block) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "// %s\n", blk.Doc)
+	fmt.Fprintf(&b, "// Each attribute is an output field; the value is CEL over `input`.\n")
+	fmt.Fprintf(&b, "transform %q {\n", name)
+
+	if len(fields) == 0 {
+		b.WriteString("  // TODO — e.g. email = \"lower(input.email)\"\n")
+	}
+	for _, f := range fields {
+		fmt.Fprintf(&b, "  %s = %q\n", f, "input."+f)
+	}
+
+	// The enrich block is worth naming here: it is the reason to make a
+	// transform reusable rather than writing the mappings inline.
+	b.WriteString("\n  // Fetch data from another connector before mapping, readable as enriched.<name>:\n")
+	b.WriteString("  // enrich \"pricing\" {\n")
+	b.WriteString("  //   connector = \"pricing_api\"\n")
+	b.WriteString("  //   params { product_id = \"input.id\" }\n")
+	b.WriteString("  // }\n")
+	b.WriteString("}\n")
+
+	return b.String()
+}
+
+// --- shared helpers ---
+
+// childOf returns a named child block, or the zero Block when absent.
+func childOf(blk schema.Block, typ string) schema.Block {
+	for _, c := range blk.Children {
+		if c.Type == typ {
+			return c
+		}
+	}
+	return schema.Block{}
+}
+
+// docFor returns an attribute's documentation from the schema, so generated
+// comments say what the schema says and cannot contradict it.
+func docFor(blk schema.Block, attr string) string {
+	for _, a := range blk.Attrs {
+		if a.Name == attr {
+			return a.Doc
+		}
+	}
+	return ""
+}
+
+// attrHints renders named attributes as a one-line hint, skipping any the
+// schema does not declare.
+func attrHints(blk schema.Block, names ...string) string {
+	var out []string
+	for _, n := range names {
+		if doc := docFor(blk, n); doc != "" {
+			out = append(out, n)
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+func splitList(spec string) []string {
+	var out []string
+	for _, s := range strings.Split(spec, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	addSagaCmd.Flags().StringVar(&addSagaFrom, "from", "", "Connector that starts the saga")
+	addSagaCmd.Flags().StringVar(&addSagaSteps, "steps", "", "Comma-separated step names, in order")
+
+	addStateMachineCmd.Flags().StringVar(&addStates, "states", "", "Comma-separated states, in lifecycle order")
+	addStateMachineCmd.Flags().StringVar(&addInitialState, "initial", "", "Starting state (default: the first)")
+
+	addValidatorCmd.Flags().StringVar(&addValidatorType, "type", "", "regex, cel or wasm (default regex)")
+	addValidatorCmd.Flags().StringVar(&addPattern, "pattern", "", "Regular expression (type = regex)")
+	addValidatorCmd.Flags().StringVar(&addExpr, "expr", "", "CEL expression (type = cel)")
+	addValidatorCmd.Flags().StringVar(&addWASM, "wasm", "", "Path to the .wasm module (type = wasm)")
+
+	addTransformCmd.Flags().StringVar(&addTransformFields, "fields", "", "Comma-separated output field names")
+
+	addCmd.AddCommand(addSagaCmd, addStateMachineCmd, addValidatorCmd, addTransformCmd)
+}

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -606,6 +606,35 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		fmt.Printf("    - %s (%d fields)\n", t.Name, len(t.Fields))
 	}
 
+	// The rest, listed only when present. A validate that acknowledges the
+	// connectors and flows but says nothing about the saga just added reads as
+	// though the file was not picked up.
+	for _, s := range config.Sagas {
+		if s == nil {
+			continue
+		}
+		trigger := "no from block — it will not run"
+		if s.From != nil {
+			trigger = s.From.Connector
+		}
+		fmt.Printf("  Saga: %s (%d steps, from %s)\n", s.Name, len(s.Steps), trigger)
+	}
+	for _, m := range config.StateMachines {
+		if m != nil {
+			fmt.Printf("  State machine: %s (%d states, initial %s)\n", m.Name, len(m.States), m.Initial)
+		}
+	}
+	for _, v := range config.Validators {
+		if v != nil {
+			fmt.Printf("  Validator: %s (%s)\n", v.Name, v.Type)
+		}
+	}
+	for _, tr := range config.Transforms {
+		if tr != nil {
+			fmt.Printf("  Transform: %s (%d mappings)\n", tr.Name, len(tr.Mappings))
+		}
+	}
+
 	return nil
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -142,7 +142,7 @@ clash.
 
 ### `mycel add`
 
-Add a connector or flow to an existing project, each in its own file.
+Add a declaration to an existing project, each in its own file.
 
 ```bash
 mycel add connector orders_db --type database --driver postgres
@@ -150,6 +150,11 @@ mycel add connector rabbit --type mq --driver rabbitmq
 mycel add flow order_created --from rabbit --operation "orders.created" --to orders_db --target orders
 mycel add type user --fields "id:number,email:string:email"
 mycel add aspect audit_log --on "create_*" --when after --action-connector audit_db
+
+mycel add saga place_order --from rabbit --steps reserve_stock,charge_card,ship
+mycel add state-machine order --states pending,paid,shipped,delivered
+mycel add validator adult --type cel --expr "input.age >= 18"
+mycel add transform normalize_user --fields id,email,created_at
 
 mycel add connector --list       # available types
 ```
@@ -168,12 +173,31 @@ mycel add connector --list       # available types
 | `--action-connector` | `aspect` | Connector the action calls |
 | `--action-flow` | `aspect` | Flow the action invokes |
 | `--fields` | `type` | Fields as `name:type[:format]`, comma-separated |
+| `--from` | `saga` | Connector that triggers the saga — required |
+| `--steps` | `saga` | Step names in order, comma-separated |
+| `--states` | `state-machine` | States in lifecycle order, comma-separated |
+| `--initial` | `state-machine` | Starting state (default: the first) |
+| `--type` | `validator` | `regex`, `cel` or `wasm` (default `regex`) |
+| `--pattern` / `--expr` / `--wasm` | `validator` | The rule itself — one is required, matching `--type` |
+| `--fields` | `transform` | Output field names, comma-separated |
 
-Files land in `connectors/<name>.mycel`, `flows/<name>.mycel` and
-`aspects/<name>.mycel` under
-`--config`. Mycel merges every `.mycel` file regardless of location, so this is
-a readability default, not a requirement — see
+Files land in the directory named after the kind — `connectors/<name>.mycel`,
+`flows/<name>.mycel`, `sagas/<name>.mycel`, `state_machines/<name>.mycel` and so
+on — under `--config`. Mycel merges every `.mycel` file regardless of location,
+so this is a readability default, not a requirement — see
 [Project Structure](../getting-started/project-structure.md).
+
+### What `add` refuses to generate
+
+Some blocks parse but cannot work, and the generator will not write one:
+
+| Refused | Why |
+|---|---|
+| An aspect with no action | Parses, then fails to register at startup |
+| A validator with no `--pattern`, `--expr` or `--wasm` | The parser rejects an empty rule by name |
+| A saga with no `--from` | Nothing triggers it; registration skips it and it never runs |
+
+The alternative is a file that loads, validates, and quietly does nothing.
 
 The connector skeleton is generated from that connector's **own schema**, so
 required attributes are the ones the runtime actually requires and cannot drift

--- a/internal/parser/body_attributes.go
+++ b/internal/parser/body_attributes.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// bodyAttributes reads a body's attributes while tolerating blocks alongside
+// them.
+//
+// hcl.Body.JustAttributes is all-or-nothing on native syntax: one block
+// anywhere in the body and it returns "Blocks are not allowed here", even for a
+// body already narrowed by PartialContent. Blocks a caller has deliberately
+// consumed still count, so a block type the parser supports becomes impossible
+// to write.
+//
+// Falls back to JustAttributes for bodies that are not native syntax — JSON
+// configuration, and the synthetic bodies used in tests — where the behaviour
+// is the documented one and there is nothing to work around.
+func bodyAttributes(body hcl.Body) (hcl.Attributes, error) {
+	if syn, ok := body.(*hclsyntax.Body); ok {
+		attrs := make(hcl.Attributes, len(syn.Attributes))
+		for name, attr := range syn.Attributes {
+			attrs[name] = attr.AsHCLAttribute()
+		}
+		return attrs, nil
+	}
+
+	attrs, diags := body.JustAttributes()
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("%s", diags.Error())
+	}
+	return attrs, nil
+}

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -1747,10 +1747,16 @@ func parseNamedTransformBlock(block *hcl.Block, ctx *hcl.EvalContext) (*transfor
 		}
 	}
 
-	// Parse remaining attributes as transform mappings
-	attrs, diags := remain.JustAttributes()
-	if diags.HasErrors() {
-		return nil, fmt.Errorf("transform block attributes error: %s", diags.Error())
+	// Parse remaining attributes as transform mappings.
+	//
+	// Not remain.JustAttributes(): on an hclsyntax body that rejects the whole
+	// document the moment it contains any block, whatever PartialContent
+	// already consumed. That made the enrich blocks parsed just above
+	// unreachable — the runtime reads them (flow_registry: named transform
+	// enrichments) and the docs show them, but no such file ever parsed.
+	attrs, err := bodyAttributes(remain)
+	if err != nil {
+		return nil, fmt.Errorf("transform block attributes error: %w", err)
 	}
 
 	for name, attr := range attrs {

--- a/internal/parser/schema_parity_test.go
+++ b/internal/parser/schema_parity_test.go
@@ -1,0 +1,150 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/v2/pkg/schema"
+)
+
+// The schema exists so that tooling can generate configuration: completions,
+// `mycel add`, exported documentation. That only works if everything the schema
+// describes is something the parser accepts. When the two drift, the generator
+// produces files that do not parse — and the drift is invisible until someone
+// runs the generated file.
+//
+// This test closes the loop mechanically: it renders a document exercising
+// every attribute and every nested block a schema declares, then feeds it to
+// the real parser. An attribute the parser does not know is an "Unsupported
+// argument" diagnostic, and the test fails naming it.
+//
+// It is the reverse of the drift that bit on_drop, where the runtime knew about
+// a value the schema did not. Both directions now have a test.
+func TestSchemaParity_SagaIsParseable(t *testing.T) {
+	assertSchemaParses(t, schema.SagaSchema(), "example")
+}
+
+// assertSchemaParses renders the block from its schema and parses it.
+func assertSchemaParses(t *testing.T, blk schema.Block, name string) {
+	t.Helper()
+
+	doc := renderBlockFromSchema(blk, []string{name}, 0)
+	t.Logf("rendered from schema:\n%s", doc)
+
+	// Not mustParse: the failure is the point, and it should name the block.
+	cfg, err := tryParse(t, doc)
+	if err != nil {
+		t.Fatalf("the %s schema describes something the parser rejects: %v\n\n%s",
+			blk.Type, err, doc)
+	}
+	if cfg == nil {
+		t.Fatalf("%s parsed to nothing", blk.Type)
+	}
+}
+
+// renderBlockFromSchema turns a schema block into HCL that exercises all of it.
+//
+// Every attribute gets a value of the right type, and every child block is
+// nested one level deep. Depth is capped because schemas are recursive — a
+// transform can hold a transform — and the goal is coverage of each declared
+// name, not of every path through them.
+func renderBlockFromSchema(blk schema.Block, labels []string, depth int) string {
+	var b strings.Builder
+
+	header := blk.Type
+	for _, l := range labels {
+		header += fmt.Sprintf(" %q", l)
+	}
+	b.WriteString(header + " {\n")
+
+	indent := strings.Repeat("  ", depth+1)
+
+	// Sort for a stable rendering, so a failure reads the same way twice.
+	attrs := append([]schema.Attr(nil), blk.Attrs...)
+	sort.Slice(attrs, func(i, j int) bool { return attrs[i].Name < attrs[j].Name })
+
+	for _, a := range attrs {
+		if skipAttrForParity(blk.Type, a.Name) {
+			continue
+		}
+		fmt.Fprintf(&b, "%s%s = %s\n", indent, a.Name, sampleValue(a))
+	}
+
+	if depth < 3 {
+		for _, child := range blk.Children {
+			childLabels := make([]string, child.Labels)
+			for i := range childLabels {
+				childLabels[i] = fmt.Sprintf("%s_%d", child.Type, i)
+			}
+			nested := renderBlockFromSchema(child, childLabels, depth+1)
+			for _, line := range strings.Split(strings.TrimRight(nested, "\n"), "\n") {
+				b.WriteString(indent + line + "\n")
+			}
+		}
+	}
+
+	b.WriteString(strings.Repeat("  ", depth) + "}\n")
+	return b.String()
+}
+
+// sampleValue produces a literal of the attribute's declared type. A declared
+// enum uses its first value, so a schema that lists a value the parser rejects
+// fails here rather than in production.
+func sampleValue(a schema.Attr) string {
+	if len(a.Values) > 0 {
+		return fmt.Sprintf("%q", a.Values[0])
+	}
+	switch a.Type {
+	case schema.TypeNumber:
+		return "1"
+	case schema.TypeBool:
+		return "true"
+	case schema.TypeList:
+		return `["a"]`
+	case schema.TypeMap:
+		return `{ key = "value" }`
+	case schema.TypeDuration:
+		return `"5s"`
+	default:
+		return `"value"`
+	}
+}
+
+// skipAttrForParity excludes attributes that are valid on their own but
+// contradict another attribute rendered alongside them. Each exclusion is a
+// real mutual exclusion in the language, not a parser shortcoming.
+func skipAttrForParity(blockType, attr string) bool {
+	// `use` points at a named block declared elsewhere; rendering it next to
+	// inline attributes asks the parser to resolve a reference this document
+	// does not contain.
+	return attr == "use"
+}
+
+// tryParse parses without failing the test, so the caller can report the
+// diagnostic against the document that produced it.
+func tryParse(t *testing.T, hcl string) (cfg *Configuration, err error) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	return parseString(t, hcl)
+}
+
+// parseString parses HCL text through the real parser, returning the error
+// instead of failing.
+func parseString(t *testing.T, hcl string) (*Configuration, error) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.mycel")
+	if err := os.WriteFile(path, []byte(hcl), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return NewHCLParser().ParseFile(context.Background(), path)
+}

--- a/internal/parser/schema_parity_test.go
+++ b/internal/parser/schema_parity_test.go
@@ -25,8 +25,17 @@ import (
 //
 // It is the reverse of the drift that bit on_drop, where the runtime knew about
 // a value the schema did not. Both directions now have a test.
-func TestSchemaParity_SagaIsParseable(t *testing.T) {
-	assertSchemaParses(t, schema.SagaSchema(), "example")
+func TestSchemaParity(t *testing.T) {
+	for _, blk := range []schema.Block{
+		schema.SagaSchema(),
+		schema.StateMachineSchema(),
+		schema.ValidatorSchema(),
+		schema.TransformSchema(),
+	} {
+		t.Run(blk.Type, func(t *testing.T) {
+			assertSchemaParses(t, blk, "example")
+		})
+	}
 }
 
 // assertSchemaParses renders the block from its schema and parses it.

--- a/internal/parser/schema_parity_test.go
+++ b/internal/parser/schema_parity_test.go
@@ -26,12 +26,10 @@ import (
 // It is the reverse of the drift that bit on_drop, where the runtime knew about
 // a value the schema did not. Both directions now have a test.
 func TestSchemaParity(t *testing.T) {
-	for _, blk := range []schema.Block{
-		schema.SagaSchema(),
-		schema.StateMachineSchema(),
-		schema.ValidatorSchema(),
-		schema.TransformSchema(),
-	} {
+	// Every root block, not a chosen few: the schema is the single source of
+	// truth for the whole language, and a block left out of this loop is one
+	// where it can quietly stop being true.
+	for _, blk := range schema.BuiltinRootSchemas() {
 		t.Run(blk.Type, func(t *testing.T) {
 			assertSchemaParses(t, blk, "example")
 		})
@@ -42,10 +40,14 @@ func TestSchemaParity(t *testing.T) {
 func assertSchemaParses(t *testing.T, blk schema.Block, name string) {
 	t.Helper()
 
-	doc := renderBlockFromSchema(blk, []string{name}, 0)
-	t.Logf("rendered from schema:\n%s", doc)
+	labels := make([]string, blk.Labels)
+	for i := range labels {
+		labels[i] = name
+	}
+	doc := renderBlockFromSchema(blk, labels, 0, true)
 
-	// Not mustParse: the failure is the point, and it should name the block.
+	// Not mustParse: the failure is the point, and it should name the block
+	// and show what was rendered.
 	cfg, err := tryParse(t, doc)
 	if err != nil {
 		t.Fatalf("the %s schema describes something the parser rejects: %v\n\n%s",
@@ -62,14 +64,10 @@ func assertSchemaParses(t *testing.T, blk schema.Block, name string) {
 // nested one level deep. Depth is capped because schemas are recursive — a
 // transform can hold a transform — and the goal is coverage of each declared
 // name, not of every path through them.
-func renderBlockFromSchema(blk schema.Block, labels []string, depth int) string {
+func renderBlockFromSchema(blk schema.Block, labels []string, depth int, withChildren bool) string {
 	var b strings.Builder
 
-	header := blk.Type
-	for _, l := range labels {
-		header += fmt.Sprintf(" %q", l)
-	}
-	b.WriteString(header + " {\n")
+	b.WriteString(blockHeader(blk, labels) + " {\n")
 
 	indent := strings.Repeat("  ", depth+1)
 
@@ -81,24 +79,66 @@ func renderBlockFromSchema(blk schema.Block, labels []string, depth int) string 
 		if skipAttrForParity(blk.Type, a.Name) {
 			continue
 		}
+		// In the children variant, an attribute a child block excludes is left
+		// out; the attribute-only variant covers it.
+		if withChildren && excludedByAChild(blk, a.Name) {
+			continue
+		}
 		fmt.Fprintf(&b, "%s%s = %s\n", indent, a.Name, sampleValue(a))
 	}
 
-	if depth < 3 {
+	// An Open block's content is named by the author, so the schema lists none
+	// — but some require at least one, like a dedupe fingerprint. Rendering a
+	// sample keeps those blocks representable.
+	if blk.Open && len(blk.Attrs) == 0 {
+		fmt.Fprintf(&b, "%sexample = %q\n", indent, "input.id")
+	}
+
+	if withChildren && depth < 5 {
 		for _, child := range blk.Children {
 			childLabels := make([]string, child.Labels)
 			for i := range childLabels {
 				childLabels[i] = fmt.Sprintf("%s_%d", child.Type, i)
 			}
-			nested := renderBlockFromSchema(child, childLabels, depth+1)
+			nested := renderBlockFromSchema(child, childLabels, depth+1, true)
 			for _, line := range strings.Split(strings.TrimRight(nested, "\n"), "\n") {
 				b.WriteString(indent + line + "\n")
+			}
+
+			// A child whose presence excludes some of its parent's attributes
+			// leaves those attributes untested, so a second copy of the same
+			// block carries them, with no children of its own. A flow may
+			// declare several destinations, so two `to` blocks is valid config
+			// rather than a trick: one writes via a transaction, the other
+			// via query.
+			if childExcludesAttrs(child) {
+				alt := renderBlockFromSchema(child, childLabels, depth+1, false)
+				for _, line := range strings.Split(strings.TrimRight(alt, "\n"), "\n") {
+					b.WriteString(indent + line + "\n")
+				}
 			}
 		}
 	}
 
 	b.WriteString(strings.Repeat("  ", depth) + "}\n")
 	return b.String()
+}
+
+// blockHeader renders the block's opening line.
+//
+// Most blocks are `type "label"`, but a few have a shape of their own — an
+// each block reads `each "<var>" in "<listExpr>"`, three labels where the
+// middle one is the keyword `in`. The schema records the count; the form is
+// documented in its Doc, so it is spelled out here.
+func blockHeader(blk schema.Block, labels []string) string {
+	if blk.Type == "each" && blk.Labels == 3 {
+		return `each "item" in "input.items"`
+	}
+	header := blk.Type
+	for _, l := range labels {
+		header += fmt.Sprintf(" %q", l)
+	}
+	return header
 }
 
 // sampleValue produces a literal of the attribute's declared type. A declared
@@ -131,7 +171,46 @@ func skipAttrForParity(blockType, attr string) bool {
 	// `use` points at a named block declared elsewhere; rendering it next to
 	// inline attributes asks the parser to resolve a reference this document
 	// does not contain.
-	return attr == "use"
+	if attr == "use" {
+		return true
+	}
+
+	// An action calls a connector or a flow, never both — the parser says so
+	// by name. Rendering every attribute at once would ask for both, so one is
+	// dropped and the other still gets exercised.
+	if blockType == "action" && attr == "flow" {
+		return true
+	}
+
+	return false
+}
+
+// excludedByAChild reports whether one of the block's children forbids this
+// attribute. The exclusions are the language's, and each is stated in the
+// child's own documentation.
+func excludedByAChild(blk schema.Block, attr string) bool {
+	for _, c := range blk.Children {
+		if c.Type != "transaction" {
+			continue
+		}
+		// A transaction is the write; there is nothing left for these to say.
+		switch attr {
+		case "query", "target", "operation", "envelope":
+			return true
+		}
+	}
+	return false
+}
+
+// childExcludesAttrs reports whether rendering this block will have dropped
+// attributes its own children forbid.
+func childExcludesAttrs(blk schema.Block) bool {
+	for _, a := range blk.Attrs {
+		if excludedByAChild(blk, a.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // tryParse parses without failing the test, so the caller can report the

--- a/internal/parser/transform_enrich_test.go
+++ b/internal/parser/transform_enrich_test.go
@@ -1,0 +1,50 @@
+package parser
+
+import "testing"
+
+// A named transform may hold enrich blocks: the runtime reads them when a flow
+// references the transform, and the documentation shows one. The parser
+// accepted the block and then rejected the document, so no such file ever
+// parsed — JustAttributes refuses a body containing any block, including the
+// ones PartialContent had already taken.
+func TestNamedTransform_AcceptsEnrichAlongsideMappings(t *testing.T) {
+	cfg := mustParse(t, `
+transform "with_pricing" {
+  enrich "pricing" {
+    connector = "pricing_service"
+    operation = "getPrice"
+    params {
+      product_id = "input.id"
+    }
+  }
+
+  id    = "input.id"
+  price = "enriched.pricing.price"
+}
+`)
+
+	if len(cfg.Transforms) != 1 {
+		t.Fatalf("expected 1 named transform, got %d", len(cfg.Transforms))
+	}
+	tr := cfg.Transforms[0]
+
+	if len(tr.Enrichments) != 1 {
+		t.Fatalf("expected the enrich block to be kept, got %d", len(tr.Enrichments))
+	}
+	e := tr.Enrichments[0]
+	if e.Name != "pricing" || e.Connector != "pricing_service" || e.Operation != "getPrice" {
+		t.Errorf("enrichment lost its wiring: %+v", e)
+	}
+	if e.Params["product_id"] != "input.id" {
+		t.Errorf("enrich params: want product_id=input.id, got %v", e.Params)
+	}
+
+	// The mappings beside the block must survive it, which is the half that
+	// JustAttributes was there to do.
+	if tr.Mappings["price"] != "enriched.pricing.price" {
+		t.Errorf("mappings lost: %v", tr.Mappings)
+	}
+	if len(tr.Mappings) != 2 {
+		t.Errorf("expected 2 mappings, got %d: %v", len(tr.Mappings), tr.Mappings)
+	}
+}

--- a/internal/runtime/saga_handler.go
+++ b/internal/runtime/saga_handler.go
@@ -20,7 +20,12 @@ func (r *Runtime) registerSagas() error {
 	sagaExecutor := saga.NewExecutor(r.connectors)
 
 	for _, cfg := range r.config.Sagas {
+		// A saga is triggered by its from block and by nothing else — no flow
+		// invokes one. Without it there is nothing to register, and the saga
+		// loads, validates, and never runs. Saying so beats leaving someone to
+		// wonder why their compensation never fired.
 		if cfg.From == nil {
+			fmt.Printf("      %s — not registered: no from block, so nothing triggers it\n", cfg.Name)
 			continue
 		}
 

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -19,7 +19,6 @@ func BuiltinRootSchemas() []Block {
 		SecuritySchema(),
 		MocksSchema(),
 		CacheDefSchema(),
-		EnvironmentSchema(),
 	}
 }
 
@@ -498,11 +497,11 @@ func AspectSchema() Block {
 		Doc:    "Cross-cutting concern applied via flow name pattern matching (AOP)",
 		Labels: 1,
 		Attrs: []Attr{
-			{Name: "on", Doc: "Flow name patterns to match (glob)", Type: TypeList},
+			{Name: "on", Doc: "Flow name patterns to match (glob)", Type: TypeList, Required: true},
 			// Kept in step with internal/aspect.When, which is the authority.
 			// on_drop was added to the runtime and never reached here, so
 			// completions and generated skeletons did not offer it.
-			{Name: "when", Doc: "When to execute", Type: TypeString, Values: []string{"before", "after", "around", "on_error", "on_drop"}},
+			{Name: "when", Doc: "When to execute", Type: TypeString, Required: true, Values: []string{"before", "after", "around", "on_error", "on_drop"}},
 			{Name: "if", Doc: "CEL condition for conditional execution", Type: TypeString},
 			{Name: "priority", Doc: "Execution priority (lower = first)", Type: TypeNumber},
 		},
@@ -519,9 +518,22 @@ func AspectSchema() Block {
 				{Name: "keys", Doc: "Specific keys to invalidate", Type: TypeList},
 				{Name: "patterns", Doc: "Key patterns to invalidate", Type: TypeList},
 			}},
-			{Type: "rate_limit", Doc: "Rate limiting", Open: true},
-			{Type: "circuit_breaker", Doc: "Circuit breaker", Open: true},
-			{Type: "response", Doc: "Response modification (headers, fields)", Open: true},
+			{Type: "rate_limit", Doc: "Rate limiting", Attrs: []Attr{
+				{Name: "key", Doc: "CEL expression the limit is counted per (e.g. the caller's IP)", Type: TypeString, Required: true},
+				{Name: "requests_per_second", Doc: "Sustained rate allowed", Type: TypeNumber, Required: true},
+				{Name: "burst", Doc: "How far above the rate a short spike may go", Type: TypeNumber},
+			}},
+			{Type: "circuit_breaker", Doc: "Circuit breaker", Attrs: []Attr{
+				{Name: "name", Doc: "Breaker name, shared by every flow naming it", Type: TypeString},
+				{Name: "failure_threshold", Doc: "Consecutive failures that open the circuit", Type: TypeNumber, Required: true},
+				{Name: "success_threshold", Doc: "Successes needed to close it again", Type: TypeNumber},
+				{Name: "timeout", Doc: "How long the circuit stays open before a trial call", Type: TypeDuration, Required: true},
+			}},
+			{Type: "response", Doc: "Response modification: headers, plus any field as a CEL expression",
+				Open: true, // every other attribute is an output field
+				Attrs: []Attr{
+					{Name: "headers", Doc: "Map of header name -> value", Type: TypeMap},
+				}},
 		},
 	}
 }
@@ -606,7 +618,15 @@ func ServiceSchema() Block {
 			{Name: "admin_port", Doc: "Admin server port (health, metrics, debug)", Type: TypeNumber},
 		},
 		Children: []Block{
-			{Type: "rate_limit", Doc: "Global rate limiting", Open: true},
+			{Type: "rate_limit", Doc: "Global rate limiting", Attrs: []Attr{
+				{Name: "enabled", Doc: "Whether the limit applies", Type: TypeBool},
+				{Name: "requests_per_second", Doc: "Sustained rate allowed", Type: TypeNumber},
+				{Name: "burst", Doc: "How far above the rate a short spike may go", Type: TypeNumber},
+				{Name: "key_extractor", Doc: "What the limit is counted per (e.g. the caller's IP)", Type: TypeString},
+				{Name: "exclude_paths", Doc: "Paths the limit does not apply to", Type: TypeList},
+				{Name: "enable_headers", Doc: "Send the standard rate-limit response headers", Type: TypeBool},
+				{Name: "storage", Doc: "Connector holding the counters; shared across instances", Type: TypeString, Ref: RefConnector},
+			}},
 			{Type: "workflow", Doc: "Workflow engine configuration", Attrs: []Attr{
 				{Name: "storage", Doc: "Workflow persistence connector", Type: TypeString, Ref: RefConnector},
 			}},
@@ -745,12 +765,20 @@ func stateMachineActionAttrs() []Attr {
 	}
 }
 
+// FunctionsSchema describes the functions block, which registers the exports of
+// a WASM module as CEL functions.
+//
+// Not Open: the parser reads this body with Content, so the two attributes
+// below are the only ones it accepts, and it requires both.
 func FunctionsSchema() Block {
 	return Block{
 		Type:   "functions",
-		Doc:    "Custom CEL functions",
+		Doc:    "Custom CEL functions from a WASM module",
 		Labels: 1,
-		Open:   true,
+		Attrs: []Attr{
+			{Name: "wasm", Doc: "Path to the .wasm module", Type: TypeString, Required: true},
+			{Name: "exports", Doc: "Exported function names to register as CEL functions", Type: TypeList, Required: true},
+		},
 	}
 }
 
@@ -766,19 +794,83 @@ func PluginSchema() Block {
 	}
 }
 
+// AuthSchema describes the auth block. Transcribed from authSchema in
+// internal/parser/auth.go, which reads this body with Content — so it is not
+// Open, and an attribute not listed here is rejected.
+//
+// The nested blocks are named but their contents are not described yet; auth is
+// by far the largest block in the language. Naming them is still worth more
+// than the Open it replaces, which claimed every attribute was valid.
 func AuthSchema() Block {
 	return Block{
 		Type: "auth",
 		Doc:  "Authentication configuration",
-		Open: true,
+		Attrs: []Attr{
+			{Name: "preset", Doc: "Baseline to start from", Type: TypeString, Values: []string{"strict", "standard", "relaxed", "development"}},
+			{Name: "secret", Doc: "Signing secret for issued tokens", Type: TypeString},
+			{Name: "storage", Doc: "Connector used to store users and sessions", Type: TypeString, Ref: RefConnector},
+		},
+		Children: []Block{
+			{Type: "storage", Doc: "Where users and sessions are kept", Attrs: []Attr{
+				{Name: "driver", Doc: "Storage backend", Type: TypeString, Required: true, Values: []string{"memory", "redis", "database"}},
+				{Name: "address", Doc: "Server address (redis)", Type: TypeString},
+				{Name: "password", Doc: "Server password (redis)", Type: TypeString},
+				{Name: "db", Doc: "Database index (redis)", Type: TypeNumber},
+				{Name: "connector", Doc: "Connector to store into (database)", Type: TypeString, Ref: RefConnector},
+				{Name: "table", Doc: "Table name (database)", Type: TypeString},
+			}},
+			{Type: "users", Doc: "Where user records live"},
+			{Type: "jwt", Doc: "Token issuing and validation"},
+			{Type: "password", Doc: "Hashing and password policy"},
+			{Type: "mfa", Doc: "Multi-factor authentication; present means enabled"},
+			{Type: "security", Doc: "Lockout, rate limiting and related defences"},
+			{Type: "sessions", Doc: "Session lifetime and limits"},
+			{Type: "social", Doc: "Social login providers"},
+			{Type: "sso", Doc: "Single sign-on"},
+			{Type: "provider", Doc: "Validate a credential against an external HTTP endpoint", Labels: 1},
+			{Type: "account_linking", Doc: "Joining identities that belong to one person"},
+			{Type: "endpoints", Doc: "Paths the auth routes are served on"},
+			{Type: "hooks", Doc: "Flows invoked around auth events"},
+			{Type: "audit", Doc: "What to record", Attrs: []Attr{
+				{Name: "connector", Doc: "Where audit records are written", Type: TypeString, Required: true, Ref: RefConnector},
+				{Name: "enabled", Doc: "Whether auditing runs", Type: TypeBool},
+				{Name: "table", Doc: "Table or collection to write into", Type: TypeString},
+				{Name: "events", Doc: "Events to record", Type: TypeList},
+				{Name: "include", Doc: "Extra fields to include on each record", Type: TypeList},
+				{Name: "retention", Doc: "How long records are kept", Type: TypeDuration},
+				{Name: "stream_to", Doc: "Connector to stream records to as well", Type: TypeString, Ref: RefConnector},
+			}},
+		},
 	}
 }
 
+// SecuritySchema describes the security block. Transcribed from
+// internal/parser/security.go; the parser reads it with Content, so it is not
+// Open.
 func SecuritySchema() Block {
 	return Block{
 		Type: "security",
-		Doc:  "Security and sanitization rules",
-		Open: true,
+		Doc:  "Input limits and sanitization rules",
+		Attrs: []Attr{
+			{Name: "max_input_length", Doc: "Largest accepted payload, in bytes", Type: TypeNumber},
+			{Name: "max_field_length", Doc: "Largest accepted single field, in bytes", Type: TypeNumber},
+			{Name: "max_field_depth", Doc: "How deeply nested a payload may be", Type: TypeNumber},
+			{Name: "allowed_control_chars", Doc: "Control characters to let through rather than strip", Type: TypeList},
+		},
+		Children: []Block{
+			{Type: "sanitizer", Doc: "A named sanitization rule", Labels: 1, Attrs: []Attr{
+				{Name: "source", Doc: "Built-in sanitizer to use", Type: TypeString},
+				{Name: "wasm", Doc: "Path to a .wasm module implementing it", Type: TypeString},
+				{Name: "entrypoint", Doc: "Exported function to call in the module", Type: TypeString},
+				{Name: "apply_to", Doc: "Which payloads it applies to", Type: TypeList},
+				{Name: "fields", Doc: "Specific fields it applies to", Type: TypeList},
+			}},
+			{Type: "flow", Doc: "Per-flow overrides of the limits above", Labels: 1, Attrs: []Attr{
+				{Name: "max_input_length", Doc: "Largest accepted payload for this flow, in bytes", Type: TypeNumber},
+				{Name: "max_field_length", Doc: "Largest accepted single field for this flow, in bytes", Type: TypeNumber},
+				{Name: "sanitizers", Doc: "Sanitizers to run for this flow", Type: TypeList},
+			}},
+		},
 	}
 }
 
@@ -803,12 +895,21 @@ func CacheDefSchema() Block {
 	}
 }
 
+// EnvironmentSchema is deliberately not in BuiltinRootSchemas: no `environment`
+// block exists. The parser accepts no such block type, so a document containing
+// one fails outright — but the schema advertised it, which is what feeds
+// completions and generated documentation.
+//
+// Per-environment configuration is done with connector profiles and env(),
+// selected by `--env`. Kept only so a caller referencing it keeps building;
+// there is nothing to describe.
+//
+// Deprecated: there is no environment block.
 func EnvironmentSchema() Block {
 	return Block{
 		Type:   "environment",
-		Doc:    "Environment-specific variables",
+		Doc:    "Not a block Mycel accepts — use connector profiles and env() with --env",
 		Labels: 1,
-		Open:   true,
 	}
 }
 

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -578,12 +578,21 @@ func FieldConstraints() []Attr {
 	}
 }
 
+// TransformSchema describes the named, reusable transform block.
+//
+// Open is not a placeholder here: every attribute is a CEL field mapping whose
+// name is chosen by the author, so there is no fixed set to declare. What was
+// missing is the enrich child block, which the parser accepts and the schema
+// did not mention.
 func TransformSchema() Block {
 	return Block{
 		Type:   "transform",
 		Doc:    "Reusable named transformation (CEL expressions)",
 		Labels: 1,
-		Open:   true, // attributes are CEL mappings
+		Open:   true, // attributes are CEL mappings: output_field = "<CEL>"
+		Children: []Block{
+			EnrichSchema(),
+		},
 	}
 }
 
@@ -605,12 +614,26 @@ func ServiceSchema() Block {
 	}
 }
 
+// ValidatorSchema describes the validator block. Transcribed from
+// internal/parser/validator.go, which is the authority.
+//
+// Which attribute is required depends on `type`, and the schema has no way to
+// say "required when type is regex" — so the three carriers are declared
+// optional and their pairing is documented. The parser rejects the wrong
+// combination by name, which is where that check belongs.
 func ValidatorSchema() Block {
 	return Block{
 		Type:   "validator",
 		Doc:    "Custom validation rule (regex, CEL, or WASM)",
 		Labels: 1,
-		Open:   true,
+		Attrs: []Attr{
+			{Name: "type", Doc: "How the rule is expressed", Type: TypeString, Required: true, Values: []string{"regex", "cel", "wasm"}},
+			{Name: "pattern", Doc: "Regular expression the value must match (type = regex)", Type: TypeString},
+			{Name: "expr", Doc: "CEL expression that must return true (type = cel)", Type: TypeString},
+			{Name: "wasm", Doc: "Path to the .wasm module (type = wasm)", Type: TypeString},
+			{Name: "entrypoint", Doc: "Exported function to call in the module", Type: TypeString, Default: "validate"},
+			{Name: "message", Doc: "Error message shown when validation fails", Type: TypeString},
+		},
 	}
 }
 
@@ -681,12 +704,44 @@ func sagaActionAttrs() []Attr {
 	}
 }
 
+// StateMachineSchema describes the state_machine block. Transcribed from
+// internal/parser/statemachine.go, which is the authority.
 func StateMachineSchema() Block {
 	return Block{
 		Type:   "state_machine",
 		Doc:    "Entity lifecycle with guards, actions, and final states",
 		Labels: 1,
-		Open:   true,
+		Attrs: []Attr{
+			{Name: "initial", Doc: "State an entity starts in", Type: TypeString, Required: true},
+		},
+		Children: []Block{
+			{Type: "state", Doc: "One state of the lifecycle", Labels: 1, Attrs: []Attr{
+				{Name: "final", Doc: "No transition may leave this state", Type: TypeBool},
+			}, Children: []Block{
+				{Type: "on", Doc: `Transition taken when this event arrives, written as: on "<event>" { }`, Labels: 1, Attrs: []Attr{
+					{Name: "transition_to", Doc: "State to move to", Type: TypeString, Required: true},
+					{Name: "guard", Doc: "CEL condition; the transition is refused when it does not hold", Type: TypeString},
+				}, Children: []Block{
+					{Type: "action", Doc: "Side effect to run on the transition", Attrs: stateMachineActionAttrs()},
+				}},
+			}},
+		},
+	}
+}
+
+// stateMachineActionAttrs is the action shape a transition can carry. It is a
+// subset of the saga action — no query, set or where — so it is written out
+// rather than shared, which would let one grow attributes the other rejects.
+func stateMachineActionAttrs() []Attr {
+	return []Attr{
+		{Name: "connector", Doc: "Connector to call", Type: TypeString, Ref: RefConnector},
+		{Name: "operation", Doc: "Operation to perform", Type: TypeString},
+		{Name: "target", Doc: "Table, queue, path or endpoint to act on", Type: TypeString},
+		{Name: "data", Doc: "Values to write, as CEL expressions", Type: TypeMap},
+		{Name: "body", Doc: "Request body, as CEL expressions", Type: TypeMap},
+		{Name: "params", Doc: "Named query parameters, as CEL expressions", Type: TypeMap},
+		{Name: "template", Doc: "Notification template name", Type: TypeString},
+		{Name: "to", Doc: "Notification recipient", Type: TypeString},
 	}
 }
 

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -614,12 +614,70 @@ func ValidatorSchema() Block {
 	}
 }
 
+// SagaSchema describes the saga block. Transcribed from internal/parser/saga.go,
+// which is the authority: every attribute and child here is one the parser
+// accepts, and nothing the parser rejects appears.
 func SagaSchema() Block {
 	return Block{
 		Type:   "saga",
 		Doc:    "Distributed transaction with automatic compensation",
 		Labels: 1,
-		Open:   true,
+		Attrs: []Attr{
+			{Name: "timeout", Doc: "Deadline for the saga as a whole", Type: TypeDuration},
+		},
+		Children: []Block{
+			{Type: "from", Doc: "What starts the saga", Attrs: []Attr{
+				{Name: "connector", Doc: "Connector the saga listens on", Type: TypeString, Required: true, Ref: RefConnector},
+				{Name: "operation", Doc: "Operation to trigger on", Type: TypeString},
+				{Name: "filter", Doc: "CEL condition; the saga runs only when it holds", Type: TypeString},
+			}},
+			SagaStepSchema(),
+			{Type: "on_complete", Doc: "Action to run once every step has succeeded", Attrs: sagaActionAttrs()},
+			{Type: "on_failure", Doc: "Action to run after compensation has unwound the saga", Attrs: sagaActionAttrs()},
+		},
+	}
+}
+
+// SagaStepSchema describes one step of a saga.
+//
+// A step must carry an action, a delay or an await — the parser rejects one
+// with none of the three — but no single one of them can be marked Required,
+// so the constraint lives in the docs and in what the generator emits.
+func SagaStepSchema() Block {
+	return Block{
+		Type:   "step",
+		Doc:    "One step of the saga, executed in declaration order",
+		Labels: 1,
+		Attrs: []Attr{
+			{Name: "timeout", Doc: "Deadline for this step", Type: TypeDuration},
+			// The executor tests for "skip" and compensates on anything else,
+			// so those are the two behaviours there are (internal/saga/executor.go).
+			{Name: "on_error", Doc: "What a failure does: compensate the saga, or skip the step and carry on", Type: TypeString, Values: []string{"compensate", "skip"}},
+			{Name: "delay", Doc: "Wait this long before continuing; a step with only a delay needs no action", Type: TypeDuration},
+			{Name: "await", Doc: "Pause until an external signal with this event name arrives", Type: TypeString},
+		},
+		Children: []Block{
+			{Type: "action", Doc: "The work this step performs", Attrs: sagaActionAttrs()},
+			{Type: "compensate", Doc: "How to undo this step when a later one fails", Attrs: sagaActionAttrs()},
+		},
+	}
+}
+
+// sagaActionAttrs is the shape shared by action, compensate, on_complete and
+// on_failure — the parser reads all four with the same function.
+func sagaActionAttrs() []Attr {
+	return []Attr{
+		{Name: "connector", Doc: "Connector to call", Type: TypeString, Ref: RefConnector},
+		{Name: "operation", Doc: "Operation to perform", Type: TypeString},
+		{Name: "target", Doc: "Table, queue, path or endpoint to act on", Type: TypeString},
+		{Name: "query", Doc: "Raw query, for database connectors", Type: TypeString},
+		{Name: "data", Doc: "Values to write, as CEL expressions", Type: TypeMap},
+		{Name: "body", Doc: "Request body, as CEL expressions", Type: TypeMap},
+		{Name: "set", Doc: "Columns to update, as CEL expressions", Type: TypeMap},
+		{Name: "where", Doc: "Row selection, as CEL expressions", Type: TypeMap},
+		{Name: "params", Doc: "Named query parameters, as CEL expressions", Type: TypeMap},
+		{Name: "template", Doc: "Notification template name", Type: TypeString},
+		{Name: "to", Doc: "Notification recipient", Type: TypeString},
 	}
 }
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestBuiltinRootSchemas(t *testing.T) {
 	schemas := BuiltinRootSchemas()
-	if len(schemas) < 16 {
-		t.Errorf("expected at least 16 root schemas, got %d", len(schemas))
+	if len(schemas) < 15 {
+		t.Errorf("expected at least 15 root schemas, got %d", len(schemas))
 	}
 
 	// Verify key block types exist
@@ -16,11 +16,20 @@ func TestBuiltinRootSchemas(t *testing.T) {
 
 	expected := []string{"connector", "flow", "type", "transform", "aspect", "service",
 		"validator", "saga", "state_machine", "functions", "plugin", "auth",
-		"security", "mocks", "cache", "environment"}
+		"security", "mocks", "cache"}
 	for _, e := range expected {
 		if !types[e] {
 			t.Errorf("missing root block type %q", e)
 		}
+	}
+
+	// "environment" used to be in the list above. There is no such block: the
+	// parser accepts no block of that type, so a document containing one fails
+	// to parse. Advertising it produced completions for something unwritable —
+	// per-environment configuration is connector profiles and env(), chosen
+	// with --env.
+	if types["environment"] {
+		t.Error("environment is not a block Mycel accepts; it must not be advertised as one")
 	}
 }
 


### PR DESCRIPTION
`saga`, `state_machine`, `validator` and `transform` were declared `Open: true` in the schema — "any attribute goes". That is why `mycel add` skipped them in 2.14.0: there was nothing to read. Completions inside them offered nothing either, and `mycel validate` could not check them.

Each is now transcribed from its parser, which stays the authority.

```bash
mycel add saga place_order --from rabbit --steps reserve_stock,charge_card,ship
mycel add state-machine order --states pending,paid,shipped
mycel add validator adult --type cel --expr "input.age >= 18"
mycel add transform normalize --fields id,email
```

`transform` keeps `Open` — its attributes are CEL mappings the author names, so there is no fixed set — but gains the `enrich` child block the parser accepts.

## Two tests, because the claim needs checking

If the schema describes everything, then what we generate from it has to be valid. That is only worth saying if something enforces it.

**Parity** renders a document exercising every attribute and every nested block a schema declares, then feeds it to the real parser. Confirmed it fails: adding an invented `retries` to `saga.step` produces

```
the saga schema describes something the parser rejects:
  Unsupported argument; An argument named "retries" is not expected here.
```

**Round-trip** writes each generator's output into a project and parses it with the same parser `mycel validate` uses. A skeleton that does not parse is worse than no skeleton, since running validate is the first thing anyone does with one.

## What they found

Parity, on its first run: **a named `transform` holding an `enrich` block never parsed.** The runtime reads those enrichments when a flow references the transform, and the documentation shows an example — but `hcl.Body.JustAttributes` refuses a body containing any block, including the `enrich` blocks `PartialContent` had just consumed. Documented, implemented, unreachable.

Round-trip found three generated files that load and then fail. Each is now refused with the flag that fixes it:

| Refused | Why |
|---|---|
| A validator with no `--pattern` / `--expr` / `--wasm` | The parser rejects an empty rule by name |
| A saga with no step, or a step with no action | The parser rejects both |
| A saga with no `--from` | Nothing triggers it |

That last one was the worst of the three: no flow invokes a saga, so without a `from` block it loaded, validated and never ran — and registration skipped it in **silence**. It now names the saga at startup.

## Also

`mycel validate` reports what it found beyond connectors, flows and types. Adding a saga and getting no acknowledgement reads as though the file was not picked up:

```
  Saga: place_order (2 steps, from api)
  State machine: order (3 states, initial pending)
  Validator: adult (cel)
  Transform: normalize (2 mappings)
```

The name-clash check covers the four new kinds too — names are global across every `.mycel` file, and it only knew about connectors and flows.

## Verified

`go test ./...` and `go vet ./...` clean, `mkdocs build --strict` exit 0. Beyond the tests, generated all four into a real `mycel init` project and validated it with the built binary.