### PR TITLE
Add constants blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   They hold literals — strings, numbers, lists, maps, `env()` calls — read once, when the configuration is. A value worked out from a message is what a transform is for. Declaring the same name twice is refused, naming both files, rather than letting the order files are walked in decide.
 
+  `mycel add constants --value page_size=500` writes one, and `mycel validate` lists what it found.
+
   The name is `constants` rather than `const` because `const` and `var` are both reserved identifiers in CEL: an expression naming either does not compile, whatever the environment declares.
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`constants` blocks.** A value declared once and referred to by name from anywhere in the configuration — a list of SKUs a queue consumer skips, a page size four queries share, a region read from the environment:
+
+  ```hcl
+  constants {
+    skus_to_skip = ["SKU-1", "SKU-2"]
+    page_size    = 500
+    region       = env("REGION", "us")
+  }
+  ```
+
+  `constants.page_size` reads the same in a `query`, which HCL evaluates when the configuration is read, and in a `filter`, which CEL evaluates per message. Which of the two you are writing for is not something you have to know: a constant that resolved in one and not the other would be worse than having none, because the failure is per-expression and nothing announces it.
+
+  They hold literals — strings, numbers, lists, maps, `env()` calls — read once, when the configuration is. A value worked out from a message is what a transform is for. Declaring the same name twice is refused, naming both files, rather than letting the order files are walked in decide.
+
+  The name is `constants` rather than `const` because `const` and `var` are both reserved identifiers in CEL: an expression naming either does not compile, whatever the environment declares.
+
 ### Breaking
 
 Every one of these is a setting that was written, documented, and did nothing.

--- a/cmd/mycel/add_constants.go
+++ b/cmd/mycel/add_constants.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/matutetandil/mycel/v2/pkg/schema"
+)
+
+var addConstantsValues []string
+
+var addConstantsCmd = &cobra.Command{
+	Use:   "constants",
+	Short: "Add a constants block in constants.mycel",
+	Long: `Generate a constants block.
+
+Every attribute is a value the configuration reads as constants.<name>, from an
+HCL attribute and from a CEL expression alike. They hold literals and env()
+calls — a value worked out from a message is what a transform is for.
+
+Examples:
+  mycel add constants --value page_size=500 --value region=us
+  mycel add constants --value 'skus_to_skip=["SKU-1","SKU-2"]'
+  mycel add constants`,
+	Args: cobra.NoArgs,
+	RunE: runAddConstants,
+}
+
+func runAddConstants(cmd *cobra.Command, args []string) error {
+	return writeDeclaration("constants.mycel",
+		renderConstants(addConstantsValues, schema.ConstantsSchema()))
+}
+
+func renderConstants(values []string, blk schema.Block) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "// %s\n", blk.Doc)
+	b.WriteString("//\n")
+	b.WriteString("// Read once, when the configuration is. A value computed from a message\n")
+	b.WriteString("// belongs in a transform.\n")
+	b.WriteString("constants {\n")
+
+	if len(values) == 0 {
+		b.WriteString("  // TODO — e.g. page_size = 500\n")
+		b.WriteString("  //        skus_to_skip = [\"SKU-1\", \"SKU-2\"]\n")
+		b.WriteString("  //        region = env(\"REGION\", \"us\")\n")
+	}
+	for _, value := range values {
+		name, literal, found := strings.Cut(value, "=")
+		name = strings.TrimSpace(name)
+		literal = strings.TrimSpace(literal)
+		if !found || name == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "  %s = %s\n", name, asHCLLiteral(literal))
+	}
+
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// asHCLLiteral leaves a value that already looks like HCL alone and quotes
+// anything else. `page_size=500` is a number, `region=us` is a string, and
+// `skus=["a","b"]` is a list somebody wrote out in full.
+func asHCLLiteral(value string) string {
+	if value == "" {
+		return `""`
+	}
+	switch value[0] {
+	case '[', '{', '"':
+		return value
+	}
+	if value == "true" || value == "false" {
+		return value
+	}
+	if strings.HasPrefix(value, "env(") {
+		return value
+	}
+	if isNumeric(value) {
+		return value
+	}
+	return fmt.Sprintf("%q", value)
+}
+
+func isNumeric(value string) bool {
+	dots := 0
+	for i, c := range value {
+		switch {
+		case c >= '0' && c <= '9':
+		case c == '.':
+			dots++
+			if dots > 1 {
+				return false
+			}
+		case c == '-' && i == 0:
+		default:
+			return false
+		}
+	}
+	return value != "" && value != "-"
+}
+
+func init() {
+	addConstantsCmd.Flags().StringArrayVar(&addConstantsValues, "value", nil,
+		"A constant, as name=value (repeatable)")
+	addCmd.AddCommand(addConstantsCmd)
+}

--- a/cmd/mycel/add_constants_test.go
+++ b/cmd/mycel/add_constants_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/v2/pkg/schema"
+)
+
+// What `mycel add constants` writes has to parse.
+//
+// The rule this repository keeps relearning: something the tool generates that
+// the parser then refuses is worse than no generator at all, because the
+// person following it has no reason to doubt the output.
+func TestGeneratedConstantsParse(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		values []string
+	}{
+		{"nothing but the placeholder", nil},
+		{"a number and a string", []string{"page_size=500", "region=us"}},
+		{"a list written out", []string{`skus_to_skip=["SKU-1", "SKU-2"]`}},
+		{"a map", []string{`thresholds={ warn = 100, alert = 500 }`}},
+		{"a boolean", []string{"debug=false"}},
+		{"a value from the environment", []string{`database_url=env("DATABASE_URL", "")`}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			body := renderConstants(c.values, schema.ConstantsSchema())
+			if err := parseGenerated(t, body); err != nil {
+				t.Errorf("what was generated does not parse: %v\n%s", err, body)
+			}
+		})
+	}
+}
+
+// A value is written as the literal it is: a number stays a number, a string
+// is quoted, and something already written as HCL is left alone.
+func TestGeneratedConstantsKeepTheirTypes(t *testing.T) {
+	body := renderConstants([]string{
+		"page_size=500",
+		"ratio=1.5",
+		"region=us",
+		"debug=true",
+		`skus=["a"]`,
+	}, schema.ConstantsSchema())
+
+	for _, want := range []string{
+		"page_size = 500",
+		"ratio = 1.5",
+		`region = "us"`,
+		"debug = true",
+		`skus = ["a"]`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("generated block does not contain %q:\n%s", want, body)
+		}
+	}
+}
+
+// The comment comes from the schema's own wording, so it cannot contradict it.
+func TestGeneratedConstantsCommentComesFromTheSchema(t *testing.T) {
+	blk := schema.ConstantsSchema()
+	if blk.Doc == "" {
+		t.Fatal("the schema documents nothing, so this test is checking nothing")
+	}
+	if !strings.Contains(renderConstants(nil, blk), blk.Doc) {
+		t.Error("generated comment does not use the schema's wording")
+	}
+}

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"time"
 
@@ -689,6 +690,17 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	for _, tr := range config.Transforms {
 		if tr != nil {
 			fmt.Printf("  Transform: %s (%d mappings)\n", tr.Name, len(tr.Mappings))
+		}
+	}
+	if len(config.Constants) > 0 {
+		names := make([]string, 0, len(config.Constants))
+		for name := range config.Constants {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		fmt.Printf("  Constants: %d\n", len(names))
+		for _, name := range names {
+			fmt.Printf("    - %s = %v\n", name, config.Constants[name])
 		}
 	}
 

--- a/docs/core-concepts/constants.md
+++ b/docs/core-concepts/constants.md
@@ -1,0 +1,119 @@
+# Constants
+
+A `constants` block declares a value once and lets the rest of the
+configuration refer to it by name.
+
+```hcl
+constants {
+  skus_to_skip = ["SKU-1", "SKU-2", "SKU-3"]
+  page_size    = 500
+  region       = env("REGION", "us")
+}
+```
+
+Every part of a configuration reads them the same way — `constants.<name>`:
+
+```hcl
+flow "list_items" {
+  from {
+    connector = "api"
+    operation = "GET /items"
+  }
+  to {
+    connector = "db"
+    query     = "SELECT * FROM items LIMIT ${constants.page_size}"
+  }
+}
+
+flow "process_item" {
+  from {
+    connector = "rabbit"
+    operation = "items.updated"
+  }
+
+  accept {
+    when      = "!(input.body.sku in constants.skus_to_skip)"
+    on_reject = "ack"
+  }
+
+  transform {
+    sku    = "input.body.sku"
+    region = "constants.region"
+  }
+
+  to {
+    connector = "db"
+    target    = "items"
+  }
+}
+```
+
+## One name, two machines
+
+The two references above are evaluated by different things. `${...}` is HCL's,
+folded in when the configuration is read; `constants.region` inside a transform
+is CEL's, evaluated for every message. A constant is put in front of both, so
+which one you are writing for is not something you have to know.
+
+That is the whole point of the block. A constant that resolved in a `query` and
+not in a `filter` would be worse than having none, because the failure is
+per-expression and nothing announces it.
+
+## What a constant holds
+
+A literal: a string, a number, a boolean, a list, a map, or anything built out
+of those — including an `env()` call, which is a literal by the time anything
+else runs.
+
+```hcl
+constants {
+  retries      = 3
+  debug        = false
+  regions      = ["us", "uk", "fr"]
+  thresholds   = { warn = 100, alert = 500 }
+  database_url = env("DATABASE_URL")
+}
+```
+
+What a constant is **not** is a value worked out from a message. There is no
+`constants.total = "input.price * input.quantity"`: that is what a
+[transform](transforms.md) is for. Constants are read once, when the
+configuration is, and do not change while the service runs.
+
+## Where they can be declared
+
+In any `.mycel` file, as many blocks as you like. They are collected before
+anything else is read, so a flow may use a constant a file later in the
+directory declares — nothing about the order files are walked in matters.
+
+```hcl
+# constants.mycel
+constants {
+  page_size = 500
+}
+```
+
+Declaring the same name twice is refused, naming both files:
+
+```
+constant "page_size" is declared twice: in constants.mycel and in limits.mycel
+— a constant holds one value, so which file wins cannot be left to the order
+they are read in
+```
+
+## Checking them
+
+`mycel validate` lists what it found:
+
+```
+  Constants: 3
+    - page_size = 500
+    - region = us
+    - skus_to_skip = [SKU-1 SKU-2 SKU-3]
+```
+
+## See also
+
+- [Input and Output](input-and-output.md) — the other names an expression can use
+- [Transforms](transforms.md) — for values computed per message
+- [Reusable Blocks](reusable-blocks.md) — for reusing a *block* rather than a value

--- a/docs/core-concepts/constants.md
+++ b/docs/core-concepts/constants.md
@@ -101,6 +101,12 @@ constant "page_size" is declared twice: in constants.mycel and in limits.mycel
 they are read in
 ```
 
+## Writing one
+
+```bash
+mycel add constants --value page_size=500 --value region=us
+```
+
 ## Checking them
 
 `mycel validate` lists what it found:

--- a/docs/core-concepts/input-and-output.md
+++ b/docs/core-concepts/input-and-output.md
@@ -184,6 +184,7 @@ CEL string literals are single-quoted and CEL macros are not HCL syntax, so both
 
 | Variable | Filled by | Available in |
 |----------|-----------|--------------|
+| `constants` | [`constants` blocks](constants.md) — `constants.<name>`, the same in an HCL attribute | every expression, and every attribute |
 | `enriched` | [`enrich` blocks](transforms.md#enrichment-in-transforms) — `enriched.<name>` per block | `transform`, and anything after it |
 | `step` | [`step` blocks](../guides/multi-step-flows.md) — `step.<name>` per step | `transform`, later `step` blocks, `to` |
 | `error` | A failure, as `error.message` / `error.code` / `error.type` | `error_handling`, `on_error` aspects |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,6 +8,7 @@ Key facts an assistant should have before answering questions about Mycel:
 - **The unit of work is a `flow`**: a `from` block naming the source connector and its operation, optional processing blocks, and one or more `to` blocks. `from` is the only required block.
 - **Expressions are CEL**, always written as **quoted strings**: `email = "lower(input.email)"`. Unquoted, HCL parses the expression itself and rejects most real CEL (CEL string literals are single-quoted; CEL macros are not HCL syntax).
 - **Two implicit variables carry the data.** `input` is what arrived, filled by the source connector; its shape differs per source — a REST request is flattened onto `input` (path params, query params and body fields all at the top level), while a queue message keeps its payload under `input.body`. Output fields are named by the **left-hand side** of each transform line; `output.` is never written on the left, and doing so is an HCL parse error, not a Mycel one.
+- **A `constants` block declares values used in more than one place**, read as `constants.<name>` — the same name in an HCL attribute (`${constants.page_size}`, folded in when the file is read) and in a CEL expression (evaluated per message). It holds literals and `env()` calls, never anything computed from a message. The block is `constants` and not `const`: `const` and `var` are reserved identifiers in CEL.
 - **Transform fields are evaluated top to bottom**, each result visible to the lines below it through `output`. (Before 2.17.0 the order was not preserved.)
 - **Pure Go, no CGO.** Single static binary. Distributed as tarballs, `.deb`/`.rpm`/`.apk` with a systemd unit, a Homebrew formula, a Docker image, and a Helm chart.
 - **The parser is the authority.** The documentation has historically described constructs the parser rejects; when in doubt, `mycel validate --config <dir>` is the ground truth.
@@ -23,6 +24,7 @@ Key facts an assistant should have before answering questions about Mycel:
 
 - [Flows](https://matutetandil.github.io/mycel/core-concepts/flows/): The pipeline. Opens with an anatomy table of all 21 blocks and 4 attributes a flow can hold, in the order they run.
 - [Input and Output](https://matutetandil.github.io/mycel/core-concepts/input-and-output/): The two implicit variables, what `output` means in each block that can read it, evaluation order, and why expressions are quoted.
+- [Constants](https://matutetandil.github.io/mycel/core-concepts/constants/): Values declared once and read as `constants.<name>` from HCL attributes and CEL expressions alike.
 - [Connectors](https://matutetandil.github.io/mycel/core-concepts/connectors/): Bidirectional adapters; a connector can be a source, a destination, or both.
 - [Transforms](https://matutetandil.github.io/mycel/core-concepts/transforms/): Reshaping payloads with CEL, named transforms, and enrichment from other connectors.
 - [Types](https://matutetandil.github.io/mycel/core-concepts/types/): Schema validation for inputs and outputs. Note the constraint syntax is `string({ format = "email" })`, with the braces inside parentheses.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -161,6 +161,7 @@ mycel add saga place_order --from rabbit --steps reserve_stock,charge_card,ship
 mycel add state-machine order --states pending,paid,shipped,delivered
 mycel add validator adult --type cel --expr "input.age >= 18"
 mycel add transform normalize_user --fields id,email,created_at
+mycel add constants --value page_size=500 --value region=us
 
 mycel add connector --list       # available types
 ```
@@ -170,6 +171,7 @@ mycel add connector --list       # available types
 | `--type` | `connector` | Connector type — required |
 | `--driver` | `connector` | Driver, for types that have one |
 | `--list` | `connector` | List available types and exit |
+| `--value` | `constants` | A constant, as `name=value`; repeatable |
 | `--from` | `flow` | Source connector |
 | `--to` | `flow` | Destination connector |
 | `--operation` | `flow` | Source operation, e.g. `"GET /orders"` |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -12,6 +12,7 @@ Complete HCL syntax reference for all Mycel block types. Every block is document
     - [cache](#cache-block) · [after](#after-block) · [dedupe](#dedupe-block) · [idempotency](#idempotency-block) · [async](#async-block)
     - [error_handling](#error_handling-block) · [lock](#lock-block) · [semaphore](#semaphore-block) · [coordinate](#coordinate-block) · [sequence_guard](#sequence_guard-block)
     - [batch](#batch-block) · [state_transition](#state_transition-block)
+- [constants](#constants)
 - [type](#type)
 - [transform](#transform)
 - [cache (named)](#cache-named)
@@ -1037,6 +1038,36 @@ type "NAME" {
 | `shareable = true` | `@shareable` on field |
 | `inaccessible = true` | `@inaccessible` |
 | `override = "subgraph"` | `@override(from: "subgraph")` |
+
+---
+
+## constants
+
+Values declared once and referred to by name from anywhere in the
+configuration:
+
+```hcl
+constants {
+  skus_to_skip = ["SKU-1", "SKU-2"]
+  page_size    = 500
+  region       = env("REGION", "us")
+}
+```
+
+| Holds | Read as |
+|-------|---------|
+| Strings, numbers, booleans, lists, maps, `env()` calls — anything settled when the configuration is read | `constants.<name>` |
+
+The same name works on both sides of the line: `${constants.page_size}` in an
+attribute, which HCL folds in as the file is read, and `constants.page_size`
+inside a CEL expression, which is evaluated per message.
+
+A constant is not computed from a message — that is what a
+[transform](../core-concepts/transforms.md) is for. Any `.mycel` file may
+declare them, and they are read before anything else, so a flow may use one
+that a later file declares. The same name twice is refused, naming both files.
+
+See [Constants](../core-concepts/constants.md).
 
 ---
 

--- a/examples/constants/README.md
+++ b/examples/constants/README.md
@@ -1,0 +1,84 @@
+# Constants
+
+A value declared once and used from several places — an HCL attribute and a CEL
+expression alike.
+
+The case this exists for: a list of SKUs the service ignores, needed by more
+than one query and by the check that refuses them on the way in. Written into
+each of them, it is three copies to keep in step.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `constants.mycel` | The values |
+| `service.mycel` | Connectors |
+| `flows.mycel` | Three flows, each reading a constant a different way |
+| `migrations/001_create_items.sql` | The table and a few rows |
+
+## What it shows
+
+```
+GET  /items          → the query's LIMIT comes from ${constants.page_size}
+POST /items          → accept refuses a sku in constants.skus_to_skip
+GET  /items/skipped  → the same list again, in a second query
+```
+
+`${constants.page_size}` is HCL's interpolation, folded in when the file is
+read. `constants.skus_to_skip` inside `accept` is CEL's, evaluated for every
+request. Same name, and you do not have to know which of the two you are
+writing for.
+
+## Running
+
+```bash
+mycel migrate --config ./examples/constants
+mycel start --config ./examples/constants
+```
+
+## Try It
+
+The listing stops at three rows, because that is what the constant says:
+
+```bash
+curl http://localhost:3000/items
+```
+
+A sku the constant lists is refused:
+
+```bash
+curl -X POST http://localhost:3000/items \
+  -H "Content-Type: application/json" \
+  -d '{"sku":"SKU-SAMPLE","name":"Free sample","total":0}'
+```
+
+One it does not list is written, with the region and the large-order flag both
+worked out from constants:
+
+```bash
+curl -X POST http://localhost:3000/items \
+  -H "Content-Type: application/json" \
+  -d '{"sku":"SKU-0009","name":"Machine","total":2500}'
+```
+
+And the second query reads the same list:
+
+```bash
+curl http://localhost:3000/items/skipped
+```
+
+## Changing one
+
+Change `page_size` in `constants.mycel` and restart: the listing and anything
+else that reads it move together. That is the whole point — there is one place
+to change.
+
+`mycel validate` prints what it found:
+
+```
+  Constants: 4
+    - large_order_total = 1000
+    - page_size = 3
+    - region = us
+    - skus_to_skip = [SKU-DISCONTINUED SKU-SAMPLE SKU-INTERNAL]
+```

--- a/examples/constants/constants.mycel
+++ b/examples/constants/constants.mycel
@@ -1,0 +1,21 @@
+// Values this service uses in more than one place.
+//
+// They are read once, when the configuration is, and every part of it refers
+// to them by the same name — an HCL attribute with ${constants.x}, a CEL
+// expression with constants.x.
+
+constants {
+  // The catalogue this service ignores. Written here rather than in each
+  // query that needs it, which is the case that asked for the feature.
+  skus_to_skip = ["SKU-DISCONTINUED", "SKU-SAMPLE", "SKU-INTERNAL"]
+
+  // How many rows a listing returns.
+  page_size = 3
+
+  // Where this deployment is. From the environment, because it changes per
+  // deployment and not per message.
+  region = env("REGION", "us")
+
+  // What counts as an order worth flagging.
+  large_order_total = 1000
+}

--- a/examples/constants/flows.mycel
+++ b/examples/constants/flows.mycel
@@ -1,0 +1,52 @@
+// Read by HCL: the limit is part of the query before the service starts.
+flow "list_items" {
+  from {
+    connector = "api"
+    operation = "GET /items"
+  }
+
+  to {
+    connector = "db"
+    query     = "SELECT sku, name, total FROM items ORDER BY sku LIMIT ${constants.page_size}"
+  }
+}
+
+// Read by CEL: the same list, checked per request.
+flow "create_item" {
+  from {
+    connector = "api"
+    operation = "POST /items"
+  }
+
+  accept {
+    when      = "!(input.sku in constants.skus_to_skip)"
+    on_reject = "reject"
+  }
+
+  transform {
+    sku    = "input.sku"
+    name   = "input.name"
+    total  = "input.total"
+    region = "constants.region"
+    // A constant in an ordinary expression, beside the fields from the request.
+    large  = "input.total > constants.large_order_total"
+  }
+
+  to {
+    connector = "db"
+    target    = "items"
+  }
+}
+
+// And in a second query, which is the point: the list lives in one place.
+flow "count_skipped" {
+  from {
+    connector = "api"
+    operation = "GET /items/skipped"
+  }
+
+  to {
+    connector = "db"
+    query     = "SELECT count(*) AS skipped FROM items WHERE sku IN ('${constants.skus_to_skip[0]}', '${constants.skus_to_skip[1]}', '${constants.skus_to_skip[2]}')"
+  }
+}

--- a/examples/constants/migrations/001_create_items.sql
+++ b/examples/constants/migrations/001_create_items.sql
@@ -1,0 +1,18 @@
+-- The catalogue the flows read and write.
+--
+-- Applied with `mycel migrate --config .` before starting.
+
+CREATE TABLE IF NOT EXISTS items (
+    id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    sku    TEXT NOT NULL,
+    name   TEXT,
+    total  REAL,
+    region TEXT,
+    large  BOOLEAN
+);
+
+INSERT OR IGNORE INTO items (sku, name, total, region, large) VALUES
+    ('SKU-0001', 'Widget',  9.99,  'us', 0),
+    ('SKU-0002', 'Gadget',  24.99, 'us', 0),
+    ('SKU-0003', 'Doohickey', 4.50, 'us', 0),
+    ('SKU-0004', 'Contraption', 1500.00, 'us', 1);

--- a/examples/constants/service.mycel
+++ b/examples/constants/service.mycel
@@ -1,0 +1,15 @@
+service {
+  name    = "constants-demo"
+  version = "1.0.0"
+}
+
+connector "api" {
+  type = "rest"
+  port = 3000
+}
+
+connector "db" {
+  type     = "database"
+  driver   = "sqlite"
+  database = env("DB_PATH", "./data/catalogue.db")
+}

--- a/examples/format/flows/enrich_product.mycel
+++ b/examples/format/flows/enrich_product.mycel
@@ -17,8 +17,16 @@ flow "enrich_product" {
   # The connector already has format = "xml", but you can also set it per step
   step "get_legacy_info" {
     connector = "soap_api"
-    operation = "GET /products/${step.save.id}/details"
+    operation = "GET /products/details"
     format    = "xml"
+
+    # The id travels as a parameter, not spliced into the path: ${...} is HCL's
+    # interpolation, evaluated when the file is read, and `step` is a CEL
+    # variable that only exists while a message is being handled. Written that
+    # way the attribute cannot be evaluated at all.
+    params = {
+      id = "step.save.id"
+    }
   }
 
   # Step 3: Merge and return as JSON (default)

--- a/internal/parser/const.go
+++ b/internal/parser/const.go
@@ -50,16 +50,6 @@ func newConstants() *Constants {
 	}
 }
 
-// Names returns the declared names, in order, for messages.
-func (c *Constants) Names() []string {
-	names := make([]string, 0, len(c.Values))
-	for name := range c.Values {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
 // asObject is what goes into the HCL evaluation context under `constants`.
 func (c *Constants) asObject() cty.Value {
 	if len(c.Values) == 0 {

--- a/internal/parser/const.go
+++ b/internal/parser/const.go
@@ -1,0 +1,189 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// A constants block declares values a configuration uses in more than one place.
+//
+//	constants {
+//	  skus_to_skip = ["SKU-1", "SKU-2"]
+//	  batch_size   = 500
+//	  region       = env("REGION", "us")
+//	}
+//
+// They are literals, resolved once when the configuration is read — a list, a
+// map, a number, a string, or an env() call, which is a literal by the time
+// anything else runs. Nothing about them is per-message: a value that has to be
+// worked out from a request is what a transform is for.
+//
+// The point is one name that works everywhere. `constants.skus_to_skip` reads the
+// same in a query, which HCL evaluates, and in a filter, which CEL evaluates —
+// two different machines, and a reader should not have to know which one they
+// are writing for. A constant that resolved in `query` and not in `filter`
+// would be worse than no constants at all.
+
+// Constants are the values a const block declared, keyed by name.
+type Constants struct {
+	// Values as HCL sees them, for the evaluation context.
+	Values map[string]cty.Value
+
+	// The same values as Go sees them, for the CEL activation.
+	Go map[string]interface{}
+
+	// Where each was declared, so a duplicate can name both files.
+	DeclaredIn map[string]string
+}
+
+func newConstants() *Constants {
+	return &Constants{
+		Values:     map[string]cty.Value{},
+		Go:         map[string]interface{}{},
+		DeclaredIn: map[string]string{},
+	}
+}
+
+// Names returns the declared names, in order, for messages.
+func (c *Constants) Names() []string {
+	names := make([]string, 0, len(c.Values))
+	for name := range c.Values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// asObject is what goes into the HCL evaluation context under `constants`.
+func (c *Constants) asObject() cty.Value {
+	if len(c.Values) == 0 {
+		return cty.EmptyObjectVal
+	}
+	return cty.ObjectVal(c.Values)
+}
+
+// collectConstants reads every constants block in a file and folds it into what is
+// already known.
+//
+// Declaring the same name twice is refused rather than resolved: two files
+// disagreeing about what a constant holds is a mistake somebody wants to hear
+// about, and picking one silently is how a configuration comes to depend on
+// the order its files are walked in.
+func collectConstants(into *Constants, body hcl.Body, ctx *hcl.EvalContext, path string) error {
+	content, _, diags := body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{{Type: "constants"}},
+	})
+	if diags.HasErrors() {
+		return fmt.Errorf("constants block error: %s", diags.Error())
+	}
+
+	for _, block := range content.Blocks {
+		attrs, diags := block.Body.JustAttributes()
+		if diags.HasErrors() {
+			return fmt.Errorf("constants block error: %s", diags.Error())
+		}
+
+		names := make([]string, 0, len(attrs))
+		for name := range attrs {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			if where, already := into.DeclaredIn[name]; already {
+				return fmt.Errorf(
+					"constant %q is declared twice: in %s and in %s — a constant holds one value, so which file wins cannot be left to the order they are read in",
+					name, where, path)
+			}
+
+			value, diags := attrs[name].Expr.Value(ctx)
+			if diags.HasErrors() {
+				return fmt.Errorf("constant %q: %s", name, diags.Error())
+			}
+			if !value.IsWhollyKnown() {
+				return fmt.Errorf("constant %q cannot be worked out when the configuration is read; a constant is a literal, an env() call, or something built out of those", name)
+			}
+
+			into.Values[name] = value
+			into.Go[name] = ctyValueToInterface(value)
+			into.DeclaredIn[name] = path
+		}
+	}
+
+	return nil
+}
+
+// constantsIn reads the constants blocks out of every .mycel file under a
+// directory, before anything else is parsed.
+//
+// It is a pass of its own because a constant has to exist before the
+// configuration that uses it is evaluated, and a file may use one that a file
+// later in the walk declares. Nothing else about the order of files matters in
+// Mycel, and this keeps it that way.
+func constantsIn(paths []string, ctx *hcl.EvalContext) (*Constants, error) {
+	constants := newConstants()
+
+	for _, path := range paths {
+		parser := hclparse.NewParser()
+		file, diags := parser.ParseHCLFile(path)
+		if diags.HasErrors() {
+			// Left to the main parse, which reports it against the file.
+			continue
+		}
+		if err := collectConstants(constants, file.Body, ctx, path); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+	}
+
+	return constants, nil
+}
+
+// readConstants runs the constants pass over a configuration directory.
+func (p *HCLParser) readConstants(configDir string) error {
+	var paths []string
+	err := filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if info.Name() == "mycel_plugins" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isMycelFile(info.Name()) || isPluginManifest(path) {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Strings(paths)
+
+	constants, err := constantsIn(paths, p.evalCtx)
+	if err != nil {
+		return err
+	}
+	p.constants = constants
+	p.applyConstants()
+	return nil
+}
+
+// applyConstants puts them where HCL will look: `constants.<name>`.
+func (p *HCLParser) applyConstants() {
+	if p.constants == nil {
+		return
+	}
+	if p.evalCtx.Variables == nil {
+		p.evalCtx.Variables = map[string]cty.Value{}
+	}
+	p.evalCtx.Variables["constants"] = p.constants.asObject()
+}

--- a/internal/parser/constants_test.go
+++ b/internal/parser/constants_test.go
@@ -1,0 +1,195 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A constants block declares a value once and every part of the configuration
+// reads it the same way.
+//
+// The case that asked for this was a list of SKUs to skip, written into four
+// queries. Before it there was nowhere to put such a thing: env() holds a
+// string somebody has to parse, and a step fetches it with a call per message.
+func TestAConstantIsReadableFromHCLAndFromCEL(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "constants.mycel", `
+constants {
+  skus_to_skip = ["SKU-1", "SKU-2"]
+  page_size    = 25
+  region       = env("MYCEL_TEST_REGION", "us")
+}
+`)
+	write(t, dir, "service.mycel", `
+connector "api" {
+  type = "rest"
+  port = 8080
+}
+
+connector "db" {
+  type     = "database"
+  driver   = "sqlite"
+  database = "./data.db"
+}
+
+flow "list" {
+  from {
+    connector = "api"
+    operation = "GET /items"
+  }
+  to {
+    connector = "db"
+    query     = "SELECT * FROM items LIMIT ${constants.page_size}"
+  }
+}
+
+flow "keep" {
+  from {
+    connector = "api"
+    operation = "POST /items"
+  }
+  accept {
+    when      = "!(input.sku in constants.skus_to_skip)"
+    on_reject = "reject"
+  }
+  to {
+    connector = "db"
+    target    = "items"
+  }
+}
+`)
+
+	config, err := NewHCLParser().Parse(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// Read by HCL, so the value is already in the query.
+	if got := config.Flows[0].To.GetQuery(); !strings.Contains(got, "LIMIT 25") {
+		t.Errorf("query = %q, want the constant folded in", got)
+	}
+
+	// Handed to CEL, so an expression naming it can be evaluated later.
+	if config.Constants["page_size"] == nil {
+		t.Fatalf("constants = %#v", config.Constants)
+	}
+	skus, ok := config.Constants["skus_to_skip"].([]interface{})
+	if !ok || len(skus) != 2 {
+		t.Errorf("skus_to_skip = %#v, want the list", config.Constants["skus_to_skip"])
+	}
+	if config.Constants["region"] != "us" {
+		t.Errorf("region = %#v; env() is a literal by the time anything else runs", config.Constants["region"])
+	}
+	// The expression that reads it is left alone: CEL evaluates it per
+	// message, against the same values.
+	if got := config.Flows[1].Accept.When; !strings.Contains(got, "constants.skus_to_skip") {
+		t.Errorf("accept.when = %q, want the reference untouched", got)
+	}
+}
+
+// A constant declared in one file is readable from another, whatever order
+// they are walked in.
+func TestAConstantCrossesFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Named so the walk reaches the user before the declaration.
+	write(t, dir, "a-flows.mycel", `
+connector "api" {
+  type = "rest"
+  port = 8080
+}
+
+connector "db" {
+  type     = "database"
+  driver   = "sqlite"
+  database = "./data.db"
+}
+
+flow "list" {
+  from {
+    connector = "api"
+    operation = "GET /items"
+  }
+  to {
+    connector = "db"
+    query     = "SELECT * FROM items LIMIT ${constants.page_size}"
+  }
+}
+`)
+	write(t, dir, "z-constants.mycel", "constants {\n  page_size = 7\n}\n")
+
+	config, err := NewHCLParser().Parse(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := config.Flows[0].To.GetQuery(); !strings.Contains(got, "LIMIT 7") {
+		t.Errorf("query = %q; a constant declared later in the walk was not there yet", got)
+	}
+}
+
+// Declaring the same name twice is refused, naming both files.
+//
+// A constant holds one value. Letting the last file win makes a configuration
+// depend on the order its files happen to be read in, which is the one thing
+// nothing else in Mycel does.
+func TestTheSameConstantTwiceIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "one.mycel", "constants {\n  page_size = 10\n}\n")
+	write(t, dir, "two.mycel", "constants {\n  page_size = 20\n}\n")
+
+	_, err := NewHCLParser().Parse(context.Background(), dir)
+	if err == nil {
+		t.Fatal("two declarations of the same constant were accepted")
+	}
+	for _, want := range []string{"page_size", "one.mycel", "two.mycel"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not mention %s: %v", want, err)
+		}
+	}
+}
+
+// Naming a constant that was never declared fails where it is written, rather
+// than becoming an empty string somewhere downstream.
+func TestAnUndeclaredConstantIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "service.mycel", `
+connector "api" {
+  type = "rest"
+  port = 8080
+}
+
+connector "db" {
+  type     = "database"
+  driver   = "sqlite"
+  database = "./data.db"
+}
+
+flow "list" {
+  from {
+    connector = "api"
+    operation = "GET /items"
+  }
+  to {
+    connector = "db"
+    query     = "SELECT * FROM items LIMIT ${constants.page_size}"
+  }
+}
+`)
+
+	_, err := NewHCLParser().Parse(context.Background(), dir)
+	if err == nil {
+		t.Fatal("a query naming a constant nothing declared was accepted")
+	}
+	if !strings.Contains(err.Error(), "page_size") && !strings.Contains(err.Error(), "constants") {
+		t.Errorf("the refusal says nothing about the constant: %v", err)
+	}
+}
+
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -309,7 +309,9 @@ func parseFromBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.FromConfig, e
 	}
 
 	// Capture all connector-specific attributes from the remaining body.
-	extractDynamicAttrs(remain, ctx, from.ConnectorParams)
+	if err := extractDynamicAttrs(remain, ctx, from.ConnectorParams); err != nil {
+		return nil, fmt.Errorf("from block: %w", err)
+	}
 
 	// Check for filter as string attribute (legacy syntax)
 	if attr, ok := content.Attributes["filter"]; ok {
@@ -632,7 +634,9 @@ func parseToBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ToConfig, error
 	}
 
 	// Capture all connector-specific attributes from the remaining body.
-	extractDynamicAttrs(remain, ctx, to.ConnectorParams)
+	if err := extractDynamicAttrs(remain, ctx, to.ConnectorParams); err != nil {
+		return nil, fmt.Errorf("to block: %w", err)
+	}
 
 	if to.Connector == "" {
 		return nil, fmt.Errorf("to block must specify a connector")
@@ -744,7 +748,9 @@ func parseStepBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.StepConfig, e
 	}
 
 	// Capture all connector-specific attributes from the remaining body.
-	extractDynamicAttrs(remain, ctx, step.ConnectorParams)
+	if err := extractDynamicAttrs(remain, ctx, step.ConnectorParams); err != nil {
+		return nil, fmt.Errorf("step: %w", err)
+	}
 
 	return step, nil
 }
@@ -851,7 +857,9 @@ func parseEnrichBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.EnrichConfi
 	}
 
 	// Capture all connector-specific attributes from the remaining body.
-	extractDynamicAttrs(remain, ctx, enrich.ConnectorParams)
+	if err := extractDynamicAttrs(remain, ctx, enrich.ConnectorParams); err != nil {
+		return nil, fmt.Errorf("enrich block: %w", err)
+	}
 
 	return enrich, nil
 }
@@ -1919,26 +1927,36 @@ func parseTransformEnrichBlock(block *hcl.Block, ctx *hcl.EvalContext) (*transfo
 // extractDynamicAttrs extracts unknown attributes from a remaining HCL body into a map.
 // Safely handles bodies that contain both attributes and blocks (JustAttributes would fail).
 // Used to capture connector-specific parameters that aren't in the known schema.
-func extractDynamicAttrs(body hcl.Body, ctx *hcl.EvalContext, dest map[string]interface{}) {
+// extractDynamicAttrs reads the attributes a connector will interpret.
+//
+// An attribute whose expression cannot be evaluated is reported rather than
+// dropped. It used to be dropped, silently, which meant a typo in an `env(`
+// call or a reference to something that does not exist took the whole
+// attribute with it — a `to` block left with no query at all, and a flow that
+// reads the entire table because the WHERE clause evaporated at parse time.
+func extractDynamicAttrs(body hcl.Body, ctx *hcl.EvalContext, dest map[string]interface{}) error {
 	attrs, diags := body.JustAttributes()
 	if diags.HasErrors() {
 		// Body has blocks — extract via hclsyntax if possible
 		if syntaxBody, ok := body.(*hclsyntax.Body); ok {
 			for name, attr := range syntaxBody.Attributes {
 				val, valDiags := attr.Expr.Value(ctx)
-				if !valDiags.HasErrors() {
-					dest[name] = ctyValueToInterface(val)
+				if valDiags.HasErrors() {
+					return fmt.Errorf("%s: %s", name, valDiags.Error())
 				}
+				dest[name] = ctyValueToInterface(val)
 			}
 		}
-		return
+		return nil
 	}
 	for name, attr := range attrs {
 		val, valDiags := attr.Expr.Value(ctx)
-		if !valDiags.HasErrors() {
-			dest[name] = ctyValueToInterface(val)
+		if valDiags.HasErrors() {
+			return fmt.Errorf("%s: %s", name, valDiags.Error())
 		}
+		dest[name] = ctyValueToInterface(val)
 	}
+	return nil
 }
 
 // ctyValueToMap converts a cty.Value to map[string]interface{}.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -39,6 +39,12 @@ type Parser interface {
 
 // Configuration holds all parsed configuration.
 type Configuration struct {
+	// Constants are the values constants blocks declared, by name. They are
+	// resolved when the configuration is read, and the runtime hands them to
+	// CEL so that `constants.x` means the same thing in an expression as it
+	// does in an HCL attribute.
+	Constants map[string]interface{}
+
 	// Connectors are all connector configurations.
 	Connectors []*connector.Config
 
@@ -365,6 +371,7 @@ func (c *Configuration) ValidateUniqueNames() error {
 type HCLParser struct {
 	hclParser *hclparse.Parser
 	evalCtx   *hcl.EvalContext
+	constants *Constants
 	registry  *schema.Registry
 }
 
@@ -440,6 +447,14 @@ func isPluginManifest(path string) bool {
 func (p *HCLParser) Parse(ctx context.Context, configDir string) (*Configuration, error) {
 	config := NewConfiguration()
 
+	// The constants first, out of every file, before anything that might use
+	// one is evaluated. A file may refer to a constant another file declares,
+	// and nothing else in Mycel depends on the order files are walked in.
+	if err := p.readConstants(configDir); err != nil {
+		return nil, err
+	}
+	config.Constants = p.constants.Go
+
 	// Walk directory and find all .mycel files
 	err := filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -506,7 +521,19 @@ func (p *HCLParser) ParseFile(ctx context.Context, path string) (*Configuration,
 		return nil, fmt.Errorf("HCL parse error: %s", diags.Error())
 	}
 
+	// A file parsed on its own carries its own constants. Parse() has already
+	// read every file's by the time it gets here, and reading them twice is
+	// refused as a duplicate — so this only runs when nothing has.
+	if p.constants == nil {
+		p.constants = newConstants()
+		if err := collectConstants(p.constants, file.Body, p.evalCtx, path); err != nil {
+			return nil, err
+		}
+		p.applyConstants()
+	}
+
 	config := NewConfiguration()
+	config.Constants = p.constants.Go
 
 	// Decode the body into our schema
 	content, diags := file.Body.Content(rootSchema())
@@ -660,6 +687,7 @@ func rootSchema() *hcl.BodySchema {
 			{Type: "plugin", LabelNames: []string{"name"}},
 			{Type: "saga", LabelNames: []string{"name"}},
 			{Type: "state_machine", LabelNames: []string{"name"}},
+			{Type: "constants"},
 			{Type: "service"},
 			{Type: "mocks"},
 			{Type: "auth"},

--- a/internal/runtime/constants_live_test.go
+++ b/internal/runtime/constants_live_test.go
@@ -1,0 +1,226 @@
+package runtime
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// A constant, against a running service, on both sides of the line.
+//
+// The whole claim of the block is one name that works everywhere: `${...}` in
+// an HCL attribute, which is folded in when the configuration is read, and
+// `constants.x` in a CEL expression, which is evaluated per message. They are
+// two different machines, and a reader should not have to know which one they
+// are writing for — so this exercises one of each in the same service.
+func TestAConstantReachesBothTheQueryAndTheCondition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starting a service")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "data.db")
+	port := freeLocalPort(t)
+	adminPort := freeLocalPort(t)
+
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("constants.mycel", `
+constants {
+  skus_to_skip = ["SKU-1", "SKU-2"]
+  page_size    = 2
+}
+`)
+	write("service.mycel", fmt.Sprintf(`
+connector "api" {
+  type = "rest"
+  port = %d
+}
+
+connector "db" {
+  type     = "database"
+  driver   = "sqlite"
+  database = %q
+}
+
+service {
+  name       = "constants"
+  admin_port = %d
+}
+
+flow "list_items" {
+  from {
+    connector = "api"
+    operation = "GET /items"
+  }
+  to {
+    connector = "db"
+    query     = "SELECT sku FROM items ORDER BY sku LIMIT ${constants.page_size}"
+  }
+}
+
+flow "keep_item" {
+  from {
+    connector = "api"
+    operation = "POST /items"
+  }
+  accept {
+    when      = "!(input.sku in constants.skus_to_skip)"
+    on_reject = "reject"
+  }
+  to {
+    connector = "db"
+    target    = "items"
+  }
+}
+`, port, dbPath, adminPort))
+
+	seed(t, dbPath,
+		`CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, sku TEXT)`,
+		`INSERT INTO items (sku) VALUES ('SEED-1'), ('SEED-2'), ('SEED-3')`)
+
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+
+	// Start serves until the context is cancelled, so it runs beside the test
+	// rather than before it.
+	rt, err := startTestRuntime(ctx, dir)
+	if err != nil {
+		t.Fatalf("runtime: %v", err)
+	}
+	defer func() { _ = rt.Shutdown() }()
+	waitForPort(t, port)
+
+	// HCL: the limit is in the query, folded in when the file was read.
+	var listed []map[string]interface{}
+	get(t, fmt.Sprintf("http://127.0.0.1:%d/items", port), &listed)
+	if len(listed) != 2 {
+		t.Errorf("the query returned %d rows, want the %v the constant sets", len(listed), 2)
+	}
+
+	// CEL: the accept block reads the same constant, per message.
+	if status := post(t, fmt.Sprintf("http://127.0.0.1:%d/items", port), `{"sku":"SKU-1"}`); status >= 500 {
+		t.Errorf("a listed sku answered %d", status)
+	}
+	if status := post(t, fmt.Sprintf("http://127.0.0.1:%d/items", port), `{"sku":"SKU-9"}`); status >= 400 {
+		t.Errorf("a sku the constant does not list answered %d", status)
+	}
+
+	var after []map[string]interface{}
+	get(t, fmt.Sprintf("http://127.0.0.1:%d/items", port), &after)
+
+	stored := storedSKUs(t, dbPath)
+	if contains(stored, "SKU-1") {
+		t.Errorf("a sku the constant lists was written: %v", stored)
+	}
+	if !contains(stored, "SKU-9") {
+		t.Errorf("a sku the constant does not list was refused: %v", stored)
+	}
+}
+
+func freeLocalPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func waitForPort(t *testing.T, port int) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("nothing listening on %d", port)
+}
+
+func get(t *testing.T, url string, into interface{}) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(into); err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+}
+
+func post(t *testing.T, url, body string) int {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+func contains(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func seed(t *testing.T, dbPath string, statements ...string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("%s: %v", statement, err)
+		}
+	}
+}
+
+func storedSKUs(t *testing.T, dbPath string) []string {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT sku FROM items ORDER BY id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var sku string
+		if err := rows.Scan(&sku); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, sku)
+	}
+	return out
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -253,6 +253,10 @@ func New(opts Options) (*Runtime, error) {
 		return nil, fmt.Errorf("failed to parse configuration: %w", err)
 	}
 
+	// The constants, before any flow is registered: a transformer is built as
+	// each flow is wired, and every one of them has to see the same values.
+	transform.SetDefaultConstants(config.Constants)
+
 	// Check each flow's "from" block against its source connector's schema,
 	// so a missing required parameter fails here instead of surfacing later
 	// as a confusing runtime error.
@@ -2573,6 +2577,7 @@ func (r *Runtime) hotReloadSwitch(ctx context.Context) error {
 	newResolver := connector.NewOperationResolver()
 
 	// Update runtime state
+	transform.SetDefaultConstants(newConfig.Constants)
 	r.config = newConfig
 	r.connectors = newRegistry
 	r.operationResolver = newResolver

--- a/internal/transform/cel.go
+++ b/internal/transform/cel.go
@@ -24,6 +24,10 @@ import (
 type CELTransformer struct {
 	env *cel.Env
 
+	// constants declared by const blocks, available to every expression as
+	// `const.<name>`. Empty when the configuration declares none.
+	constants map[string]interface{}
+
 	// Cache compiled programs for reuse
 	mu       sync.RWMutex
 	programs map[string]cel.Program
@@ -48,8 +52,9 @@ func NewCELTransformerWithOptions(additionalOptions ...cel.EnvOption) (*CELTrans
 	}
 
 	return &CELTransformer{
-		env:      env,
-		programs: make(map[string]cel.Program),
+		constants: defaultConstantsSnapshot(),
+		env:       env,
+		programs:  make(map[string]cel.Program),
 	}, nil
 }
 
@@ -64,6 +69,11 @@ func baseCELOptions() []cel.EnvOption {
 		ext.Sets(),     // sets.contains, sets.equivalent, sets.intersects
 
 		// Input variable - the request data
+		// Values a constants block declared. Always in scope, empty when nothing
+		// declared any, so an expression naming a constant that does not exist
+		// says "no such key" rather than refusing to compile.
+		cel.Variable("constants", cel.MapType(cel.StringType, cel.DynType)),
+
 		cel.Variable("input", cel.MapType(cel.StringType, cel.DynType)),
 
 		// Output variable - for referencing already-set output fields
@@ -957,7 +967,7 @@ func (t *CELTransformer) Evaluate(ctx context.Context, expr string, input map[st
 	}
 
 	// Evaluate
-	result, _, err := prog.Eval(activation)
+	result, _, err := t.eval(prog, activation)
 	if err != nil {
 		return nil, fmt.Errorf("CEL eval error: %w", err)
 	}
@@ -979,7 +989,7 @@ func (t *CELTransformer) EvaluateWith(ctx context.Context, expr string, activati
 	if err != nil {
 		return nil, err
 	}
-	result, _, err := prog.Eval(activation)
+	result, _, err := t.eval(prog, activation)
 	if err != nil {
 		return nil, fmt.Errorf("CEL eval error: %w", err)
 	}
@@ -1018,7 +1028,7 @@ func (t *CELTransformer) Transform(ctx context.Context, input map[string]interfa
 		}
 
 		// Evaluate with current activation (output grows with each rule)
-		result, _, err := prog.Eval(activation)
+		result, _, err := t.eval(prog, activation)
 		if err != nil {
 			if hook != nil {
 				hook.AfterRule(ctx, i, rule, nil, err)
@@ -1136,7 +1146,7 @@ func (t *CELTransformer) EvaluateExpression(ctx context.Context, input map[strin
 	}
 
 	// Evaluate
-	result, _, err := prog.Eval(activation)
+	result, _, err := t.eval(prog, activation)
 	if err != nil {
 		return nil, fmt.Errorf("CEL eval error: %w", err)
 	}
@@ -1193,7 +1203,7 @@ func (t *CELTransformer) EvaluateExpressionWithOutput(ctx context.Context, input
 		}
 	}
 
-	result, _, err := prog.Eval(activation)
+	result, _, err := t.eval(prog, activation)
 	if err != nil {
 		return nil, fmt.Errorf("CEL eval error: %w", err)
 	}
@@ -1256,7 +1266,7 @@ func (t *CELTransformer) EvaluateExpressionWithSteps(ctx context.Context, input 
 	}
 
 	// Evaluate
-	result, _, err := prog.Eval(activation)
+	result, _, err := t.eval(prog, activation)
 	if err != nil {
 		return nil, fmt.Errorf("CEL eval error: %w", err)
 	}
@@ -1303,7 +1313,7 @@ func (t *CELTransformer) TransformOnError(ctx context.Context, input map[string]
 			return nil, fmt.Errorf("failed to compile expression for %q: %w", rule.Target, err)
 		}
 
-		value, _, err := prog.Eval(activation)
+		value, _, err := t.eval(prog, activation)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate expression for %q: %w", rule.Target, err)
 		}
@@ -1358,7 +1368,7 @@ func (t *CELTransformer) TransformResponse(ctx context.Context, input map[string
 			return nil, fmt.Errorf("failed to compile expression for '%s': %w", rule.Target, err)
 		}
 
-		val, _, err := prog.Eval(activation)
+		val, _, err := t.eval(prog, activation)
 		if err != nil {
 			if hook != nil {
 				hook.AfterRule(ctx, i, rule, nil, err)
@@ -1422,7 +1432,7 @@ func (t *CELTransformer) TransformWithContext(ctx context.Context, input map[str
 		}
 
 		// Evaluate with current activation (output grows with each rule)
-		result, _, err := prog.Eval(activation)
+		result, _, err := t.eval(prog, activation)
 		if err != nil {
 			if hook != nil {
 				hook.AfterRule(ctx, i, rule, nil, err)
@@ -1478,7 +1488,7 @@ func (t *CELTransformer) EvaluateCondition(ctx context.Context, data map[string]
 	}
 
 	// Evaluate
-	result, _, err := prog.Eval(activation)
+	result, _, err := t.eval(prog, activation)
 	if err != nil {
 		return false, fmt.Errorf("CEL condition eval error: %w", err)
 	}
@@ -1570,4 +1580,62 @@ func getRequestedTopFields(inputVal ref.Val) ref.Val {
 	}
 
 	return fieldsVal
+}
+
+// eval runs a compiled expression with the constants in scope.
+//
+// Every evaluation in this package goes through here, which is what makes
+// `constants.batch_size` mean the same thing in a transform, a filter, a dedupe
+// fingerprint and a `when` — the alternative was adding the same key to nine
+// activations and finding out later which one was missed.
+func (t *CELTransformer) eval(prog cel.Program, activation map[string]interface{}) (ref.Val, *cel.EvalDetails, error) {
+	if activation != nil {
+		if _, present := activation["constants"]; !present {
+			activation["constants"] = t.constantsOrEmpty()
+		}
+	}
+	return prog.Eval(activation)
+}
+
+// constantsOrEmpty is what `constants` holds when nothing declared any: an empty
+// map rather than nothing at all, so an expression naming a constant that does
+// not exist says "no such key" instead of failing to compile against an
+// undeclared reference.
+func (t *CELTransformer) constantsOrEmpty() map[string]interface{} {
+	if t.constants == nil {
+		return map[string]interface{}{}
+	}
+	return t.constants
+}
+
+// SetConstants gives one transformer the values a configuration's constants
+// blocks declared.
+func (t *CELTransformer) SetConstants(constants map[string]interface{}) {
+	t.constants = constants
+}
+
+// The constants every transformer built from here on is given.
+//
+// A service has one set of them — they are read once, when the configuration
+// is — and transformers are built in a dozen places as flows are registered.
+// Handing them over here rather than threading them through every constructor
+// is the difference between one line and twelve, and twelve is where one gets
+// missed and a single `when` expression silently has no constants in scope.
+var (
+	defaultConstantsMu sync.RWMutex
+	defaultConstants   map[string]interface{}
+)
+
+// SetDefaultConstants records what constants blocks declared, before any flow
+// is registered.
+func SetDefaultConstants(values map[string]interface{}) {
+	defaultConstantsMu.Lock()
+	defer defaultConstantsMu.Unlock()
+	defaultConstants = values
+}
+
+func defaultConstantsSnapshot() map[string]interface{} {
+	defaultConstantsMu.RLock()
+	defer defaultConstantsMu.RUnlock()
+	return defaultConstants
 }

--- a/internal/transform/constants_test.go
+++ b/internal/transform/constants_test.go
@@ -1,0 +1,106 @@
+package transform
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// A constant is in scope in every expression, not in some of them.
+//
+// The point of the block is one name that works everywhere: a constant that
+// resolved in a query and not in a filter would be worse than no constants at
+// all, because the failure is per-expression and nothing announces it. There
+// are ten places in this package that evaluate an expression, and they all go
+// through one door for that reason.
+func TestAConstantIsInScopeWhereverAnExpressionIs(t *testing.T) {
+	transformer, err := NewCELTransformer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	transformer.SetConstants(map[string]interface{}{
+		"skus_to_skip": []interface{}{"SKU-1", "SKU-2"},
+		"page_size":    25,
+		"region":       "us",
+	})
+
+	input := map[string]interface{}{"sku": "SKU-1", "name": "Widget"}
+
+	// A transform mapping.
+	out, err := transformer.Transform(context.Background(), input, []Rule{
+		{Target: "skipped", Expression: "input.sku in constants.skus_to_skip"},
+		{Target: "region", Expression: "constants.region"},
+		{Target: "half", Expression: "constants.page_size / 2"},
+	})
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	if out["skipped"] != true {
+		t.Errorf("skipped = %#v", out["skipped"])
+	}
+	if out["region"] != "us" {
+		t.Errorf("region = %#v", out["region"])
+	}
+
+	// A condition, which is what a filter, an accept and a `when` all are.
+	// A condition is given the whole activation, so the request goes under
+	// the name the expression uses for it.
+	held, err := transformer.EvaluateCondition(context.Background(),
+		map[string]interface{}{"input": input},
+		"!(input.sku in constants.skus_to_skip)")
+	if err != nil {
+		t.Fatalf("condition: %v", err)
+	}
+	if held {
+		t.Error("the condition let through a sku the constant lists")
+	}
+
+	// A single expression, which is what a key, a fingerprint and a step
+	// parameter are.
+	value, err := transformer.EvaluateExpression(context.Background(), input, nil,
+		"'page:' + string(constants.page_size)")
+	if err != nil {
+		t.Fatalf("expression: %v", err)
+	}
+	if value != "page:25" {
+		t.Errorf("expression = %#v", value)
+	}
+}
+
+// With nothing declared, an expression naming a constant says so rather than
+// refusing to compile against a name that does not exist.
+func TestNamingAConstantThatWasNeverDeclared(t *testing.T) {
+	transformer, err := NewCELTransformer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = transformer.Transform(context.Background(), map[string]interface{}{},
+		[]Rule{{Target: "x", Expression: "constants.nope"}})
+	if err == nil {
+		t.Fatal("naming an undeclared constant was accepted")
+	}
+	if got := err.Error(); !strings.Contains(got, "no such key") && !strings.Contains(got, "nope") {
+		t.Errorf("the error reads %q; it should point at the name", got)
+	}
+}
+
+// And the values a service was given reach a transformer built afterwards,
+// which is how the runtime hands them over: once, before any flow is wired.
+func TestTransformersBuiltAfterwardsGetTheConstants(t *testing.T) {
+	SetDefaultConstants(map[string]interface{}{"region": "nz"})
+	t.Cleanup(func() { SetDefaultConstants(nil) })
+
+	transformer, err := NewCELTransformer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := transformer.Transform(context.Background(), map[string]interface{}{},
+		[]Rule{{Target: "region", Expression: "constants.region"}})
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	if out["region"] != "nz" {
+		t.Errorf("region = %#v, want what the service declared", out["region"])
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Connectors: core-concepts/connectors.md
       - Flows: core-concepts/flows.md
       - Input and Output: core-concepts/input-and-output.md
+      - Constants: core-concepts/constants.md
       - Reusable Blocks: core-concepts/reusable-blocks.md
       - Transforms: core-concepts/transforms.md
       - Types: core-concepts/types.md

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -19,6 +19,7 @@ func BuiltinRootSchemas() []Block {
 		SecuritySchema(),
 		MocksSchema(),
 		CacheDefSchema(),
+		ConstantsSchema(),
 	}
 }
 
@@ -1083,6 +1084,20 @@ func MockConnectorsSchema() Block {
 	return Block{
 		Type: "connectors",
 		Doc:  "Per-connector mock settings, keyed by connector name: db = { latency = \"50ms\" }",
+		Open: true,
+	}
+}
+
+// ConstantsSchema is the block that declares values used in more than one
+// place.
+//
+// Open, because the names are the author's: a constants block holds whatever
+// that configuration needs twice. What it may not hold is a nested block —
+// these are values, not configuration.
+func ConstantsSchema() Block {
+	return Block{
+		Type: "constants",
+		Doc:  "Values declared once and referred to as constants.<name>, in HCL attributes and in CEL expressions alike",
 		Open: true,
 	}
 }


### PR DESCRIPTION
Declare a value once and refer to it by name from anywhere in the configuration.

```hcl
constants {
  skus_to_skip = ["SKU-1", "SKU-2"]
  page_size    = 500
  region       = env("REGION", "us")
}
```

The case that asked for it: a list of SKUs a consumer skips, written into four
queries. Until now there was nowhere to put such a thing — `env()` holds a
string somebody has to parse, and a step fetches it with a call per message.

## One name, two machines

`${constants.page_size}` in a query is HCL's interpolation, folded in when the
configuration is read. `constants.skus_to_skip` in a filter is CEL's, evaluated
per message. They are two different evaluators and a reader should not have to
know which one they are writing for — a constant that resolved in a query and
not in a filter would be worse than having none, because the failure is
per-expression and nothing announces it.

So the values go in front of both: the HCL evaluation context, and every one of
the ten places in `internal/transform` that evaluates an expression, which now
go through a single `eval` for that reason.

They are read in a pass of their own, before anything else, so a flow may use a
constant that a file later in the walk declares — nothing else in Mycel depends
on the order files are read in, and this keeps it that way. Declaring the same
name twice is refused, naming both files.

## Why `constants` and not `const`

`const` and `var` are both **reserved identifiers in CEL**: an expression
naming either does not compile, whatever the environment declares. Found by
trying it, before the name was in anybody's configuration.

## Behaviour change to know about

An attribute whose expression cannot be evaluated used to be **dropped in
silence**. A `to` block whose query named something undeclared ended up with no
query at all — a flow reading an entire table because its `WHERE` clause
evaporated at parse time. It is reported now, which is also what makes an
undeclared constant fail where it is written.

That surfaced one such attribute in the tree: a step in the `format` example
interpolating `${step.save.id}` into an HCL attribute, where `step` is a CEL
variable that does not exist until a message is being handled. That step had
never had an operation at all.

## What is in here

- `constants` blocks: parser, HCL evaluation context, CEL environment, schema.
- `mycel add constants --value page_size=500`, and `mycel validate` lists what
  it found.
- `examples/constants` — three flows, each reading a constant a different way.
  Every command in its README was run.
- Docs: a core-concepts page, the configuration reference, the CLI page,
  `llms.txt`, and the table of context variables in Input and Output.

## Checks

- `go test ./...` and `go vet ./...` clean; `gofmt` clean.
- Integration suite 205/0.
- All 54 examples validate.
- The end-to-end test was verified in reverse: with the runtime not handing the
  constants over, it fails.
