### PR TITLE
chore: move the last two actions off Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
       # same OCI repository as the chart, not from a file in the chart. The
       # media types below are the ones it looks for; it ignores anything else.
       - name: Set up ORAS
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@v2
 
       # `helm registry login` writes to Helm's own credential store, which oras
       # does not read, so this login is not redundant.
@@ -302,7 +302,7 @@ jobs:
           cache: true
 
       - name: Build archives and packages
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
The 2.18.0 release warned:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: oras-project/setup-oras@v1
```

Sweeping every action across the workflows found a second one in the same state — `goreleaser/goreleaser-action@v6` — which had not warned yet only because its job runs later in the release.

Both have a moving major tag already on Node 24: `setup-oras@v2` and `goreleaser-action@v7`. Checked that v7 still declares the `version` and `args` inputs this workflow passes. After the change nothing under `.github/workflows` targets Node 20.