### PR TITLE
chore: bump version to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.17.0] - 2026-08-11
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -35,7 +35,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "2.16.0"
+	version = "2.17.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Dates the changelog entry and sets the version string.

Release contents: transform fields evaluated in declaration order, unquoted expressions no longer losing part of themselves, a non-string mapping value reported instead of panicking, the new Input and Output documentation, the rewritten integration patterns page, `llms.txt`, and Artifact Hub publishing for the Helm chart.

See #52.