### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.0] - 2026-08-27
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.1.0"
+	version = "3.2.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.2.0. Two files, two lines: the `[Unreleased]` heading becomes `[3.2.0] - 2026-08-27`, and the version constant in `cmd/mycel/main.go` follows.

Contents, from #71:

- **`compare_when` on the `dedupe` block** — dedupe that stops trusting its own cache once the record it describes is gone. Additive: absent means always compare, so nothing changes for a flow that does not set it.
- **A dropped message no longer emits its coordinate signal** — a drop short-circuits before `to`, so the waiters were being released against an effect that never happened.

Minor rather than patch: `compare_when` is a new attribute. No breaking changes, no security section — so the release notes will carry the changelog link rather than a warning block, which is what the assembly step does when a version has neither (verified against this CHANGELOG by running the step's script).

Pre-tag checks:

- `go.mod` says `go 1.25.0` and both Dockerfiles pin `golang:1.25-alpine` — the mismatch that broke the 2.10.0 release.
- `go mod tidy` leaves `go.mod` and `go.sum` untouched.
- `mycel version` on a binary built from this commit reports 3.2.0.
- All 65 example directories validate; `go test ./...`, `vet` and `gofmt` clean.