### PR TITLE
Sign the chart, validate its values, and fix the config it mounts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Keyless signing: cosign exchanges this OIDC token for a short-lived
+      # Fulcio certificate, so there is no private key to store or rotate.
+      id-token: write
 
     steps:
       - name: Checkout
@@ -56,6 +59,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -66,12 +70,27 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # Signing by digest rather than by tag covers every tag pointing at this
+      # manifest at once, and cannot drift if a tag is later moved. The digest
+      # is content-addressed, so it is the same in both registries.
+      - name: Sign the images
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${REGISTRY_GITHUB}/${IMAGE_NAME_GITHUB}@${DIGEST}"
+          cosign sign --yes "${IMAGE_NAME_DOCKERHUB}@${DIGEST}"
+
   helm-release:
     runs-on: ubuntu-latest
     needs: build-and-push
     permissions:
       contents: write
       packages: write
+      # See the note on the same permission in build-and-push.
+      id-token: write
 
     steps:
       - name: Checkout
@@ -106,9 +125,38 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      # helm push reports the digest on stderr; capture it rather than
+      # re-resolving the tag, so the signature is tied to exactly what was
+      # just pushed.
       - name: Push Helm chart to GHCR
+        id: chart
         run: |
-          helm push .helm-packages/mycel-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          # Without pipefail the pipeline reports tee's exit code, so a failed
+          # push would sail through. Actions' default shell does not set it.
+          set -euo pipefail
+          helm push .helm-packages/mycel-${{ steps.version.outputs.version }}.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}/charts 2>&1 | tee /tmp/helm-push.log
+          # `|| true` so that a missing digest reaches the check below with its
+          # own message, instead of errexit killing the step on grep's status.
+          DIGEST=$(grep -oE 'sha256:[0-9a-f]{64}' /tmp/helm-push.log | head -1 || true)
+          if [ -z "$DIGEST" ]; then
+            echo "could not read the chart digest from helm push output" >&2
+            cat /tmp/helm-push.log >&2
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          echo "Chart digest: $DIGEST"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # This is what flips the "signed" flag on the Artifact Hub chart page:
+      # for an OCI repository it looks for cosign signatures attached to the
+      # chart by cosign's tag-based discovery.
+      - name: Sign the Helm chart
+        run: |
+          cosign sign --yes \
+            "ghcr.io/${{ github.repository_owner }}/charts/mycel@${{ steps.chart.outputs.digest }}"
 
       # Artifact Hub reads its repository metadata from a reserved tag on the
       # same OCI repository as the chart, not from a file in the chart. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The Helm chart mounted configuration the runtime ignores.** The ConfigMap wrote `service.hcl`, `connectors.hcl`, `flows.hcl` and `types.hcl`, and auto-discovery globbed `config/**.hcl` — but the runtime has only parsed `.mycel` since 1.18.0. Deploying with the chart mounted those files at `/etc/mycel` and started a service with an empty configuration, silently: no error, no warning, zero connectors and zero flows. Keys are now written as `.mycel`, and files dropped in `config/` are matched on both extensions and renamed, so a chart directory left over from before the rename keeps working.
+- **The chart's own default configuration did not parse.** `mycel.config.service` shipped a `service` block with a `port` attribute, which the parser rejects — the block takes `name`, `version` and `admin_port`, and a listening port belongs to the connector that listens. The extension bug had been hiding it, since the file was never read in the first place.
+
+### Added
+
+- **The Helm chart is signed.** Every release now signs the chart and both container images with cosign, keyless: the workflow's OIDC token is exchanged for a short-lived Fulcio certificate, so there is no private key to store or rotate. Signing is by digest, which covers every tag pointing at the same manifest. This is also what Artifact Hub looks for to mark the chart as signed.
+- **`values.schema.json` for the Helm chart.** Helm validates values against it on `install`, `upgrade`, `template` and `lint`, so a typo or a wrong type fails with a precise message — `additional properties 'replicasCount' not allowed` — instead of rendering broken manifests. Enums are pinned where the chart only accepts a fixed set (`logLevel`, `env`, `pullPolicy`, `service.type`, `pathType`), ports are range-checked, durations and paths are pattern-checked, and the keys of `mycel.config.extra` must end in `.mycel` for the same reason the ConfigMap fix exists. Artifact Hub renders it as a browsable reference.
+
 ## [2.17.1] - 2026-08-11
 
 ### Security

--- a/helm/mycel/README.md
+++ b/helm/mycel/README.md
@@ -62,26 +62,26 @@ helm uninstall my-mycel
 
 ## Configuration
 
-Mycel on Kubernetes works exactly like Mycel locally: the same `.hcl` files define your service. The Helm chart takes care of packaging them into a Kubernetes ConfigMap and mounting them at `/etc/mycel` so the Mycel binary can read them.
+Mycel on Kubernetes works exactly like Mycel locally: the same `.mycel` files define your service. The Helm chart takes care of packaging them into a Kubernetes ConfigMap and mounting them at `/etc/mycel` so the Mycel binary can read them.
 
 There are three ways to provide your HCL configuration, from simplest to most flexible.
 
 ### Option 1: From Your HCL Directory (Recommended)
 
-Copy or symlink your project's `.hcl` files into the chart's `config/` directory. The chart auto-discovers every `.hcl` file and packages them into a ConfigMap — no listing, no flags.
+Copy or symlink your project's `.mycel` files into the chart's `config/` directory. The chart auto-discovers every `.mycel` file and packages them into a ConfigMap — no listing, no flags.
 
 **Example:** given a typical Mycel project:
 
 ```
 my-service/
-├── config.hcl
+├── config.mycel
 ├── connectors/
-│   ├── api.hcl
-│   └── database.hcl
+│   ├── api.mycel
+│   └── database.mycel
 ├── flows/
-│   └── users.hcl
+│   └── users.mycel
 └── types/
-    └── user.hcl
+    └── user.mycel
 ```
 
 Deploy it:
@@ -94,7 +94,7 @@ cp -r my-service/* helm/mycel/config/
 helm install my-service ./helm/mycel -f values.yaml
 ```
 
-The chart finds all `.hcl` files under `config/` recursively and flattens them into the ConfigMap (e.g., `connectors/api.hcl` becomes key `connectors_api.hcl`). Mycel reads them all regardless of filename.
+The chart finds all `.mycel` files under `config/` recursively and flattens them into the ConfigMap (e.g., `connectors/api.mycel` becomes key `connectors_api.mycel`). Mycel reads them all regardless of filename.
 
 > **Tip:** The `config/` directory is gitignored by default so each SysOps/environment can use different HCL files without committing them to the chart repo.
 
@@ -160,15 +160,15 @@ mycel:
     existingConfigMap: "my-mycel-config"
 ```
 
-The chart will skip creating its own ConfigMap and mount yours at `/etc/mycel`. Your ConfigMap must contain keys matching HCL filenames (e.g., `service.hcl`, `connectors.hcl`).
+The chart will skip creating its own ConfigMap and mount yours at `/etc/mycel`. Your ConfigMap must contain keys matching HCL filenames (e.g., `service.mycel`, `connectors.mycel`).
 
 Create it from your project directory:
 
 ```bash
 kubectl create configmap my-mycel-config \
-  --from-file=service.hcl=config.hcl \
-  --from-file=connectors.hcl=connectors/api.hcl \
-  --from-file=flows.hcl=flows/users.hcl
+  --from-file=service.mycel=config.mycel \
+  --from-file=connectors.mycel=connectors/api.mycel \
+  --from-file=flows.mycel=flows/users.mycel
 
 helm install my-service ./helm/mycel \
   --set mycel.config.existingConfigMap=my-mycel-config
@@ -317,10 +317,10 @@ podDisruptionBudget:
 | `mycel.hotReload` | Enable hot reload | `false` |
 | `mycel.config.enabled` | Enable ConfigMap | `true` |
 | `mycel.config.existingConfigMap` | Use an existing ConfigMap instead of creating one | `""` |
-| `mycel.config.service` | service.hcl content (supports `--set-file`) | See values.yaml |
-| `mycel.config.connectors` | connectors.hcl content | `""` |
-| `mycel.config.flows` | flows.hcl content | `""` |
-| `mycel.config.types` | types.hcl content | `""` |
+| `mycel.config.service` | service.mycel content (supports `--set-file`) | See values.yaml |
+| `mycel.config.connectors` | connectors.mycel content | `""` |
+| `mycel.config.flows` | flows.mycel content | `""` |
+| `mycel.config.types` | types.mycel content | `""` |
 | `mycel.config.extra` | Additional HCL files | `{}` |
 | `mycel.secrets.enabled` | Enable secrets | `false` |
 | `mycel.secrets.env` | Secret environment variables | `{}` |

--- a/helm/mycel/templates/configmap.yaml
+++ b/helm/mycel/templates/configmap.yaml
@@ -6,28 +6,41 @@ metadata:
   labels:
     {{- include "mycel.labels" . | nindent 4 }}
 data:
-  {{- /* Auto-discover HCL files from config/ directory */}}
-  {{- $files := .Files.Glob "config/**.hcl" }}
-  {{- range $path, $bytes := $files }}
+  {{- /*
+    Keys must end in .mycel. The runtime only parses that extension
+    (internal/parser: isConfigFile), so a key named service.hcl is mounted into
+    /etc/mycel and then ignored — the service starts with an empty
+    configuration and says nothing about it.
+
+    Files dropped in config/ are matched on both extensions and renamed, so a
+    chart directory left over from before the 1.18 rename still works.
+  */}}
+  {{- $mycelFiles := .Files.Glob "config/**.mycel" }}
+  {{- $legacyFiles := .Files.Glob "config/**.hcl" }}
+  {{- range $path, $bytes := $mycelFiles }}
   {{ trimPrefix "config/" $path | replace "/" "_" }}: |
     {{- toString $bytes | nindent 4 }}
   {{- end }}
+  {{- range $path, $bytes := $legacyFiles }}
+  {{ trimPrefix "config/" $path | replace "/" "_" | replace ".hcl" ".mycel" }}: |
+    {{- toString $bytes | nindent 4 }}
+  {{- end }}
   {{- /* Inline values from values.yaml (only when no files discovered) */}}
-  {{- if not $files }}
+  {{- if and (not $mycelFiles) (not $legacyFiles) }}
   {{- if .Values.mycel.config.service }}
-  service.hcl: |
+  service.mycel: |
     {{- .Values.mycel.config.service | nindent 4 }}
   {{- end }}
   {{- if .Values.mycel.config.connectors }}
-  connectors.hcl: |
+  connectors.mycel: |
     {{- .Values.mycel.config.connectors | nindent 4 }}
   {{- end }}
   {{- if .Values.mycel.config.flows }}
-  flows.hcl: |
+  flows.mycel: |
     {{- .Values.mycel.config.flows | nindent 4 }}
   {{- end }}
   {{- if .Values.mycel.config.types }}
-  types.hcl: |
+  types.mycel: |
     {{- .Values.mycel.config.types | nindent 4 }}
   {{- end }}
   {{- range $filename, $content := .Values.mycel.config.extra }}

--- a/helm/mycel/values.schema.json
+++ b/helm/mycel/values.schema.json
@@ -1,0 +1,280 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Mycel Helm chart values",
+  "description": "Helm validates values against this schema on install, upgrade, template and lint, so a mistyped value fails with a clear message instead of producing broken manifests.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of replicas. Ignored when autoscaling.enabled is true."
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+        "tag": { "type": "string", "description": "Defaults to the chart appVersion when empty." }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" }
+      }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "nodePort": {
+          "type": ["integer", "string"],
+          "description": "Only used when type is NodePort. Empty string means let Kubernetes choose.",
+          "anyOf": [
+            { "type": "integer", "minimum": 30000, "maximum": 32767 },
+            { "type": "string", "maxLength": 0 }
+          ]
+        },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "host": { "type": "string", "minLength": 1 },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": { "type": "string", "minLength": 1 },
+                    "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] }
+                  },
+                  "required": ["path"]
+                }
+              }
+            },
+            "required": ["host"]
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": { "type": "string" },
+              "hosts": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "resources": { "type": "object" },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": {
+          "anyOf": [
+            { "type": "integer", "minimum": 1, "maximum": 100 },
+            { "type": "string", "maxLength": 0 }
+          ]
+        },
+        "targetMemoryUtilizationPercentage": {
+          "description": "Empty string disables the memory metric.",
+          "anyOf": [
+            { "type": "integer", "minimum": 1, "maximum": 100 },
+            { "type": "string", "maxLength": 0 }
+          ]
+        }
+      }
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "mycel": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "type": "string",
+          "enum": ["development", "staging", "production"],
+          "description": "Sets MYCEL_ENV, which selects environment-aware defaults."
+        },
+        "logLevel": { "type": "string", "enum": ["debug", "info", "warn", "error"] },
+        "logFormat": { "type": "string", "enum": ["text", "json"] },
+        "hotReload": { "type": "boolean" },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingConfigMap": {
+              "type": "string",
+              "description": "Name of a ConfigMap you manage yourself. Its keys must end in .mycel or the runtime ignores them."
+            },
+            "service": { "type": "string" },
+            "connectors": { "type": "string" },
+            "flows": { "type": "string" },
+            "types": { "type": "string" },
+            "extra": {
+              "type": "object",
+              "description": "Extra configuration files, keyed by filename.",
+              "additionalProperties": { "type": "string" },
+              "propertyNames": {
+                "pattern": "\\.mycel$",
+                "description": "The runtime only parses files ending in .mycel."
+              }
+            }
+          }
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "env": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "healthCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "liveness": { "$ref": "#/definitions/probe" },
+        "readiness": { "$ref": "#/definitions/probe" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "path": { "type": "string", "pattern": "^/" },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespace": { "type": "string" },
+            "labels": { "type": "object" },
+            "interval": { "$ref": "#/definitions/duration" },
+            "scrapeTimeout": { "$ref": "#/definitions/duration" }
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "$ref": "#/definitions/replicaBound" },
+        "maxUnavailable": {
+          "description": "Alternative to minAvailable. Empty string leaves it unset.",
+          "$ref": "#/definitions/replicaBound"
+        }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "description": "Raw Kubernetes EnvVar entries.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "value": { "type": "string" },
+          "valueFrom": { "type": "object" }
+        },
+        "required": ["name"]
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "mountPath": { "type": "string", "minLength": 1 }
+        },
+        "required": ["name", "mountPath"]
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": { "name": { "type": "string", "minLength": 1 } },
+        "required": ["name"]
+      }
+    },
+    "initContainers": { "type": "array", "items": { "type": "object" } },
+    "sidecarContainers": { "type": "array", "items": { "type": "object" } }
+  },
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": { "type": "string", "pattern": "^/" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "duration": {
+      "type": "string",
+      "pattern": "^[0-9]+(ms|s|m|h)$",
+      "description": "A Prometheus duration, e.g. 30s or 1m."
+    },
+    "replicaBound": {
+      "anyOf": [
+        { "type": "integer", "minimum": 0 },
+        { "type": "string", "pattern": "^([0-9]+%?)?$" }
+      ]
+    }
+  }
+}

--- a/helm/mycel/values.yaml
+++ b/helm/mycel/values.yaml
@@ -123,8 +123,8 @@ mycel:
   hotReload: false
 
   # Configuration files
-  # Option 1 (recommended): copy your .hcl files into helm/mycel/config/
-  #   The chart auto-discovers all .hcl files and creates the ConfigMap.
+  # Option 1 (recommended): copy your .mycel files into helm/mycel/config/
+  #   The chart auto-discovers them and creates the ConfigMap.
   # Option 2: write HCL inline below (service, connectors, flows, types).
   # Option 3: set existingConfigMap to reference a ConfigMap you manage yourself.
   config:
@@ -132,19 +132,21 @@ mycel:
     enabled: true
     # -- Use an existing ConfigMap instead of creating one (set to ConfigMap name)
     existingConfigMap: ""
-    # -- Service configuration (service.hcl content) — used only when config/ is empty
+    # -- Service configuration (service.mycel content) — used only when config/ is empty.
+    # The service block takes name, version and admin_port; a listening port
+    # belongs to the connector that listens, not here.
     service: |
       service {
-        name = "mycel"
-        port = 8080
+        name    = "mycel"
+        version = "1.0.0"
       }
-    # -- Connectors configuration (connectors.hcl content)
+    # -- Connectors configuration (connectors.mycel content)
     connectors: ""
-    # -- Flows configuration (flows.hcl content)
+    # -- Flows configuration (flows.mycel content)
     flows: ""
-    # -- Types configuration (types.hcl content)
+    # -- Types configuration (types.mycel content)
     types: ""
-    # -- Additional HCL files (key: filename, value: content)
+    # -- Additional configuration files (key: filename ending in .mycel, value: content)
     extra: {}
 
   # Secrets configuration


### PR DESCRIPTION
Three things for the Helm chart. The first was found while testing the others
and matters most.

## The chart mounted configuration the runtime ignores

The ConfigMap wrote `service.hcl`, `connectors.hcl`, `flows.hcl` and
`types.hcl`, and auto-discovery globbed `config/**.hcl`. The runtime has only
parsed `.mycel` since 1.18.0 (`internal/parser`, `isConfigFile`).

Reproduced by rendering the chart, writing the ConfigMap out to a directory and
running the real binary against it:

```
files mounted: service.hcl
Connectors: 0    Flows: 0    Types: 0
```

No error, no warning — deploying with the chart started a service with an empty
configuration. Keys are now `.mycel`, and files dropped in `config/` are matched
on both extensions and renamed, so a chart directory left over from before the
rename keeps working.

Fixing that surfaced the next one: the chart's own default `service` block
carries a `port` attribute the parser rejects. It was invisible while the file
was being ignored. The block takes `name`, `version` and `admin_port`; a
listening port belongs to the connector that listens.

## Signing

cosign keyless — the workflow's OIDC token becomes a short-lived Fulcio
certificate, so there is no key to store or rotate. Covers the chart and both
container images, signing by digest so every tag on the same manifest is
covered and nothing drifts if a tag moves. It is also what Artifact Hub looks
for to mark an OCI chart as signed.

Two corrections made while writing it: `sigstore/cosign-installer` has no
moving `v4` tag (pinned to `v4.1.2`), and `helm push | tee` reports tee's exit
code, so the step needs `pipefail` explicitly — Actions' default shell does not
set it and a failed push would have sailed through.

**These steps only run on a tag, so this PR's checks do not exercise them.**

## values.schema.json

Helm validates values on `install`, `upgrade`, `template` and `lint`.
Calibrated in both directions:

- the chart's own defaults validate
- twelve legitimate configurations still render (NodePort with an explicit
  port, PDB with `25%`, `extraEnv` with `valueFrom`, ingress with TLS,
  `existingConfigMap`, …)
- ten realistic mistakes are rejected with the path named

The most valuable part is `additionalProperties: false`:

```
Error: values don't meet the specifications of the schema(s)...
- at '': additional properties 'replicasCount' not allowed
```

Verified that the schema ships inside the packaged `.tgz` and applies from
there, which is where Artifact Hub reads it.