### PR TITLE
Dedupe that can distrust its own cache, and a drop that stops signalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`compare_when` on the `dedupe` block — dedupe that stops trusting its own cache once the record it describes is gone.** A stored fingerprint says the content was written once; it does not say it is still written. Nothing in dedupe observes the downstream record leaving by a path the flow never sees — an admin deleting it by hand, a restore from an older backup, a data fix — and there is usually no delete flow to clear the fingerprint when it happens. The re-send meant to repair the damage then matches a fingerprint describing something that no longer exists and is acked in milliseconds having written nothing. The optional predicate gates the comparison, and only the comparison: false means the stored fingerprint is not consulted and the message cannot be dropped, while a successful write still commits the new one, so the next message can be. Evaluated against `input.*` and `output.*`, the same scope as the projection, which is what puts a `step` result within reach of it. Absent means always compare, so nothing changes for a flow that does not set it. It fails open — a predicate that cannot be evaluated, or that does not return a boolean, warns and processes the message, the same direction the cache-error path already takes.
+
+  The check has to go here and not in `fingerprint {}`, which is where it naturally gets tried first. A projection field is symmetric: it fires when the record appears as well as when it disappears. And the fingerprint committed after a write is the one computed *before* it, so on a create the stored reading of "does this exist" is `0` by definition while every later message computes `1` — real duplicates stop being suppressed, and the deletion the field was added to catch still matches and still gets dropped. Both directions land backwards. `examples/dedupe` now carries a flow using the gate, the reasoning is in the attribute's own doc comment, and a test runs the wrong version to show what it does.
+
+### Fixed
+
+- **A dropped message no longer emits its coordinate signal.** A signal asserts that the flow applied its effect, and a drop short-circuits before `to`. From the coordinator's side the two were indistinguishable: `dedupe` and `sequence_guard` both return their filtered result with a nil error, and the emit fires whenever the inner call returns no error, so a suppressed message told everything waiting on it to proceed. In the case that found this, a style dropped as a duplicate emitted `parent_ready` anyway; its twelve child items then ran against a parent that did not exist, ten writing nothing and two failing on a foreign key. It could not be worked around in configuration either — the transform has already run by the time `signal.when` is evaluated, so the output it sees on a drop is the same one it sees on a write. A `filter` or `accept` rejection returns before the sync wrappers and was never affected.
+
+- **A step naming a read verb where a table goes no longer looks like a missing table.** The parity test over the examples skips the write verbs by name and read `operation = "query"` as a table called `query`.
+
 ## [3.1.0] - 2026-08-26
 
 ### Breaking

--- a/docs/core-concepts/flows.md
+++ b/docs/core-concepts/flows.md
@@ -858,6 +858,7 @@ flow "process_payment" {
 | `fingerprint {}` | yes | Block of named CEL expressions whose values form the projection; must list every persisted field — omitting one would silently drop real changes |
 | `ttl` | no | How long to keep stored fingerprints. Supports `"30d"` and `"2w"` plus stdlib units; malformed values fail the parse |
 | `on_duplicate` | no | Behavior on match: `"ack"` (default), `"reject"`, `"requeue"` |
+| `compare_when` | no | CEL predicate gating the comparison **only**. False: the stored fingerprint is not consulted, so the message cannot be dropped — but a successful write still commits the new one. `input.*` and `output.*` in scope. Use it when the downstream record can disappear by a path the flow cannot observe; see [`compare_when`](../reference/configuration.md#dedupe-block) for why the check must not go in `fingerprint {}` |
 
 **Pipeline order:** `dedupe` runs **after** `transform` because the fingerprint references `output.*` (the transformed payload). Earlier versions ran the (key-based) dedupe before transform — see CHANGELOG v2.1.0 for migration.
 

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -223,6 +223,53 @@ flow "process_payment" {
 | `fingerprint {}` | block | yes | — | Named CEL expressions whose values form the projection. Both `input.*` and `output.*` (transform result) are in scope. Must list every persisted field — omitting one would silently drop real changes |
 | `ttl` | string | no | — | How long to keep stored fingerprints. Supports `"30d"` and `"2w"` plus stdlib units (`s`/`m`/`h`); malformed values fail the parse |
 | `on_duplicate` | string | no | `"ack"` | Behavior on fingerprint match: `"ack"`, `"reject"`, `"requeue"`. Matches the `sequence_guard` vocabulary so MQ consumers handle it uniformly |
+| `compare_when` | string | no | — | CEL predicate gating Phase A **only**. False: the stored fingerprint is not consulted, so the message cannot be dropped; Phase B still commits after a successful write. `input.*` and `output.*` in scope. See [When the record can vanish](#when-the-record-can-vanish) |
+
+### When the record can vanish
+
+A stored fingerprint says the content was written once. It does not say it is still written. Nothing in dedupe observes the downstream record being removed by a path the flow never sees — a manual delete in an admin UI, a restore, a data fix — and there is usually no flow to clear the fingerprint when that happens. The re-send meant to repair the damage then matches a fingerprint describing a record that no longer exists, and is dropped.
+
+`compare_when` gates the comparison, and only the comparison:
+
+```hcl
+step "check_present" {
+  connector = "db"
+  query     = "SELECT CAST(COALESCE((SELECT 1 FROM products WHERE sku = :sku LIMIT 1), 0) AS SIGNED) AS row_exists"
+  params    = { sku = "input.body.sku" }
+  on_error  = "fail"
+}
+
+transform {
+  row_exists = "int(step.check_present.row_exists)"
+  name       = "input.body.name"
+}
+
+dedupe {
+  cache        = "fp_cache"
+  key          = "'sku_fp:' + input.body.sku"
+  ttl          = "30d"
+  compare_when = "output.row_exists == 1"
+  fingerprint {
+    name = "output.name"
+  }
+}
+```
+
+- **false** → Phase A is skipped entirely: no `GET`, no comparison, no drop. Phase B still runs, so the write commits a fresh fingerprint and the next message *can* be suppressed. Gating both phases would leave the cache empty forever and the primitive permanently inert on the flow.
+- **true** or absent → unchanged behavior.
+- Fails **open**: a predicate that cannot be evaluated, or that does not return a boolean, logs a warning and processes the message. Same direction as the cache-error path — one extra downstream call is recoverable, a silently swallowed message is not.
+
+!!! warning "The existence check goes in `compare_when`, not in `fingerprint {}`"
+    Adding `row_exists` to the projection looks like it should work — record gone, projection differs, message reprocessed — and it does the opposite in both directions.
+
+    Phase A and Phase B share one projection: the fingerprint Phase B stores is the one Phase A computed, i.e. the **pre-write** reading. On a create, "does this record exist" is `0` by definition, so the stored value is `0` forever while every later message computes `1`.
+
+    | situation | stored | computed | result |
+    |---|---|---|---|
+    | record exists, duplicate re-send | 0 | 1 | mismatch → **duplicate reaches the destination** |
+    | record deleted externally, re-send | 0 | 0 | match → **dropped**, which is the case it was added for |
+
+    It breaks suppression exactly where suppression worked, and stays inert exactly where invalidation was needed.
 
 ### Pipeline order
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -928,6 +928,7 @@ dedupe {
   key          = "'sku_fp:' + input.body.payload.productItemId"  # Required: CEL expression for the per-resource key
   ttl          = "30d"                                           # Optional: supports "d" / "w" plus stdlib units; malformed values fail the parse
   on_duplicate = "ack"                                           # Optional: "ack" (default), "reject", "requeue"
+  compare_when = "output.row_exists == 1"                        # Optional: gates the comparison only (see below)
 
   fingerprint {                                                   # Required: at least one named CEL expression
     name   = "output.name"                                        # Both input.* and output.* (transform result) are in scope
@@ -938,6 +939,48 @@ dedupe {
 ```
 
 **Pipeline order:** `dedupe` runs **after** `transform` because the fingerprint expressions reference `output.*`. Earlier versions (≤ 2.0.0) ran a key-based dedupe before transform; see CHANGELOG v2.1.0 for migration.
+
+**`compare_when` — when "already seen" and "already applied" diverge.** A stored fingerprint says this content was written once, not that it is still written. If the downstream record can disappear by a path the flow never observes — a manual delete, a restore, a data fix — nothing clears the fingerprint, and the re-send that was meant to repair the damage is dropped as a duplicate instead. `compare_when` is how a flow says the stored fingerprint is no longer trustworthy:
+
+- **false** → the stored fingerprint is not consulted and the message **cannot** be dropped. It still writes, and Phase B still commits the new fingerprint, so the *next* message can be suppressed normally.
+- **true** or absent → exactly the behavior above.
+- Evaluated against `input.*` and `output.*`, the same scope as `fingerprint {}` — so a `step` result routed through `transform` is reachable from it.
+- Fails **open**: a predicate that cannot be evaluated (or does not return a boolean) logs a warning and processes the message, matching the fail-open convention for cache errors. One extra downstream call is recoverable; a silently swallowed message is not.
+
+!!! warning "Put the existence check in `compare_when`, never in `fingerprint {}`"
+    A projection field is symmetric: it fires when the record disappears **and** when it appears. The fingerprint committed after a write is the one computed *before* it, so on a create the stored reading of "does this exist" is always `0` while every later message computes `1`. Both directions land backwards — real duplicates stop being suppressed, and the deletion the field was added to catch still matches and still gets dropped.
+
+```hcl
+step "check_present" {
+  connector = "db"
+  query     = "SELECT CAST(COALESCE((SELECT 1 FROM products WHERE sku = :sku LIMIT 1), 0) AS SIGNED) AS row_exists"
+  params    = { sku = "input.body.sku" }
+  on_error  = "fail"
+}
+
+transform {
+  row_exists = "int(step.check_present.row_exists)"
+  # ... the fields actually written downstream
+}
+
+dedupe {
+  cache        = "redis_cache"
+  key          = "'sku_fp:' + input.body.sku"
+  ttl          = "30d"
+  compare_when = "output.row_exists == 1"
+  fingerprint {
+    name = "output.name"
+    # row_exists deliberately NOT here — it is a gate, not a hash input
+  }
+}
+```
+
+| situation | gate | outcome |
+|---|---|---|
+| record present, identical content | compare | dropped as a duplicate |
+| record present, content changed | compare | fingerprint differs → processed |
+| first write, record absent | skip | processed → Phase B stores the fingerprint |
+| record deleted externally, identical content | skip | **processed and rewritten** |
 
 **Canonical encoding rules:** map keys sorted alphabetically; array elements sorted by their encoded bytes (treated as order-insensitive sets); each value type-tagged and length-prefixed so `"a,b"` cannot collide with `["a","b"]`; whole-number floats normalize to ints.
 

--- a/examples/dedupe/README.md
+++ b/examples/dedupe/README.md
@@ -102,6 +102,84 @@ transform {
 Audit every array field in your `fingerprint {}` for order sensitivity
 before going to production.
 
+## When the record can vanish: `compare_when`
+
+A stored fingerprint says this content was written once. It does not say it is
+still written.
+
+Nothing in dedupe observes the downstream record being removed by a path the
+flow never sees — a manual delete, a restore from an older backup, a data fix —
+and there is usually no delete flow to clear the fingerprint when it happens.
+The re-send meant to repair the damage then matches a fingerprint describing a
+record that no longer exists, and is dropped in milliseconds having written
+nothing. Anything downstream that was waiting on that write proceeds against a
+record that is not there.
+
+`item_create_with_existence_gate.mycel` closes that hole. A step asks the one
+question the message cannot answer, and `compare_when` gates the comparison on
+it:
+
+```hcl
+step "check_present" {
+  connector = "catalog"
+  query     = "SELECT CAST(COALESCE((SELECT 1 FROM catalog_items WHERE sku = :sku LIMIT 1), 0) AS SIGNED) AS row_exists"
+  params    = { sku = "input.body.payload.productItemId" }
+  on_error  = "fail"
+}
+
+transform {
+  row_exists = "int(step.check_present.row_exists)"
+  # ... the fields actually written downstream
+}
+
+dedupe {
+  cache        = "fp_cache"
+  key          = "'sku_fp:' + input.body.payload.productItemId"
+  compare_when = "output.row_exists == 1"
+  fingerprint {
+    sku  = "output.sku"
+    name = "output.name"
+  }
+}
+```
+
+| situation | gate | outcome |
+|---|---|---|
+| record present, identical content | compare | dropped as a duplicate |
+| record present, content changed | compare | fingerprint differs → processed |
+| first write, record absent | skip | processed → the new fingerprint is stored |
+| record deleted externally, identical content | skip | **processed and rewritten** |
+
+Two properties are load-bearing:
+
+- **Only the comparison is gated.** The new fingerprint is still committed
+  after a successful write. Gating that too would leave the cache empty
+  forever, so no later message could be suppressed either and the primitive
+  would be permanently inert on this flow.
+- **It fails open.** A predicate that cannot be evaluated, or that returns
+  something other than a boolean, logs a warning and processes the message.
+  One extra downstream call is recoverable; a silently swallowed message is
+  not.
+
+### ⚠️ The existence check does not go in `fingerprint {}`
+
+Adding `row_exists` to the projection looks like it should do the same job —
+record gone, projection differs, message reprocessed — and it does the opposite
+in both directions.
+
+Phase A and Phase B share one projection: the fingerprint Phase B stores is the
+one Phase A computed, i.e. the **pre-write** reading. On a create, "does this
+record exist" is `0` by definition, so the stored value stays `0` forever while
+every later message computes `1`.
+
+| situation | stored | computed | result |
+|---|---|---|---|
+| record exists, duplicate re-send | 0 | 1 | mismatch → **the duplicate reaches the downstream** |
+| record deleted externally, re-send | 0 | 0 | match → **dropped**, which is the case it was added for |
+
+It breaks suppression exactly where suppression was working, and stays inert
+exactly where invalidation was needed. Put the check in `compare_when`.
+
 ## Composition with other primitives
 
 The flow combines several primitives that together make dedupe
@@ -125,14 +203,21 @@ full effectiveness in a clustered deployment.
 | File | Description |
 |------|-------------|
 | `config.mycel` | Service configuration |
-| `connectors.mycel` | RabbitMQ, Magento HTTP, and the in-memory cache for fingerprints |
+| `connectors.mycel` | RabbitMQ, Magento HTTP, the in-memory cache for fingerprints, and the catalog the existence gate reads |
 | `item_update_with_dedupe.mycel` | The `item_update_with_dedupe` flow |
+| `item_create_with_existence_gate.mycel` | The `item_create_with_existence_gate` flow — dedupe with `compare_when` |
+| `migrations/001_catalog.sql` | The catalog table the existence gate reads |
 
 ## Run locally
 
 ```bash
 export RABBITMQ_URL="amqp://guest:guest@localhost:5672/"
 export MAGENTO_URL="https://your-magento.example.com"
+
+# Creates the catalog table the existence gate reads. Without it the
+# check_present step fails and the create flow retries instead of starting.
+mycel migrate --config ./examples/dedupe
+
 mycel start --config ./examples/dedupe
 ```
 

--- a/examples/dedupe/connectors.mycel
+++ b/examples/dedupe/connectors.mycel
@@ -41,3 +41,15 @@ connector "magento" {
   base_url = env("MAGENTO_URL", "https://be.dev.mercury.waterworks.com")
   timeout  = "30s"
 }
+
+// The catalog the downstream writes into, read here only to answer one
+// question: does the record this message describes still exist?
+//
+// That question is what `compare_when` on the second flow needs, and it is
+// deliberately NOT answerable from the message: the whole point is that the
+// record can disappear by a path this consumer never sees.
+connector "catalog" {
+  type     = "database"
+  driver   = "sqlite"
+  database = env("CATALOG_DB", "./data/catalog.db")
+}

--- a/examples/dedupe/item_create_with_existence_gate.mycel
+++ b/examples/dedupe/item_create_with_existence_gate.mycel
@@ -1,0 +1,103 @@
+// Example: dedupe that stops trusting its own cache once the record it
+// describes is gone.
+//
+// The flow next door drops a message whose content matches the last content
+// written for the same key. That is the right answer while the write it
+// remembers is still in place. It stops being the right answer the moment the
+// record leaves the downstream by a path this consumer never sees — an admin
+// deleting it by hand, a restore from an older backup, a data fix. Nothing
+// clears the fingerprint when that happens, and there is no delete flow to do
+// it, so the re-send meant to repair the damage matches a fingerprint
+// describing something that no longer exists and is acked in milliseconds
+// having written nothing.
+//
+// `compare_when` is how the flow says the stored fingerprint is no longer
+// trustworthy. It gates the comparison, and ONLY the comparison:
+//
+//   false → the stored fingerprint is not consulted, so the message cannot be
+//           dropped. It writes, and the new fingerprint is still committed
+//           afterwards — which is what lets the NEXT message be suppressed.
+//   true  → ordinary dedupe.
+//
+// Gating both phases instead would leave the cache empty forever and the
+// primitive permanently inert on this flow.
+//
+//   from(rabbit) → accept → step(check_present) → transform
+//                → dedupe(compare_when) → to(magento)
+flow "item_create_with_existence_gate" {
+  from {
+    connector = "rabbit"
+    operation = "all.in.magento.q"
+    filter {
+      condition = "input.body.metadata.headers.elementType == 'product' && input.body.metadata.headers.operation == 'create'"
+      on_reject = "requeue"
+    }
+  }
+
+  accept {
+    when      = "has(input.body.payload.productItemId) && input.body.payload.productItemId != ''"
+    on_reject = "reject"
+  }
+
+  // The one thing the message cannot tell us. COALESCE so the query always
+  // returns exactly one row: a step whose query returns a single row comes
+  // back as an object, and `step.check_present.row_exists` would fail to index
+  // a list. on_error = "fail" for the same reason — a `default = []` would
+  // reintroduce the list shape, and a database that is down should retry, not
+  // quietly answer "gone" and send every message downstream.
+  step "check_present" {
+    connector = "catalog"
+      query     = "SELECT CAST(COALESCE((SELECT 1 FROM catalog_items WHERE sku = :sku LIMIT 1), 0) AS SIGNED) AS row_exists"
+    params    = { sku = "input.body.payload.productItemId" }
+    on_error  = "fail"
+  }
+
+  transform {
+    sku  = "input.body.payload.productItemId"
+    name = "trim(input.body.payload.productItemName ?? '')"
+
+    // Carried into output.* so the gate below can read it. It is NOT product
+    // data and it is NOT in the fingerprint — see the note there.
+    row_exists = "int(step.check_present.row_exists)"
+  }
+
+  dedupe {
+    cache        = "fp_cache"
+    key          = "'sku_fp:' + input.body.payload.productItemId"
+    ttl          = "30d"
+    on_duplicate = "ack"
+
+    // Only suppress duplicates while the record this fingerprint describes is
+    // still there.
+    compare_when = "output.row_exists == 1"
+
+    fingerprint {
+      sku  = "output.sku"
+      name = "output.name"
+
+      // row_exists deliberately absent. Putting the existence check in the
+      // projection is the mistake this attribute exists to avoid: a projection
+      // field is symmetric, so it fires when the record APPEARS as well. The
+      // fingerprint committed after a write is the one computed BEFORE it, so
+      // on a create the stored reading is always 0 while every later message
+      // computes 1 — duplicates stop being suppressed, and the deletion the
+      // field was added to catch still matches and still gets dropped. Both
+      // directions land backwards.
+    }
+  }
+
+  to {
+    connector = "magento"
+    target    = "/rest/V1/mercury/products/items"
+    operation = "POST"
+    envelope  = "productData"
+  }
+
+  error_handling {
+    retry {
+      attempts = 3
+      delay    = "2s"
+      backoff  = "exponential"
+    }
+  }
+}

--- a/examples/dedupe/migrations/001_catalog.sql
+++ b/examples/dedupe/migrations/001_catalog.sql
@@ -1,0 +1,11 @@
+-- The catalog table the existence gate reads.
+--
+-- Applied with `mycel migrate --config .` before starting. In a real
+-- deployment this is the downstream's own schema (Magento's
+-- catalog_product_entity, an ERP's item master), read but never written by
+-- this consumer.
+CREATE TABLE IF NOT EXISTS catalog_items (
+    sku        TEXT PRIMARY KEY,
+    name       TEXT,
+    updated_at TEXT
+);

--- a/internal/examples/tables_test.go
+++ b/internal/examples/tables_test.go
@@ -122,6 +122,16 @@ func TestEveryTableAnExampleNamesIsCreated(t *testing.T) {
 	}
 }
 
+// isReadVerb reports whether a value written where a table goes is one of the
+// verbs a read can name. connector.IsWriteOperation covers the other half.
+func isReadVerb(operation string) bool {
+	switch strings.ToUpper(strings.TrimSpace(operation)) {
+	case "SELECT", "QUERY", "READ", "FIND", "GET", "SCAN", "COUNT":
+		return true
+	}
+	return false
+}
+
 // tablesNamed collects the tables an example's flows read from and write to.
 func tablesNamed(
 	config *parser.Configuration,
@@ -147,8 +157,11 @@ func tablesNamed(
 	// named resolves what a flow wrote where a table goes: either a table, or
 	// the name of an operation the connector declares, which holds one.
 	named := func(connectorName, value string) {
-		// A plain verb is what the flow does, not a name it refers to.
-		if connector.IsWriteOperation(value) || strings.EqualFold(value, "SELECT") {
+		// A plain verb is what the flow does, not a name it refers to. The
+		// read verbs need listing as explicitly as the write ones: read as a
+		// name, `operation = "query"` sent this test looking for a table
+		// called query.
+		if connector.IsWriteOperation(value) || isReadVerb(value) {
 			return
 		}
 		if op, isOperation := operations[connectorName][value]; isOperation {

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -838,6 +838,29 @@ type DedupeConfig struct {
 	// the stored one: "ack" (default), "reject", or "requeue". Matches the
 	// sequence_guard vocabulary so MQ consumers handle it uniformly.
 	OnDuplicate string
+
+	// CompareWhen optionally gates the comparison — and only the comparison.
+	// When set and it evaluates false, the stored fingerprint is not consulted
+	// and the message can never be dropped as a duplicate; the new fingerprint
+	// is still committed after a successful write, so the NEXT message can be.
+	// Evaluated against `input.*` and `output.*`, the same scope as
+	// Fingerprint. Empty means always compare, which is the default.
+	//
+	// Use it when "already seen" and "already applied" can diverge — when the
+	// downstream record can disappear by a path this flow cannot observe (a
+	// manual delete, a restore, a data fix) and nothing clears the fingerprint:
+	//
+	//	compare_when = "output.row_exists == 1"
+	//
+	// Put that existence check HERE, never in Fingerprint. A projection field
+	// is symmetric: it also fires when the record APPEARS, which permanently
+	// breaks suppression on a create. The fingerprint committed after a write
+	// is the one computed BEFORE it, so on a create the stored reading of
+	// "does this exist" is always 0 while every later message computes 1 —
+	// duplicates stop being suppressed, and the deletion the field was added
+	// to catch still matches and still gets dropped. Both directions land
+	// backwards.
+	CompareWhen string
 }
 
 // AsyncConfig defines async execution for a flow.

--- a/internal/parser/dedupe_compare_when_test.go
+++ b/internal/parser/dedupe_compare_when_test.go
@@ -1,0 +1,218 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const compareWhenFlowPrefix = `
+flow "gated" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    cache = "memory_cache"
+    key   = "'sku:' + input.body.sku"
+    ttl   = "30d"
+`
+
+const compareWhenFlowSuffix = `
+    fingerprint {
+      name = "output.name"
+    }
+  }
+  to {
+    connector = "api"
+    operation = "POST"
+    target    = "/styles"
+  }
+}
+`
+
+func parseGatedFlow(t *testing.T, compareWhenLine string) *Configuration {
+	t.Helper()
+	return mustParse(t, compareWhenFlowPrefix+compareWhenLine+compareWhenFlowSuffix)
+}
+
+// TestDedupeCompareWhenQuoted: the ordinary spelling, a quoted CEL string.
+func TestDedupeCompareWhenQuoted(t *testing.T) {
+	cfg := parseGatedFlow(t, `    compare_when = "output.style_exists == 1"`)
+
+	d := cfg.Flows[0].Dedupe
+	if d.CompareWhen != "output.style_exists == 1" {
+		t.Errorf("compare_when: want %q, got %q", "output.style_exists == 1", d.CompareWhen)
+	}
+	// It must not have leaked into the thing it is deliberately NOT part of.
+	if _, ok := d.Fingerprint["style_exists"]; ok {
+		t.Error("compare_when must not add anything to the fingerprint projection")
+	}
+}
+
+// TestDedupeCompareWhenUnquoted: written bare, HCL cannot evaluate it against
+// its own context, so the raw source text is what has to survive — the same
+// path `key` and the fingerprint expressions take.
+func TestDedupeCompareWhenUnquoted(t *testing.T) {
+	cfg := parseGatedFlow(t, `    compare_when = output.style_exists == 1`)
+
+	if got := cfg.Flows[0].Dedupe.CompareWhen; got != "output.style_exists == 1" {
+		t.Errorf("compare_when: want %q, got %q", "output.style_exists == 1", got)
+	}
+}
+
+// TestDedupeCompareWhenAbsentIsEmpty: absent means "always compare", and the
+// runtime distinguishes that from a configured predicate by the empty string.
+func TestDedupeCompareWhenAbsentIsEmpty(t *testing.T) {
+	cfg := parseGatedFlow(t, "")
+
+	if got := cfg.Flows[0].Dedupe.CompareWhen; got != "" {
+		t.Errorf("compare_when should be empty when unset, got %q", got)
+	}
+}
+
+// TestDedupeCompareWhenEmptyStringRejected: an empty predicate is never what
+// anyone means. Silently treating it as "always compare" would make a typo
+// (or an env() that resolved to nothing) look like a working gate.
+func TestDedupeCompareWhenEmptyStringRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := compareWhenFlowPrefix + `    compare_when = ""` + compareWhenFlowSuffix
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.mycel"), []byte(src), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := NewHCLParser().Parse(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("an empty compare_when must be rejected, not silently ignored")
+	}
+	if !strings.Contains(err.Error(), "compare_when") {
+		t.Errorf("the error must name the attribute; got: %v", err)
+	}
+}
+
+// TestNamedDedupeCarriesCompareWhen: a reusable block can carry the gate, so
+// several flows with the same "can this record vanish" story share one
+// definition.
+func TestNamedDedupeCarriesCompareWhen(t *testing.T) {
+	cfg := mustParseDir(t, `
+dedupe "gated_by_existence" {
+  cache        = "memory_cache"
+  key          = "'sku:' + input.body.sku"
+  ttl          = "30d"
+  on_duplicate = "ack"
+  compare_when = "output.style_exists == 1"
+  fingerprint {
+    name = "output.name"
+  }
+}
+
+flow "uses_named" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    use = "dedupe.gated_by_existence"
+  }
+  to {
+    connector = "api"
+    operation = "POST"
+    target    = "/styles"
+  }
+}
+`)
+
+	if len(cfg.NamedDedupes) != 1 || cfg.NamedDedupes[0].CompareWhen != "output.style_exists == 1" {
+		t.Fatalf("named dedupe did not keep compare_when: %+v", cfg.NamedDedupes)
+	}
+	if got := cfg.Flows[0].Dedupe.CompareWhen; got != "output.style_exists == 1" {
+		t.Errorf("a flow referencing the named block must inherit compare_when, got %q", got)
+	}
+}
+
+// TestFlowDedupeOverridesCompareWhen: the same attribute-level override every
+// other dedupe attribute already supports. A flow whose existence check has a
+// different shape reuses the base and replaces just the gate.
+func TestFlowDedupeOverridesCompareWhen(t *testing.T) {
+	cfg := mustParseDir(t, `
+dedupe "base" {
+  cache        = "memory_cache"
+  key          = "'sku:' + input.body.sku"
+  ttl          = "30d"
+  on_duplicate = "ack"
+  compare_when = "output.style_exists == 1"
+  fingerprint {
+    name = "output.name"
+  }
+}
+
+flow "narrower" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    use          = "dedupe.base"
+    compare_when = "output.row_id > 0"
+  }
+  to {
+    connector = "api"
+    operation = "POST"
+    target    = "/items"
+  }
+}
+`)
+
+	d := cfg.Flows[0].Dedupe
+	if d.CompareWhen != "output.row_id > 0" {
+		t.Errorf("inline compare_when must win, got %q", d.CompareWhen)
+	}
+	// And the rest of the base survived the override.
+	if d.Cache != "memory_cache" || d.TTL != "30d" || d.Fingerprint["name"] != "output.name" {
+		t.Errorf("overriding compare_when must not disturb the rest of the base: %+v", d)
+	}
+}
+
+// TestNamedDedupeWithoutCompareWhenKeepsBase: an inline block that does NOT
+// set the gate inherits the base's, rather than clearing it. Getting this
+// backwards would silently disable the gate on every flow that reuses a
+// gated block without restating it.
+func TestNamedDedupeWithoutCompareWhenKeepsBase(t *testing.T) {
+	cfg := mustParseDir(t, `
+dedupe "base" {
+  cache        = "memory_cache"
+  key          = "'sku:' + input.body.sku"
+  ttl          = "30d"
+  on_duplicate = "ack"
+  compare_when = "output.style_exists == 1"
+  fingerprint {
+    name = "output.name"
+  }
+}
+
+flow "inherits" {
+  from {
+    connector = "rabbit"
+    operation = "q"
+  }
+  dedupe {
+    use = "dedupe.base"
+    ttl = "7d"
+  }
+  to {
+    connector = "api"
+    operation = "POST"
+    target    = "/items"
+  }
+}
+`)
+
+	d := cfg.Flows[0].Dedupe
+	if d.CompareWhen != "output.style_exists == 1" {
+		t.Errorf("an override that does not mention compare_when must keep the base's, got %q", d.CompareWhen)
+	}
+	if d.TTL != "7d" {
+		t.Errorf("ttl override: want 7d, got %q", d.TTL)
+	}
+}

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -1539,6 +1539,7 @@ func parseTransformMappings(block *hcl.Block, ctx *hcl.EvalContext) (map[string]
 //	  key          = "input.message_id"
 //	  ttl          = "1h"
 //	  on_duplicate = "ack"
+//	  compare_when = "output.row_exists == 1"  // optional; gates the compare only
 //	  fingerprint { id = "input.body.id" }
 //	}
 //
@@ -1579,6 +1580,7 @@ func parseDedupeBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow
 			{Name: "key"},
 			{Name: "ttl"},
 			{Name: "on_duplicate"},
+			{Name: "compare_when"},
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "fingerprint"},
@@ -1639,6 +1641,21 @@ func parseDedupeBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow
 			return nil, fmt.Errorf("dedupe on_duplicate error: %s", diags.Error())
 		}
 		dedupe.OnDuplicate = stringOrEmpty(val)
+	}
+
+	// compare_when is a CEL predicate, so it is read the same way as `key`:
+	// quoted it evaluates to a string, unquoted it fails to evaluate against
+	// the HCL context and the raw source text is what the runtime needs.
+	if attr, ok := content.Attributes["compare_when"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			dedupe.CompareWhen = extractExpressionText(attr.Expr)
+		} else {
+			dedupe.CompareWhen = stringOrEmpty(val)
+		}
+		if dedupe.CompareWhen == "" {
+			return nil, fmt.Errorf("dedupe compare_when must not be empty — omit the attribute to always compare")
+		}
 	}
 
 	// Parse the fingerprint block — named CEL expressions, same shape as a

--- a/internal/parser/resolve.go
+++ b/internal/parser/resolve.go
@@ -87,6 +87,9 @@ func mergeDedupe(base, inline *flow.DedupeConfig) *flow.DedupeConfig {
 	if inline.OnDuplicate != "" {
 		merged.OnDuplicate = inline.OnDuplicate
 	}
+	if inline.CompareWhen != "" {
+		merged.CompareWhen = inline.CompareWhen
+	}
 	if len(inline.Fingerprint) > 0 {
 		merged.Fingerprint = make(map[string]string, len(base.Fingerprint)+len(inline.Fingerprint))
 		for k, v := range base.Fingerprint {

--- a/internal/runtime/coordinate_signal_drop_test.go
+++ b/internal/runtime/coordinate_signal_drop_test.go
@@ -1,0 +1,220 @@
+package runtime
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/matutetandil/mycel/v3/internal/connector/cache/memory"
+	"github.com/matutetandil/mycel/v3/internal/connector/cache/types"
+	httpconn "github.com/matutetandil/mycel/v3/internal/connector/http"
+	"github.com/matutetandil/mycel/v3/internal/flow"
+	msync "github.com/matutetandil/mycel/v3/internal/sync"
+	"github.com/matutetandil/mycel/v3/internal/transform"
+)
+
+// newSignallingHandler builds a flow that emits a coordinate signal after a
+// successful write, and drops messages through one of the two gates that sit
+// INSIDE the coordinate wrapper (dedupe, sequence_guard).
+//
+// The signal key deliberately reads a field that neither the dedupe key nor
+// the fingerprint projection covers, so a drop and the write that preceded it
+// ask for two different signal keys. That is what makes "did the drop emit?"
+// observable: without it, a false emit would be indistinguishable from the
+// legitimate one already stored.
+func newSignallingHandler(t *testing.T, withDedupe, withSequenceGuard bool) (*FlowHandler, *msync.Manager, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	dest := httpconn.New("api", srv.URL, 0, nil, nil, 1)
+	if err := dest.Connect(context.Background()); err != nil {
+		t.Fatalf("dest.Connect: %v", err)
+	}
+
+	memCache := memory.New("fp_cache", &types.Config{Driver: "memory"})
+	if err := memCache.Connect(context.Background()); err != nil {
+		t.Fatalf("cache connect: %v", err)
+	}
+
+	tr, err := transform.NewCELTransformer()
+	if err != nil {
+		t.Fatalf("transformer: %v", err)
+	}
+	mgr := msync.NewManager()
+
+	cfg := &flow.Config{
+		Name: "signalling_flow",
+		From: &flow.FromConfig{
+			Connector:       "rabbit",
+			ConnectorParams: map[string]interface{}{"target": "q"},
+		},
+		Coordinate: &flow.CoordinateConfig{
+			Storage: &flow.SyncStorageConfig{Driver: "memory"},
+			Timeout: "5s",
+			Signal: &flow.SignalConfig{
+				Emit: "'ready:' + input.body.n",
+				TTL:  "1m",
+			},
+		},
+		Transform: &flow.TransformConfig{
+			Mappings: map[string]string{"sku": "input.body.sku"},
+		},
+		To: &flow.ToConfig{
+			Connector:       "api",
+			ConnectorParams: map[string]interface{}{"target": "/post", "operation": "POST"},
+		},
+	}
+
+	if withDedupe {
+		cfg.Dedupe = &flow.DedupeConfig{
+			Cache:       "fp_cache",
+			Key:         "'sku:' + input.body.sku",
+			OnDuplicate: "ack",
+			// Only the sku: two messages differing solely in `n` are duplicates.
+			Fingerprint: map[string]string{"sku": "output.sku"},
+			TTL:         "1h",
+		}
+	}
+	if withSequenceGuard {
+		cfg.SequenceGuard = &flow.SequenceGuardConfig{
+			Storage:  &flow.SyncStorageConfig{Driver: "memory"},
+			Key:      "'seq:' + input.body.sku",
+			Sequence: "input.body.seq",
+			OnOlder:  "ack",
+			TTL:      "1h",
+		}
+	}
+
+	h := &FlowHandler{
+		Config:      cfg,
+		SourceType:  "mq",
+		Dest:        dest,
+		DedupeCache: memCache,
+		Transformer: tr,
+		SyncManager: mgr,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	return h, mgr, func() {
+		srv.Close()
+		_ = memCache.Close(context.Background())
+		_ = mgr.Close()
+	}
+}
+
+func signalExists(t *testing.T, mgr *msync.Manager, key string) bool {
+	t.Helper()
+	coord, err := mgr.GetCoordinator(context.Background(), &msync.SyncStorageConfig{Driver: "memory"})
+	if err != nil {
+		t.Fatalf("GetCoordinator: %v", err)
+	}
+	ok, err := coord.Exists(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Exists(%q): %v", key, err)
+	}
+	return ok
+}
+
+func assertDropped(t *testing.T, result interface{}, wantReason string) {
+	t.Helper()
+	drop, ok := result.(*flow.FilteredResultWithPolicy)
+	if !ok || !drop.Filtered {
+		t.Fatalf("expected the message to be dropped, got %T (%v)", result, result)
+	}
+	if drop.Reason != wantReason {
+		t.Fatalf("drop reason = %q, want %q", drop.Reason, wantReason)
+	}
+}
+
+// TestCoordinateSignal_NotEmittedOnDedupeDrop is the headline contract: a
+// message suppressed as a duplicate never reached `to`, so it must not tell
+// waiters that its effect landed.
+//
+// Pre-fix, dedupe returned (*FilteredResultWithPolicy, nil) and
+// ExecuteWithCoordinate emits whenever the inner call returns a nil error, so
+// the drop signalled anyway. In production that released children against a
+// parent that had been suppressed and no longer existed downstream.
+func TestCoordinateSignal_NotEmittedOnDedupeDrop(t *testing.T) {
+	h, mgr, done := newSignallingHandler(t, true, false)
+	defer done()
+
+	ctx := context.Background()
+
+	// First delivery writes and legitimately signals.
+	first := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "1"}}
+	if _, err := h.HandleRequest(ctx, first); err != nil {
+		t.Fatalf("first HandleRequest: %v", err)
+	}
+	if !signalExists(t, mgr, "ready:1") {
+		t.Fatal("a successful write must emit its signal; ready:1 missing")
+	}
+
+	// Same content, so a duplicate — but a different signal key, so an emit
+	// from the drop is visible rather than masked by the one above.
+	second := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "2"}}
+	result, err := h.HandleRequest(ctx, second)
+	if err != nil {
+		t.Fatalf("second HandleRequest: %v", err)
+	}
+	assertDropped(t, result, "dedupe_match")
+
+	if signalExists(t, mgr, "ready:2") {
+		t.Fatal("a dedupe-dropped message emitted its coordinate signal: nothing was written, so waiters were released against an effect that never happened")
+	}
+}
+
+// TestCoordinateSignal_NotEmittedOnSequenceGuardDrop: the same gate, reached
+// through the other primitive that returns a drop with a nil error.
+func TestCoordinateSignal_NotEmittedOnSequenceGuardDrop(t *testing.T) {
+	h, mgr, done := newSignallingHandler(t, false, true)
+	defer done()
+
+	ctx := context.Background()
+
+	newer := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "1", "seq": 20}}
+	if _, err := h.HandleRequest(ctx, newer); err != nil {
+		t.Fatalf("first HandleRequest: %v", err)
+	}
+	if !signalExists(t, mgr, "ready:1") {
+		t.Fatal("a successful write must emit its signal; ready:1 missing")
+	}
+
+	older := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "2", "seq": 10}}
+	result, err := h.HandleRequest(ctx, older)
+	if err != nil {
+		t.Fatalf("second HandleRequest: %v", err)
+	}
+	assertDropped(t, result, "sequence_older")
+
+	if signalExists(t, mgr, "ready:2") {
+		t.Fatal("an out-of-order message emitted its coordinate signal despite writing nothing")
+	}
+}
+
+// TestCoordinateSignal_StillEmittedOnSuccess guards the other direction: the
+// fix must not make the signal conditional on anything but the drop, or every
+// coordinate-based handoff stops working.
+func TestCoordinateSignal_StillEmittedOnSuccess(t *testing.T) {
+	h, mgr, done := newSignallingHandler(t, true, false)
+	defer done()
+
+	ctx := context.Background()
+
+	for _, sku := range []string{"A", "B"} {
+		input := map[string]interface{}{"body": map[string]interface{}{"sku": sku, "n": sku}}
+		if _, err := h.HandleRequest(ctx, input); err != nil {
+			t.Fatalf("HandleRequest(%s): %v", sku, err)
+		}
+		if !signalExists(t, mgr, "ready:"+sku) {
+			t.Fatalf("distinct content must still signal; ready:%s missing", sku)
+		}
+	}
+}

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -5,7 +5,9 @@
 //	Phase A (before `to`): compute a canonical fingerprint over the named
 //	    projection, GET the previously stored fingerprint for the key, and
 //	    compare byte-for-byte. On match the message is dropped according
-//	    to on_duplicate without invoking `to`.
+//	    to on_duplicate without invoking `to`. Skipped entirely when the
+//	    optional compare_when predicate is false, so a message can never be
+//	    dropped against a fingerprint the flow has declared untrustworthy.
 //
 //	Phase B (after `to`): SET the new fingerprint for the key when the
 //	    message's final disposition is terminal-as-processed — i.e. on a
@@ -29,6 +31,12 @@
 // `to`. Re-sending the same content is a no-op by construction. Cache
 // errors fail open (the message is processed) so a broken Redis cannot
 // silently swallow traffic.
+//
+// That invariant holds over the flow's own writes only. It says the content
+// was applied once, not that it is still applied: nothing here observes a
+// downstream record being removed by a path the flow never sees. compare_when
+// is how a flow says so — see DedupeConfig.CompareWhen for why the check
+// belongs there and not in the projection.
 package runtime
 
 import (
@@ -112,12 +120,57 @@ func (h *FlowHandler) dedupeAwareWrite(
 		Wait:    true,
 	}
 
+	compare := h.shouldCompareDedupe(ctx, input, payload, key)
+
 	// The stage is announced around the whole decision, so a trace shows the
 	// comparison and its verdict, and a breakpoint on dedupe stops before the
 	// fingerprint is looked up rather than never.
 	return trace.RecordStage(ctx, trace.StageDedupe, key, input, func() (interface{}, error) {
-		return h.dedupeDecide(ctx, lockCfg, lockKey, storageKey, key, fp, ttl, cfg, write)
+		return h.dedupeDecide(ctx, lockCfg, lockKey, storageKey, key, fp, ttl, cfg, compare, write)
 	})
+}
+
+// shouldCompareDedupe evaluates the optional compare_when predicate. It gates
+// Phase A only: false means "do not consult the stored fingerprint", never
+// "skip dedupe". Phase B still commits on a successful write, which is what
+// lets suppression re-establish itself on the next message — gating both
+// phases would leave the cache empty forever and the primitive permanently
+// inert on the flow.
+//
+// Every failure path returns false, i.e. process the message. That is
+// deliberately the opposite of the intuitive choice and matches the fail-open
+// convention the Get error path already follows: the cost of a wrong `false`
+// is one extra downstream call, and the cost of a wrong `true` is a message
+// silently swallowed.
+func (h *FlowHandler) shouldCompareDedupe(ctx context.Context, input, payload map[string]interface{}, key string) bool {
+	expr := h.Config.Dedupe.CompareWhen
+	if expr == "" {
+		return true
+	}
+	val, err := h.Transformer.EvaluateExpressionWithOutput(ctx, input, payload, expr)
+	if err != nil {
+		slog.Warn("dedupe compare_when evaluation failed; not comparing, message will be processed",
+			"flow", h.Config.Name,
+			"key", key,
+			"expression", expr,
+			"error", err)
+		return false
+	}
+	b, ok := val.(bool)
+	if !ok {
+		slog.Warn("dedupe compare_when did not evaluate to a boolean; not comparing, message will be processed",
+			"flow", h.Config.Name,
+			"key", key,
+			"expression", expr,
+			"value", val)
+		return false
+	}
+	if !b {
+		slog.Debug("dedupe comparison skipped by compare_when",
+			"flow", h.Config.Name,
+			"key", key)
+	}
+	return b
 }
 
 func (h *FlowHandler) dedupeDecide(
@@ -127,29 +180,32 @@ func (h *FlowHandler) dedupeDecide(
 	fp []byte,
 	ttl time.Duration,
 	cfg *flow.DedupeConfig,
+	compare bool,
 	write func() (interface{}, error),
 ) (interface{}, error) {
 	return h.SyncManager.ExecuteWithLock(ctx, lockCfg, lockKey, func() (interface{}, error) {
-		// Phase A: GET stored, compare.
-		stored, found, getErr := h.DedupeCache.Get(ctx, storageKey)
-		if getErr != nil {
-			// Fail open: cache errors should never block message processing.
-			// Worst case is one extra downstream call.
-			slog.Warn("dedupe Get failed; proceeding with message",
-				"flow", h.Config.Name,
-				"key", key,
-				"error", getErr)
-		} else if found && bytes.Equal(stored, fp) {
-			slog.Info("dedupe match; dropping duplicate",
-				"flow", h.Config.Name,
-				"key", key,
-				"policy", cfg.OnDuplicate)
-			return &flow.FilteredResultWithPolicy{
-				Filtered: true,
-				Policy:   cfg.OnDuplicate,
-				Reason:   "dedupe_match",
-				Detail:   fmt.Sprintf("key %q already seen within the dedupe window", key),
-			}, nil
+		// Phase A: GET stored, compare — unless the flow gated it.
+		if compare {
+			stored, found, getErr := h.DedupeCache.Get(ctx, storageKey)
+			if getErr != nil {
+				// Fail open: cache errors should never block message processing.
+				// Worst case is one extra downstream call.
+				slog.Warn("dedupe Get failed; proceeding with message",
+					"flow", h.Config.Name,
+					"key", key,
+					"error", getErr)
+			} else if found && bytes.Equal(stored, fp) {
+				slog.Info("dedupe match; dropping duplicate",
+					"flow", h.Config.Name,
+					"key", key,
+					"policy", cfg.OnDuplicate)
+				return &flow.FilteredResultWithPolicy{
+					Filtered: true,
+					Policy:   cfg.OnDuplicate,
+					Reason:   "dedupe_match",
+					Detail:   fmt.Sprintf("key %q already seen within the dedupe window", key),
+				}, nil
+			}
 		}
 
 		// Not a duplicate — run the actual write.

--- a/internal/runtime/dedupe_compare_when_test.go
+++ b/internal/runtime/dedupe_compare_when_test.go
@@ -1,0 +1,462 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/matutetandil/mycel/v3/internal/connector"
+	"github.com/matutetandil/mycel/v3/internal/connector/cache/memory"
+	"github.com/matutetandil/mycel/v3/internal/connector/cache/types"
+	"github.com/matutetandil/mycel/v3/internal/flow"
+	msync "github.com/matutetandil/mycel/v3/internal/sync"
+	"github.com/matutetandil/mycel/v3/internal/transform"
+)
+
+// newCompareWhenHandler builds the shape compare_when exists for: a flow whose
+// downstream record can vanish by a path it never observes, so a step reports
+// whether the record is still there and the dedupe gate reads that report.
+//
+// The existence field lives ONLY in compare_when. Putting it in the projection
+// instead is the trap this attribute is here to avoid, and
+// TestDedupe_ExistenceInFingerprintIsTheTrap below demonstrates why.
+func newCompareWhenHandler(t *testing.T, compareWhen string) (*FlowHandler, *bytes.Buffer, func()) {
+	t.Helper()
+
+	memCache := memory.New("fp_cache", &types.Config{Driver: "memory"})
+	if err := memCache.Connect(context.Background()); err != nil {
+		t.Fatalf("cache connect: %v", err)
+	}
+	mgr := msync.NewManager()
+	tr, err := transform.NewCELTransformer()
+	if err != nil {
+		t.Fatalf("transformer: %v", err)
+	}
+
+	logs := &bytes.Buffer{}
+
+	h := &FlowHandler{
+		Config: &flow.Config{
+			Name: "compare_when_flow",
+			From: &flow.FromConfig{Connector: "rabbit"},
+			Dedupe: &flow.DedupeConfig{
+				Cache:       "fp_cache",
+				Key:         "'sku:' + input.sku",
+				OnDuplicate: "ack",
+				CompareWhen: compareWhen,
+				Fingerprint: map[string]string{"name": "output.name"},
+				TTL:         "1h",
+			},
+		},
+		DedupeCache: memCache,
+		SyncManager: mgr,
+		Transformer: tr,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return h, logs, func() {
+		_ = memCache.Close(context.Background())
+		_ = mgr.Close()
+	}
+}
+
+// countingWrite returns a write closure plus a live counter of its calls.
+func countingWrite() (func() (interface{}, error), *int32) {
+	var calls int32
+	return func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return &connector.Result{Affected: 1}, nil
+	}, &calls
+}
+
+func isDrop(result interface{}) bool {
+	drop, ok := result.(*flow.FilteredResultWithPolicy)
+	return ok && drop.Filtered
+}
+
+// storedFingerprint reads what Phase B committed, so a test can assert the
+// cache was written even on a run where the comparison never happened.
+func storedFingerprint(t *testing.T, h *FlowHandler, key string) []byte {
+	t.Helper()
+	v, found, err := h.DedupeCache.Get(context.Background(), dedupeStorageKey(h.Config.Name, key))
+	if err != nil {
+		t.Fatalf("cache Get: %v", err)
+	}
+	if !found {
+		return nil
+	}
+	return v
+}
+
+// TestDedupe_CompareWhenAbsent_UnchangedBehaviour: the attribute is additive,
+// so a flow that does not set it must behave exactly as before.
+func TestDedupe_CompareWhenAbsent_UnchangedBehaviour(t *testing.T) {
+	h, _, done := newCompareWhenHandler(t, "")
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	payload := map[string]interface{}{"name": "Widget"}
+	write, calls := countingWrite()
+
+	if r, err := h.dedupeAwareWrite(context.Background(), input, payload, write); err != nil || isDrop(r) {
+		t.Fatalf("first call: err=%v drop=%v", err, isDrop(r))
+	}
+	r2, err := h.dedupeAwareWrite(context.Background(), input, payload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if !isDrop(r2) {
+		t.Fatal("without compare_when the second identical message must still be dropped")
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("write calls = %d, want 1", got)
+	}
+}
+
+// TestDedupe_CompareWhenTrue_DropsDuplicate: the gate open, dedupe behaves
+// normally. This is the steady state the feature is supposed to preserve —
+// the record exists, so a re-send of identical content is suppressed.
+func TestDedupe_CompareWhenTrue_DropsDuplicate(t *testing.T) {
+	h, _, done := newCompareWhenHandler(t, "output.row_exists == 1")
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	present := map[string]interface{}{"name": "Widget", "row_exists": 1}
+	write, calls := countingWrite()
+
+	// Seed the cache through a first pass so there is something to match.
+	if _, err := h.dedupeAwareWrite(context.Background(), input, present, write); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	r2, err := h.dedupeAwareWrite(context.Background(), input, present, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if !isDrop(r2) {
+		t.Fatal("with compare_when true and a matching fingerprint the message must be dropped")
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("write calls = %d, want 1", got)
+	}
+}
+
+// TestDedupe_CompareWhenFalse_ProcessesDespiteMatch is the point of the
+// feature: the stored fingerprint matches byte for byte, and the message is
+// processed anyway because the flow has declared that fingerprint no longer
+// describes anything that exists.
+func TestDedupe_CompareWhenFalse_ProcessesDespiteMatch(t *testing.T) {
+	h, _, done := newCompareWhenHandler(t, "output.row_exists == 1")
+	defer done()
+
+	input := map[string]interface{}{"sku": "X1"}
+	write, calls := countingWrite()
+
+	// Record present: writes and stores the fingerprint.
+	present := map[string]interface{}{"name": "Widget", "row_exists": 1}
+	if _, err := h.dedupeAwareWrite(context.Background(), input, present, write); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Same content — the projection covers `name` only, so the fingerprint is
+	// identical — but the record has since been deleted downstream.
+	gone := map[string]interface{}{"name": "Widget", "row_exists": 0}
+	r2, err := h.dedupeAwareWrite(context.Background(), input, gone, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if isDrop(r2) {
+		t.Fatal("compare_when false must never drop: the record is gone, so the message has to be reprocessed")
+	}
+	if got := atomic.LoadInt32(calls); got != 2 {
+		t.Errorf("write calls = %d, want 2 (the second message must reach the destination)", got)
+	}
+}
+
+// TestDedupe_CompareWhenFalse_StillCommitsPhaseB is the regression that would
+// otherwise break suppression forever: gating both phases would leave the
+// cache un-refreshed, so no later message could ever be suppressed either.
+func TestDedupe_CompareWhenFalse_StillCommitsPhaseB(t *testing.T) {
+	h, _, done := newCompareWhenHandler(t, "output.row_exists == 1")
+	defer done()
+
+	ctx := context.Background()
+	input := map[string]interface{}{"sku": "X1"}
+	write, _ := countingWrite()
+
+	// A run with the gate closed and nothing in the cache.
+	gone := map[string]interface{}{"name": "Widget", "row_exists": 0}
+	if _, err := h.dedupeAwareWrite(ctx, input, gone, write); err != nil {
+		t.Fatalf("gated call: %v", err)
+	}
+	stored := storedFingerprint(t, h, "sku:X1")
+	if stored == nil {
+		t.Fatal("Phase B must commit even when compare_when skipped the comparison, or suppression can never re-establish itself")
+	}
+
+	// And the very next message, with the record now present, is suppressed
+	// against exactly that fingerprint.
+	present := map[string]interface{}{"name": "Widget", "row_exists": 1}
+	r, err := h.dedupeAwareWrite(ctx, input, present, write)
+	if err != nil {
+		t.Fatalf("follow-up call: %v", err)
+	}
+	if !isDrop(r) {
+		t.Fatal("the fingerprint committed on the gated run must suppress the next duplicate")
+	}
+}
+
+// TestDedupe_CompareWhenEvaluationFails_FailsOpen: a broken predicate must
+// process the message, never swallow it. Same direction as the cache-error
+// path: one extra downstream call is recoverable, a silently dropped message
+// is not.
+func TestDedupe_CompareWhenEvaluationFails_FailsOpen(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		expr string
+	}{
+		{"undefined field", "output.no_such_field == 1"},
+		{"not a boolean", "output.name"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, done := newCompareWhenHandler(t, tc.expr)
+			defer done()
+
+			ctx := context.Background()
+			input := map[string]interface{}{"sku": "X1"}
+			payload := map[string]interface{}{"name": "Widget"}
+			write, calls := countingWrite()
+
+			// Seed the cache with a matching fingerprint by hand, so the only
+			// thing standing between this message and a drop is the predicate.
+			fp, err := h.computeDedupeFingerprint(ctx, input, payload)
+			if err != nil {
+				t.Fatalf("fingerprint: %v", err)
+			}
+			if err := h.DedupeCache.Set(ctx, dedupeStorageKey(h.Config.Name, "sku:X1"), fp, 0); err != nil {
+				t.Fatalf("cache Set: %v", err)
+			}
+
+			r, err := h.dedupeAwareWrite(ctx, input, payload, write)
+			if err != nil {
+				t.Fatalf("dedupeAwareWrite: %v", err)
+			}
+			if isDrop(r) {
+				t.Fatal("a compare_when that cannot be evaluated must fail open, not drop the message")
+			}
+			if got := atomic.LoadInt32(calls); got != 1 {
+				t.Errorf("write calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// TestDedupe_CompareWhenSeesTransformOutput: the predicate resolves against
+// the transformed payload, not the raw input — the same scope as the
+// projection, which is what makes a step result reachable from it.
+func TestDedupe_CompareWhenSeesTransformOutput(t *testing.T) {
+	// Reads output.row_exists while input carries the opposite value: if the
+	// scope were wrong, the verdict would flip.
+	h, _, done := newCompareWhenHandler(t, "output.row_exists == 1 && input.sku == 'X1'")
+	defer done()
+
+	ctx := context.Background()
+	input := map[string]interface{}{"sku": "X1", "row_exists": 0}
+	payload := map[string]interface{}{"name": "Widget", "row_exists": 1}
+	write, _ := countingWrite()
+
+	if _, err := h.dedupeAwareWrite(ctx, input, payload, write); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	r, err := h.dedupeAwareWrite(ctx, input, payload, write)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if !isDrop(r) {
+		t.Fatal("compare_when must resolve output.* against the transform result and input.* against the raw input")
+	}
+}
+
+// TestDedupe_CompareWhenFalse_Concurrent: with the gate closed every worker
+// still serializes on the dedupe lock, none of them drops, and the last one
+// out leaves a valid fingerprint behind.
+func TestDedupe_CompareWhenFalse_Concurrent(t *testing.T) {
+	h, _, done := newCompareWhenHandler(t, "output.row_exists == 1")
+	defer done()
+
+	ctx := context.Background()
+	input := map[string]interface{}{"sku": "X1"}
+	payload := map[string]interface{}{"name": "Widget", "row_exists": 0}
+	write, calls := countingWrite()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	drops := int32(0)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := h.dedupeAwareWrite(ctx, input, payload, write)
+			if err != nil {
+				t.Errorf("concurrent call: %v", err)
+				return
+			}
+			if isDrop(r) {
+				atomic.AddInt32(&drops, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if drops != 0 {
+		t.Errorf("compare_when false dropped %d of %d concurrent messages; it must never drop", drops, workers)
+	}
+	if got := atomic.LoadInt32(calls); got != workers {
+		t.Errorf("write calls = %d, want %d", got, workers)
+	}
+	if storedFingerprint(t, h, "sku:X1") == nil {
+		t.Error("the last writer must still leave a fingerprint")
+	}
+}
+
+// TestDedupe_ExistenceInFingerprintIsTheTrap documents, executably, why
+// compare_when exists rather than "just add the existence check to the
+// projection". It is the reasoning in DedupeConfig.CompareWhen, run.
+//
+// Phase B commits the fingerprint Phase A computed, i.e. the PRE-write
+// reading. On a create, "does this record exist" is 0 by definition, so the
+// stored projection says 0 forever while every later message says 1. The
+// field's two directions land backwards: real duplicates stop being
+// suppressed, and the deletion the field was added to catch still matches.
+func TestDedupe_ExistenceInFingerprintIsTheTrap(t *testing.T) {
+	ctx := context.Background()
+	input := map[string]interface{}{"sku": "X1"}
+
+	creating := map[string]interface{}{"name": "Widget", "row_exists": 0}
+	resend := map[string]interface{}{"name": "Widget", "row_exists": 1}
+	afterDelete := map[string]interface{}{"name": "Widget", "row_exists": 0}
+
+	// The mistake: existence as a projection field instead of a gate. Both
+	// branches below start from the same state — one create, which stored a
+	// projection saying the record did not exist — because that is the state
+	// a create flow is permanently in.
+	trapped := func(t *testing.T) (*FlowHandler, func()) {
+		t.Helper()
+		h, _, done := newCompareWhenHandler(t, "")
+		h.Config.Dedupe.Fingerprint["row_exists"] = "output.row_exists"
+		write, _ := countingWrite()
+		if _, err := h.dedupeAwareWrite(ctx, input, creating, write); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		return h, done
+	}
+
+	t.Run("suppression is defeated", func(t *testing.T) {
+		h, done := trapped(t)
+		defer done()
+		write, _ := countingWrite()
+		// Identical content, record now present → computes 1 against a stored
+		// 0 → no match → the duplicate reaches the destination.
+		r, err := h.dedupeAwareWrite(ctx, input, resend, write)
+		if err != nil {
+			t.Fatalf("resend: %v", err)
+		}
+		if isDrop(r) {
+			t.Fatal("guard broke: existence in the projection is supposed to DEFEAT suppression here")
+		}
+	})
+
+	t.Run("the deletion it was added to catch is dropped anyway", func(t *testing.T) {
+		h, done := trapped(t)
+		defer done()
+		write, _ := countingWrite()
+		// Record deleted downstream → computes 0 again → matches the stored 0
+		// → dropped. Exactly the message that had to be reprocessed.
+		r, err := h.dedupeAwareWrite(ctx, input, afterDelete, write)
+		if err != nil {
+			t.Fatalf("after delete: %v", err)
+		}
+		if !isDrop(r) {
+			t.Fatal("guard broke: existence in the projection is supposed to DROP the re-create here")
+		}
+	})
+
+	// The same two messages with the check moved to the gate where it
+	// belongs: suppression works, and the deleted record reprocesses.
+	gated := func(t *testing.T) (*FlowHandler, func()) {
+		t.Helper()
+		h, _, done := newCompareWhenHandler(t, "output.row_exists == 1")
+		write, _ := countingWrite()
+		if _, err := h.dedupeAwareWrite(ctx, input, creating, write); err != nil {
+			t.Fatalf("gated create: %v", err)
+		}
+		return h, done
+	}
+
+	t.Run("gated: duplicate suppressed", func(t *testing.T) {
+		h, done := gated(t)
+		defer done()
+		write, _ := countingWrite()
+		r, err := h.dedupeAwareWrite(ctx, input, resend, write)
+		if err != nil {
+			t.Fatalf("gated resend: %v", err)
+		}
+		if !isDrop(r) {
+			t.Error("with the check in compare_when, a re-send against an existing record must be suppressed")
+		}
+	})
+
+	t.Run("gated: external delete reprocesses", func(t *testing.T) {
+		h, done := gated(t)
+		defer done()
+		write, calls := countingWrite()
+		r, err := h.dedupeAwareWrite(ctx, input, afterDelete, write)
+		if err != nil {
+			t.Fatalf("gated after delete: %v", err)
+		}
+		if isDrop(r) {
+			t.Error("with the check in compare_when, a re-create after an external delete must be processed")
+		}
+		if got := atomic.LoadInt32(calls); got != 1 {
+			t.Errorf("write calls = %d, want 1", got)
+		}
+	})
+}
+
+// jsonKeys is a small helper asserting the fingerprint is still the canonical
+// encoding of the projection and nothing about compare_when leaked into it.
+func TestDedupe_CompareWhenNotPartOfFingerprint(t *testing.T) {
+	withGate, _, done := newCompareWhenHandler(t, "output.row_exists == 1")
+	defer done()
+	without, _, done2 := newCompareWhenHandler(t, "")
+	defer done2()
+
+	ctx := context.Background()
+	input := map[string]interface{}{"sku": "X1"}
+	payload := map[string]interface{}{"name": "Widget", "row_exists": 1}
+
+	a, err := withGate.computeDedupeFingerprint(ctx, input, payload)
+	if err != nil {
+		t.Fatalf("fingerprint with gate: %v", err)
+	}
+	b, err := without.computeDedupeFingerprint(ctx, input, payload)
+	if err != nil {
+		t.Fatalf("fingerprint without gate: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Errorf("compare_when must not change the fingerprint: %s vs %s", a, b)
+	}
+	// And it really is the projection, not something else.
+	var projection map[string]interface{}
+	if err := json.Unmarshal(a, &projection); err == nil {
+		if _, leaked := projection["row_exists"]; leaked {
+			t.Error("row_exists leaked into the projection")
+		}
+	} else if strings.Contains(string(a), "row_exists") {
+		t.Error("row_exists leaked into the fingerprint bytes")
+	}
+}

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -1449,6 +1449,30 @@ func (h *FlowHandler) executeFlowCore(ctx context.Context, input map[string]inte
 			signalExpr := h.Config.Coordinate.Signal.Emit
 			whenExpr := h.Config.Coordinate.Signal.When
 			signalKeyFn = func(result interface{}) (string, bool) {
+				// A dropped message is not a completed one. The signal is an
+				// assertion that this flow applied its effect, and a drop
+				// short-circuits before `to` — nothing was written, so the
+				// waiters must not be released.
+				//
+				// From the coordinator's side a drop is indistinguishable from
+				// a success: dedupe and sequence_guard return a
+				// FilteredResultWithPolicy with a nil error, so the emit ran
+				// anyway. Downstream that is worse than a missing signal — a
+				// consumer waiting on `parent_ready` proceeded against a parent
+				// that had been suppressed as a duplicate and, in the case that
+				// found this, no longer existed.
+				//
+				// `signal.when` cannot cover this from configuration: the
+				// transform has already run by then, so the output it sees on a
+				// drop is identical to the one it sees on a write.
+				if drop, ok := result.(*flow.FilteredResultWithPolicy); ok && drop.Filtered {
+					slog.Info("coordinate signal skipped",
+						"flow", h.Config.Name,
+						"reason", "message dropped",
+						"drop_reason", drop.Reason,
+						"policy", drop.Policy)
+					return "", false
+				}
 				output := outputSlot.Get()
 				if output == nil {
 					// Fallback to the destination response when no

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -430,6 +430,7 @@ func DedupeSchema() Block {
 			{Name: "key", Doc: "CEL expression for the per-resource fingerprint key (evaluated against input.*)", Type: TypeString},
 			{Name: "ttl", Doc: "How long to keep stored fingerprints after the last update", Type: TypeDuration},
 			{Name: "on_duplicate", Doc: "Behavior on fingerprint match", Type: TypeString, Values: []string{"ack", "reject", "requeue"}},
+			{Name: "compare_when", Doc: "CEL predicate gating the comparison only (input.* and output.* in scope). False: the stored fingerprint is not consulted and the message cannot be dropped, but a successful write still stores the new one. Use for an existence check the fingerprint cannot express; never put that check in fingerprint", Type: TypeString},
 		},
 		Children: []Block{
 			{


### PR DESCRIPTION
Two independent changes to what happens when a message is dropped. Both came out of a report from the Mercury consumers team running 3.1.0 in production, where a style suppressed as a duplicate took twelve child items down with it.

## Do not emit a coordinate signal for a dropped message

A signal asserts that the flow applied its effect. A drop short-circuits before `to`, so nothing was written and the waiters must not be released.

From the coordinator's side a drop was indistinguishable from a success: `dedupe` and `sequence_guard` both return a `FilteredResultWithPolicy` with a **nil error**, and `ExecuteWithCoordinate` emits whenever the inner call returns no error. Both gates sit inside the coordinate wrapper, so both signalled. (A `filter` or `accept` rejection returns before the sync wrappers and was never affected.)

Downstream that is worse than a missing signal. In the case that found this, a style dropped as a duplicate emitted `parent_ready` anyway; its twelve child items then ran against a parent that did not exist — ten wrote nothing, two failed on a foreign key.

It could not be worked around in configuration either: the transform has already run by the time `signal.when` is evaluated, so the output it sees on a drop is identical to the one it sees on a write.

Tests assert both drop paths stay silent and that an ordinary write still signals. The first two fail without the change.

## `compare_when` on the `dedupe` block

A stored fingerprint says this content was written once. It does not say it is **still** written. Nothing in dedupe observes the downstream record leaving by a path the flow never sees — an admin deleting it by hand, a restore from an older backup, a data fix — and there is usually no delete flow to clear the fingerprint when it happens. The re-send meant to repair the damage then matches a fingerprint describing something that no longer exists, and is acked in milliseconds having written nothing.

The new optional predicate gates the comparison, and **only** the comparison:

```hcl
step "check_present" {
  connector = "catalog"
  query     = "SELECT CAST(COALESCE((SELECT 1 FROM catalog_items WHERE sku = :sku LIMIT 1), 0) AS SIGNED) AS row_exists"
  params    = { sku = "input.body.sku" }
  on_error  = "fail"
}

transform {
  row_exists = "int(step.check_present.row_exists)"
}

dedupe {
  cache        = "fp_cache"
  key          = "'sku_fp:' + input.body.sku"
  compare_when = "output.row_exists == 1"
  fingerprint {
    name = "output.name"
  }
}
```

| situation | gate | outcome |
|---|---|---|
| record present, identical content | compare | dropped as a duplicate |
| record present, content changed | compare | fingerprint differs → processed |
| first write, record absent | skip | processed → the new fingerprint is stored |
| record deleted externally, identical content | skip | **processed and rewritten** |

Three properties are load-bearing:

- **Only Phase A is gated.** Phase B still commits after a successful write, which is what lets suppression re-establish itself on the next message. Gating both would leave the cache empty forever and the primitive permanently inert on the flow.
- **Absent means always compare**, so a flow that does not set it is unaffected. Additive.
- **It fails open.** A predicate that cannot be evaluated, or that does not return a boolean, warns and processes the message — the same direction the cache-error path already takes. One extra downstream call is recoverable; a silently swallowed message is not.

### The check does not go in `fingerprint {}`

Which is where it gets tried first, and it does the opposite in both directions. A projection field is symmetric: it fires when the record *appears* as well as when it disappears. And the fingerprint committed after a write is the one computed **before** it, so on a create the stored reading of "does this exist" is `0` by definition while every later message computes `1`.

| situation | stored | computed | result |
|---|---|---|---|
| record exists, duplicate re-send | 0 | 1 | mismatch → the duplicate reaches the downstream |
| record deleted externally, re-send | 0 | 0 | match → **dropped**, which is the case it was added for |

It breaks suppression exactly where suppression was working, and stays inert exactly where invalidation was needed. `TestDedupe_ExistenceInFingerprintIsTheTrap` runs that wrong version, so the reasoning is executable rather than a comment.

## Also

The examples parity test skipped write verbs written where a table goes, but not read verbs, so `operation = "query"` sent it looking for a table called `query`.

## Verification

- `go build`, `go vet`, `gofmt`, `go test ./...` clean.
- Integration suite via `run.sh`: **216 passed, 0 failed**.
- All 65 example directories still validate; `mkdocs build --strict` with no warnings.
- Every new test was confirmed to fail against the unfixed code before being kept.

Documented in `reference/configuration.md`, `guides/caching.md` and the `core-concepts/flows.md` attribute table, with a working flow in `examples/dedupe`.