### PR TITLE
Build the release notes from the changelog, and clear two action warnings

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload the coverage profile
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: tests/integration/coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,9 +204,69 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Lifts this version's Breaking and Security sections out of the
+      # changelog so the release page leads with them.
+      #
+      # The 3.0.0 release went out with GitHub's generated notes alone: a list
+      # of pull request titles that said nothing about `mfa { required }`
+      # starting to require it, or about the module path moving to /v3. A major
+      # version exists to make someone read before they upgrade, and the page
+      # they land on has to be the one that tells them.
+      #
+      # Only Breaking and Security are lifted, not the whole section: 3.0.0's
+      # runs to 117 KB against a 125 KB limit on the release body, so a bigger
+      # release would fail to publish. Everything else is one link away.
+      - name: Assemble the release notes
+        id: notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+
+          section=$(awk -v hdr="## [$version]" '
+            index($0, hdr) == 1 { f = 1; next }
+            /^## \[/ { if (f) exit }
+            f { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$(printf '%s' "$section" | tr -d '[:space:]')" ]; then
+            echo "::error::CHANGELOG.md has no section for $version. Add one before tagging." >&2
+            exit 1
+          fi
+
+          warnings=$(printf '%s\n' "$section" | awk '
+            /^### / { keep = ($0 ~ /^### (Breaking|Security)/) }
+            keep
+          ')
+
+          changelog="https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/CHANGELOG.md"
+
+          {
+            if [ -n "$(printf '%s' "$warnings" | tr -d '[:space:]')" ]; then
+              echo "**Read this before upgrading.** The full detail for every change is in [CHANGELOG.md]($changelog)."
+              echo
+              printf '%s\n' "$warnings"
+            else
+              echo "Every change in this release is listed in [CHANGELOG.md]($changelog)."
+            fi
+            echo
+            echo "---"
+            echo
+          } > release-notes.md
+
+          size=$(wc -c < release-notes.md)
+          echo "Assembled $size bytes of notes for $version."
+          # The generated pull request list is appended to this by the API, so
+          # leave room for it under the 125,000 character ceiling.
+          if [ "$size" -gt 100000 ]; then
+            echo "::error::Release notes are $size bytes; the release body caps at 125,000." >&2
+            exit 1
+          fi
+
+      # `body_path` with `generate_release_notes` puts the changelog warnings
+      # first and GitHub's generated pull request list underneath.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          body_path: release-notes.md
           generate_release_notes: true
 
   # Keeps the Homebrew tap pointing at the release just published.
@@ -304,7 +364,10 @@ jobs:
       - name: Build archives and packages
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          # `latest` warns that it locks to the current major anyway. Naming
+          # the major keeps the pin and drops the warning; .goreleaser.yml
+          # declares `version: 2`, which is that same major.
+          version: "~> v2"
           args: release --clean
 
       - name: Attach to release


### PR DESCRIPTION
## The release notes

3.0.0 went out with GitHub's generated notes alone — a list of pull request titles that said nothing about `mfa { required = "true" }` starting to require it, or about the module path moving to `/v3`. A major version exists to make someone read before they upgrade, and the page they land on has to be the one that tells them. [That release was corrected by hand](https://github.com/matutetandil/mycel/releases/tag/v3.0.0), which is the part that does not survive to the next one.

`create-release` now lifts this version's **Breaking** and **Security** sections out of `CHANGELOG.md` and passes them as `body_path`, with `generate_release_notes` still on. The API puts the given body first and the generated pull request list underneath — the layout 3.0.0 ended up with manually.

**Only those two sections, not the whole entry.** 3.0.0's changelog section runs to **117 KB against a 125 KB ceiling** on the release body, so dumping it would have failed to publish on a release only slightly bigger. Everything else is one link away.

Two ways it refuses rather than publishing something wrong:

- A tag whose version has no changelog section fails the job, naming what to add, instead of publishing an empty release.
- The assembled notes are size-checked before they are handed over.

### Verified by running the step's own script the way the runner does (`bash -e`, from the repo root, against the real changelog)

| Tag | Result |
|---|---|
| `v3.0.0` | Breaking section lifted — 3,719 bytes |
| `v2.17.1` | no Breaking, has Security — Security lifted |
| `v2.16.0` | neither — a single link line |
| `v9.9.9` | no section → exit 1, `::error::CHANGELOG.md has no section for 9.9.9. Add one before tagging.` |

## The two warnings

- **Node 20.** `actions/upload-artifact@v4` (integration.yml) declares `node20`, which the runners now force onto Node 24 with a deprecation notice — this was the only one in the four workflows. v5 is also `node20`; **v6 was the first major on Node 24**, and v7 is current. The three inputs used here (`name`, `path`, `if-no-files-found`) are unchanged in v7, and `archive` defaults to the old zip behaviour. Every other action in all four workflows was audited against its `action.yml`: all Node 24 or composite.
- **goreleaser.** `version: latest` warns *"You are using 'latest' as default version. Will lock to '~> v2'."* Naming the major keeps the identical pin without the warning; `.goreleaser.yml` declares `version: 2`, the same major.

All four workflow files parse as valid YAML after the change. Nothing outside `.github/workflows/` is touched.