### PR TITLE
chore: bump version to 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.16.0] - 2026-08-10
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -35,7 +35,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "2.15.0"
+	version = "2.16.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Release bump for **2.16.0**, on top of #50.

| File | Change |
|---|---|
| `CHANGELOG.md` | `## [Unreleased]` → `## [2.16.0] - 2026-08-10` |
| `cmd/mycel/main.go` | `version = "2.15.0"` → `"2.16.0"` |

**Minor.** Four new `mycel add` subcommands and a schema that now describes what the parser actually accepts. Nothing in the HCL surface changed, and all 55 example configs still validate — checked against the rebuilt binary, since the schema feeds `mycel validate` and tightening it could have broken real files.

One behaviour change worth naming: `mycel add validator` now requires the rule for the type chosen (`--pattern`, `--expr` or `--wasm`). It previously wrote a file with an empty placeholder there, which the parser rejects — so the command produced something that could not be loaded.

### Pre-tag check

`go.mod` on `go 1.25.0`, both Dockerfiles on `golang:1.25-alpine`. Verified by hand and by the `docker` job here.