### PR TITLE
chore: bump version to 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.17.1] - 2026-08-11
 
 ### Security
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -35,7 +35,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "2.17.0"
+	version = "2.17.1"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Dates the changelog entry and sets the version string.

Security release: every vulnerability Trivy reported against the 2.17.0 image is fixed — 2 critical, 14 high, 13 medium and 5 low, down to zero. See #54.