### PR TITLE
Authenticate cosign to GHCR before signing the chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,21 @@ jobs:
         run: |
           helm package helm/mycel --destination .helm-packages
 
-      - name: Login to GitHub Container Registry
+      # Two logins, deliberately. `helm registry login` writes to Helm's own
+      # credential store, which nothing else reads; cosign and oras read the
+      # Docker config. Signing the chart failed in the 2.18.0 release with
+      # "UNAUTHORIZED: unauthenticated" for exactly this reason — the images
+      # signed fine because docker/login-action had already run in that job.
+      - name: Login to GitHub Container Registry (Helm)
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Login to GitHub Container Registry (Docker config, for cosign and oras)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # helm push reports the digest on stderr; capture it rather than
       # re-resolving the tag, so the signature is tied to exactly what was


### PR DESCRIPTION
The 2.18.0 release failed at `Sign the Helm chart`:

```
UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.
```

`helm registry login` writes to Helm's own credential store, which cosign does not read. This is the same reason the oras step already carries its own login — applied to oras and then missed for cosign in the same file. Image signing in `build-and-push` worked because `docker/login-action` had already written the Docker config in that job.

`helm-release` now runs `docker/login-action` as well, which serves both cosign and oras; helm keeps its own login because it reads nowhere else.

The signing steps only run on a tag, so this PR's checks cannot exercise the fix — it is verified by the next release reaching `Sign the Helm chart` and passing.