### PR TITLE
Read a SQL comment as a comment, and stop warning about a signal a flow chose not to emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **An apostrophe in a SQL comment no longer unbinds every parameter after it.** The binder that rewrites `:name` placeholders into what a driver accepts knew about string literals and nothing else, so a comment was read as if it were code: `-- the item's parent` opened a literal that never closed, and every placeholder past it reached the driver as literal text with no argument bound. The statement failed with `missing named argument "sku"` — naming the parameter, never the comment — and `mycel validate` does not execute SQL, so it passed a query that could not run. It went wrong the other way too, and that one is quieter: `-- ratio:sku` had its colon bound as a placeholder, so a comment consumed one of the statement's arguments and everything after it shifted by one. The scanner now knows the lexical structure that can hide a colon or a quote — line and block comments, string literals, quoted identifiers — and it is one scanner rather than three near-identical copies, one per driver, differing only in whether they wrote `?` or `$1`. Each dialect's own rules come with it: MySQL's `#` comments, its backslash escapes and its requirement that `--` be followed by whitespace; Postgres's nested block comments; SQLite's three ways of quoting an identifier. The same reading now answers "which placeholders does this statement carry", which is used to publish GraphQL arguments — a colon in a comment used to become an argument nothing could ever fill.
+
+- **A flow behaving as written no longer logs as though it were misconfigured.** Deciding not to emit a coordinate signal — because `signal.when` said no, or because the message was dropped before it reached `to` — was reported once by the code that knows the reason and then again by the emitter as `coordinate.signal.emit evaluated to empty key`, which reads as a fault in an expression that is doing its job. The two are now told apart: a deliberate decision is silent at the emitter, and an emit expression that evaluates cleanly to nothing still warns, from the code that can name which expression it was.
+
 ## [3.2.0] - 2026-08-27
 
 ### Added

--- a/docs/reference/destination-properties.md
+++ b/docs/reference/destination-properties.md
@@ -63,6 +63,22 @@ to {
 }
 ```
 
+A placeholder is only recognised where the statement is code. Colons inside a comment, a string literal or a quoted identifier are left exactly as written, and so are Postgres casts:
+
+```sql
+-- ratio:sku is a comment, not a parameter
+SELECT id, 'a:b' AS label, :sku::text
+FROM catalog
+WHERE sku = :sku          -- the item's parent may be promoted
+```
+
+Only the two `:sku` in the `SELECT` and `WHERE` bind; `ratio:sku`, `'a:b'`, and the `::text` cast are untouched. Comments are read per driver, so MySQL's `#` and its rule that `--` needs whitespace after it both apply where they should.
+
+!!! note "Fixed in 3.3.0"
+    Before 3.3.0 the binder knew about string literals and nothing else, so an apostrophe in a comment — `-- the item's parent` — opened a literal that never closed, and **every placeholder after it reached the driver unbound**. The statement failed with `missing named argument`, naming the parameter rather than the comment. In the other direction, `-- ratio:sku` was bound as if it were a placeholder and consumed one of the statement's arguments. `mycel validate` does not execute SQL, so neither showed up there.
+
+A placeholder with no matching value is left as written rather than bound to nothing, so the driver rejects the statement you wrote instead of one with an argument silently missing.
+
 ### Standard operations (no `query`)
 
 Without `query`, the operation is inferred from the HTTP method or set explicitly:

--- a/internal/connector/database/mysql/connector.go
+++ b/internal/connector/database/mysql/connector.go
@@ -549,81 +549,13 @@ func (c *Connector) buildDeleteQuery(data *connector.Data) (string, []interface{
 	return sql, args
 }
 
-// parseNamedParams replaces named parameters (:name) with MySQL positional parameters (?)
-// and returns the modified SQL along with the ordered argument values.
+// parseNamedParams rewrites :name placeholders into MySQL's own and returns
+// the arguments in order. The scan itself is shared: telling a placeholder
+// apart from a colon inside a comment, a string or a quoted identifier is the
+// same problem for every driver, and each of them used to carry its own copy
+// that knew only about string literals. See connector.BindNamedParams.
 func (c *Connector) parseNamedParams(sql string, params map[string]interface{}) (string, []interface{}) {
-	if params == nil || len(params) == 0 {
-		return sql, nil
-	}
-
-	var result strings.Builder
-	var args []interface{}
-	i := 0
-	sqlBytes := []byte(sql)
-	n := len(sqlBytes)
-
-	for i < n {
-		// Check for named parameter starting with :
-		if sqlBytes[i] == ':' {
-			// Find the end of the parameter name
-			j := i + 1
-			for j < n && isParamChar(sqlBytes[j]) {
-				j++
-			}
-
-			if j > i+1 {
-				// Extract parameter name (without the colon)
-				paramName := string(sqlBytes[i+1 : j])
-
-				// Look up the value in params
-				if val, ok := params[paramName]; ok {
-					result.WriteByte('?')
-					args = append(args, val)
-				} else {
-					// Parameter not found - keep the original text
-					result.Write(sqlBytes[i:j])
-				}
-				i = j
-				continue
-			}
-		}
-
-		// Check for string literals - don't replace inside them
-		if sqlBytes[i] == '\'' {
-			// Copy until the closing quote
-			result.WriteByte(sqlBytes[i])
-			i++
-			for i < n {
-				result.WriteByte(sqlBytes[i])
-				if sqlBytes[i] == '\'' {
-					// Check for escaped quote
-					if i+1 < n && sqlBytes[i+1] == '\'' {
-						i++
-						result.WriteByte(sqlBytes[i])
-					} else {
-						i++
-						break
-					}
-				}
-				i++
-			}
-			continue
-		}
-
-		// Regular character - just copy it
-		result.WriteByte(sqlBytes[i])
-		i++
-	}
-
-	return result.String(), args
-}
-
-// isParamChar returns true if the character is valid in a parameter name.
-func isParamChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') ||
-		(c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') ||
-		c == '_'
+	return connector.BindNamedParams(sql, params, connector.MySQLDialect)
 }
 
 // sortedKeys returns a map's keys in a fixed order.

--- a/internal/connector/database/mysql/named_params_test.go
+++ b/internal/connector/database/mysql/named_params_test.go
@@ -1,0 +1,42 @@
+package mysql
+
+import "testing"
+
+// A comment is not code. An apostrophe in one used to open a string literal
+// that never closed, so every placeholder after it reached the driver as
+// literal text with nothing bound — and `mycel validate` could not see it,
+// because it does not execute SQL.
+//
+// The scan itself is shared and tested in internal/connector; this pins the
+// driver to it and to its own placeholder style.
+func TestParseNamedParams_ApostropheInComment(t *testing.T) {
+	c := &Connector{}
+	params := map[string]interface{}{"sku": "X1", "orp": "X1-ORP"}
+
+	sql := "-- the item's parent\nSELECT id FROM t WHERE sku = :sku OR sku = :orp"
+	want := "-- the item's parent\nSELECT id FROM t WHERE sku = ? OR sku = ?"
+
+	got, args := c.parseNamedParams(sql, params)
+	if got != want {
+		t.Errorf("sql:\n  got  %q\n  want %q", got, want)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args = %d, want 2 — the placeholders after the comment were not bound", len(args))
+	}
+	if args[0] != "X1" || args[1] != "X1-ORP" {
+		t.Errorf("args = %v, want [X1 X1-ORP]", args)
+	}
+}
+
+// The other direction: a comment must not consume one of the statement's
+// arguments.
+func TestParseNamedParams_ColonInCommentIsNotAParameter(t *testing.T) {
+	c := &Connector{}
+	got, args := c.parseNamedParams("-- ratio:sku\nSELECT :sku", map[string]interface{}{"sku": "X1"})
+	if want := "-- ratio:sku\nSELECT ?"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if len(args) != 1 {
+		t.Errorf("args = %d, want 1", len(args))
+	}
+}

--- a/internal/connector/database/postgres/connector.go
+++ b/internal/connector/database/postgres/connector.go
@@ -559,87 +559,13 @@ func (c *Connector) buildDeleteQuery(data *connector.Data) (string, []interface{
 	return sql, args
 }
 
-// parseNamedParams replaces named parameters (:name) with PostgreSQL positional parameters ($1, $2, ...)
-// and returns the modified SQL along with the ordered argument values.
-// Example: "SELECT * FROM users WHERE id = :id AND status = :status"
-// With params {"id": 1, "status": "active"}
-// Returns: "SELECT * FROM users WHERE id = $1 AND status = $2", [1, "active"]
+// parseNamedParams rewrites :name placeholders into Postgres's own and returns
+// the arguments in order. The scan itself is shared: telling a placeholder
+// apart from a colon inside a comment, a string or a quoted identifier is the
+// same problem for every driver, and each of them used to carry its own copy
+// that knew only about string literals. See connector.BindNamedParams.
 func (c *Connector) parseNamedParams(sql string, params map[string]interface{}) (string, []interface{}) {
-	if params == nil || len(params) == 0 {
-		return sql, nil
-	}
-
-	var result strings.Builder
-	var args []interface{}
-	argNum := 1
-	i := 0
-	sqlBytes := []byte(sql)
-	n := len(sqlBytes)
-
-	for i < n {
-		// Check for named parameter starting with :
-		if sqlBytes[i] == ':' {
-			// Find the end of the parameter name
-			j := i + 1
-			for j < n && isParamChar(sqlBytes[j]) {
-				j++
-			}
-
-			if j > i+1 {
-				// Extract parameter name (without the colon)
-				paramName := string(sqlBytes[i+1 : j])
-
-				// Look up the value in params
-				if val, ok := params[paramName]; ok {
-					result.WriteString(fmt.Sprintf("$%d", argNum))
-					args = append(args, val)
-					argNum++
-				} else {
-					// Parameter not found - keep the original text
-					// This allows for PostgreSQL-style casts like ::int
-					result.Write(sqlBytes[i:j])
-				}
-				i = j
-				continue
-			}
-		}
-
-		// Check for string literals - don't replace inside them
-		if sqlBytes[i] == '\'' {
-			// Copy until the closing quote
-			result.WriteByte(sqlBytes[i])
-			i++
-			for i < n {
-				result.WriteByte(sqlBytes[i])
-				if sqlBytes[i] == '\'' {
-					// Check for escaped quote
-					if i+1 < n && sqlBytes[i+1] == '\'' {
-						i++
-						result.WriteByte(sqlBytes[i])
-					} else {
-						i++
-						break
-					}
-				}
-				i++
-			}
-			continue
-		}
-
-		// Regular character - just copy it
-		result.WriteByte(sqlBytes[i])
-		i++
-	}
-
-	return result.String(), args
-}
-
-// isParamChar returns true if the character is valid in a parameter name.
-func isParamChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') ||
-		(c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') ||
-		c == '_'
+	return connector.BindNamedParams(sql, params, connector.PostgresDialect)
 }
 
 // sortedKeys returns a map's keys in a fixed order.

--- a/internal/connector/database/postgres/named_params_test.go
+++ b/internal/connector/database/postgres/named_params_test.go
@@ -1,0 +1,42 @@
+package postgres
+
+import "testing"
+
+// A comment is not code. An apostrophe in one used to open a string literal
+// that never closed, so every placeholder after it reached the driver as
+// literal text with nothing bound — and `mycel validate` could not see it,
+// because it does not execute SQL.
+//
+// The scan itself is shared and tested in internal/connector; this pins the
+// driver to it and to its own placeholder style.
+func TestParseNamedParams_ApostropheInComment(t *testing.T) {
+	c := &Connector{}
+	params := map[string]interface{}{"sku": "X1", "orp": "X1-ORP"}
+
+	sql := "-- the item's parent\nSELECT id FROM t WHERE sku = :sku OR sku = :orp"
+	want := "-- the item's parent\nSELECT id FROM t WHERE sku = $1 OR sku = $2"
+
+	got, args := c.parseNamedParams(sql, params)
+	if got != want {
+		t.Errorf("sql:\n  got  %q\n  want %q", got, want)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args = %d, want 2 — the placeholders after the comment were not bound", len(args))
+	}
+	if args[0] != "X1" || args[1] != "X1-ORP" {
+		t.Errorf("args = %v, want [X1 X1-ORP]", args)
+	}
+}
+
+// The other direction: a comment must not consume one of the statement's
+// arguments.
+func TestParseNamedParams_ColonInCommentIsNotAParameter(t *testing.T) {
+	c := &Connector{}
+	got, args := c.parseNamedParams("-- ratio:sku\nSELECT :sku", map[string]interface{}{"sku": "X1"})
+	if want := "-- ratio:sku\nSELECT $1"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if len(args) != 1 {
+		t.Errorf("args = %d, want 1", len(args))
+	}
+}

--- a/internal/connector/database/sqlite/connector.go
+++ b/internal/connector/database/sqlite/connector.go
@@ -422,83 +422,11 @@ func (c *Connector) DB() *sql.DB {
 	return c.db
 }
 
-// parseNamedParams replaces named parameters (:name) with positional parameters (?)
-// and returns the modified SQL along with the ordered argument values.
-// Example: "SELECT * FROM users WHERE id = :id AND status = :status"
-// With params {"id": 1, "status": "active"}
-// Returns: "SELECT * FROM users WHERE id = ? AND status = ?", [1, "active"]
+// parseNamedParams rewrites :name placeholders into SQLite's own and returns
+// the arguments in order. The scan itself is shared: telling a placeholder
+// apart from a colon inside a comment, a string or a quoted identifier is the
+// same problem for every driver, and each of them used to carry its own copy
+// that knew only about string literals. See connector.BindNamedParams.
 func (c *Connector) parseNamedParams(sql string, params map[string]interface{}) (string, []interface{}) {
-	if params == nil || len(params) == 0 {
-		return sql, nil
-	}
-
-	var result strings.Builder
-	var args []interface{}
-	i := 0
-	sqlBytes := []byte(sql)
-	n := len(sqlBytes)
-
-	for i < n {
-		// Check for named parameter starting with :
-		if sqlBytes[i] == ':' {
-			// Find the end of the parameter name
-			j := i + 1
-			for j < n && isParamChar(sqlBytes[j]) {
-				j++
-			}
-
-			if j > i+1 {
-				// Extract parameter name (without the colon)
-				paramName := string(sqlBytes[i+1 : j])
-
-				// Look up the value in params
-				if val, ok := params[paramName]; ok {
-					result.WriteByte('?')
-					args = append(args, val)
-				} else {
-					// Parameter not found - keep the original text
-					// This allows for PostgreSQL-style casts like ::int
-					result.Write(sqlBytes[i:j])
-				}
-				i = j
-				continue
-			}
-		}
-
-		// Check for string literals - don't replace inside them
-		if sqlBytes[i] == '\'' {
-			// Copy until the closing quote
-			result.WriteByte(sqlBytes[i])
-			i++
-			for i < n {
-				result.WriteByte(sqlBytes[i])
-				if sqlBytes[i] == '\'' {
-					// Check for escaped quote
-					if i+1 < n && sqlBytes[i+1] == '\'' {
-						i++
-						result.WriteByte(sqlBytes[i])
-					} else {
-						i++
-						break
-					}
-				}
-				i++
-			}
-			continue
-		}
-
-		// Regular character - just copy it
-		result.WriteByte(sqlBytes[i])
-		i++
-	}
-
-	return result.String(), args
-}
-
-// isParamChar returns true if the character is valid in a parameter name.
-func isParamChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') ||
-		(c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') ||
-		c == '_'
+	return connector.BindNamedParams(sql, params, connector.SQLiteDialect)
 }

--- a/internal/connector/database/sqlite/named_params_test.go
+++ b/internal/connector/database/sqlite/named_params_test.go
@@ -1,0 +1,42 @@
+package sqlite
+
+import "testing"
+
+// A comment is not code. An apostrophe in one used to open a string literal
+// that never closed, so every placeholder after it reached the driver as
+// literal text with nothing bound — and `mycel validate` could not see it,
+// because it does not execute SQL.
+//
+// The scan itself is shared and tested in internal/connector; this pins the
+// driver to it and to its own placeholder style.
+func TestParseNamedParams_ApostropheInComment(t *testing.T) {
+	c := &Connector{}
+	params := map[string]interface{}{"sku": "X1", "orp": "X1-ORP"}
+
+	sql := "-- the item's parent\nSELECT id FROM t WHERE sku = :sku OR sku = :orp"
+	want := "-- the item's parent\nSELECT id FROM t WHERE sku = ? OR sku = ?"
+
+	got, args := c.parseNamedParams(sql, params)
+	if got != want {
+		t.Errorf("sql:\n  got  %q\n  want %q", got, want)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args = %d, want 2 — the placeholders after the comment were not bound", len(args))
+	}
+	if args[0] != "X1" || args[1] != "X1-ORP" {
+		t.Errorf("args = %v, want [X1 X1-ORP]", args)
+	}
+}
+
+// The other direction: a comment must not consume one of the statement's
+// arguments.
+func TestParseNamedParams_ColonInCommentIsNotAParameter(t *testing.T) {
+	c := &Connector{}
+	got, args := c.parseNamedParams("-- ratio:sku\nSELECT :sku", map[string]interface{}{"sku": "X1"})
+	if want := "-- ratio:sku\nSELECT ?"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if len(args) != 1 {
+		t.Errorf("args = %d, want 1", len(args))
+	}
+}

--- a/internal/connector/named_params.go
+++ b/internal/connector/named_params.go
@@ -1,0 +1,306 @@
+package connector
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Named parameter binding for SQL destinations.
+//
+// A query written with :name placeholders has to be rewritten into whatever
+// the driver accepts — `?` for MySQL and SQLite, `$1`, `$2` for Postgres —
+// with the values collected in the order the placeholders appear.
+//
+// Doing that means telling code apart from the parts of a statement that only
+// look like code. Each driver used to carry its own copy of this scanner and
+// each copy knew about exactly one of them, single-quoted strings, so a
+// comment was read as if it were code:
+//
+//	-- the item's parent
+//	SELECT id FROM t WHERE sku = :sku
+//
+// The apostrophe in "item's" opened a string literal that never closed, and
+// every placeholder after it was copied through as literal text — the query
+// reached the driver still saying `:sku`, with no arguments bound. It failed
+// the same way whether or not the comment was the point, and nothing in the
+// message mentioned the comment.
+//
+// It went wrong in the other direction too: `-- ratio:sku` had its `:sku`
+// replaced with a placeholder and an argument appended, so a comment consumed
+// one of the statement's arguments and the rest shifted by one.
+//
+// So the scanner knows the lexical structure that can hide a colon or a quote:
+// line comments, block comments, string literals and quoted identifiers. It is
+// not a SQL parser and does not need to be — it only has to know which
+// stretches of a statement to copy through untouched.
+
+// SQLDialect carries the lexical differences between the drivers. Everything
+// else about the scan is shared.
+type SQLDialect struct {
+	// Placeholder renders the driver's placeholder for the nth argument,
+	// counting from 1.
+	Placeholder func(n int) string
+
+	// HashComments enables `#` to end of line (MySQL).
+	HashComments bool
+
+	// DashDashNeedsSpace requires whitespace after `--` for it to start a
+	// comment (MySQL). Without it `a--b` is subtraction of a negated value,
+	// and reading it as a comment would swallow the rest of the statement —
+	// the failure this scanner exists to prevent, reintroduced elsewhere.
+	DashDashNeedsSpace bool
+
+	// BackslashEscapes treats `\x` inside a string literal as an escaped
+	// character (MySQL, unless NO_BACKSLASH_ESCAPES). Without it `'it\'s'`
+	// ends at the middle quote and the rest of the statement is scanned as
+	// if it were inside a string.
+	BackslashEscapes bool
+
+	// NestedBlockComments lets `/* a /* b */ c */` close only at the last
+	// `*/` (Postgres). Elsewhere the first one closes it.
+	NestedBlockComments bool
+
+	// IdentifierQuotes are the characters that open a quoted identifier,
+	// each paired with what closes it.
+	IdentifierQuotes map[byte]byte
+}
+
+// MySQLDialect: `?` placeholders, `#` comments, backslash escapes, backtick
+// identifiers, and `--` only when followed by whitespace.
+var MySQLDialect = SQLDialect{
+	Placeholder:        func(int) string { return "?" },
+	HashComments:       true,
+	DashDashNeedsSpace: true,
+	BackslashEscapes:   true,
+	IdentifierQuotes:   map[byte]byte{'`': '`', '"': '"'},
+}
+
+// PostgresDialect: `$N` placeholders, nested block comments, double-quoted
+// identifiers.
+var PostgresDialect = SQLDialect{
+	Placeholder:         func(n int) string { return fmt.Sprintf("$%d", n) },
+	NestedBlockComments: true,
+	IdentifierQuotes:    map[byte]byte{'"': '"'},
+}
+
+// SQLiteDialect: `?` placeholders, and the three identifier quotings SQLite
+// accepts.
+var SQLiteDialect = SQLDialect{
+	Placeholder:      func(int) string { return "?" },
+	IdentifierQuotes: map[byte]byte{'"': '"', '`': '`', '[': ']'},
+}
+
+// GenericSQLDialect is for callers that only want to know which placeholders a
+// statement carries and have no driver in hand. It takes the conservative
+// reading of every difference: `--` always comments, `#` never does, block
+// comments do not nest, and the quotings all three drivers agree on.
+var GenericSQLDialect = SQLDialect{
+	Placeholder:      func(int) string { return "?" },
+	IdentifierQuotes: map[byte]byte{'"': '"', '`': '`'},
+}
+
+// BindNamedParams rewrites :name placeholders into the dialect's own and
+// returns the arguments in the order they appear.
+//
+// A placeholder with no matching entry in params is left exactly as written.
+// That is what makes `::int` work — Postgres casts are not parameters — and it
+// leaves a genuine typo visible in the statement the driver rejects rather
+// than turning it into a silently missing argument.
+func BindNamedParams(sql string, params map[string]interface{}, d SQLDialect) (string, []interface{}) {
+	if len(params) == 0 {
+		return sql, nil
+	}
+
+	var out strings.Builder
+	out.Grow(len(sql))
+	var args []interface{}
+	argNum := 1
+
+	s := []byte(sql)
+	n := len(s)
+	i := 0
+
+	for i < n {
+		if skipped := scanSkippable(s, i, d); skipped > i {
+			out.Write(s[i:skipped])
+			i = skipped
+			continue
+		}
+
+		// A cast is two colons, not a parameter named after the second one.
+		if s[i] == ':' && i+1 < n && s[i+1] == ':' {
+			out.WriteString("::")
+			i += 2
+			continue
+		}
+
+		if s[i] == ':' {
+			j := i + 1
+			for j < n && isNamedParamChar(s[j]) {
+				j++
+			}
+			if j > i+1 {
+				name := string(s[i+1 : j])
+				if val, ok := params[name]; ok {
+					out.WriteString(d.Placeholder(argNum))
+					args = append(args, val)
+					argNum++
+				} else {
+					out.Write(s[i:j])
+				}
+				i = j
+				continue
+			}
+		}
+
+		out.WriteByte(s[i])
+		i++
+	}
+
+	return out.String(), args
+}
+
+// NamedParamsIn returns the :name placeholders a statement carries, in order
+// and without repeats, ignoring the ones inside comments, string literals and
+// quoted identifiers.
+func NamedParamsIn(sql string, d SQLDialect) []string {
+	if sql == "" {
+		return nil
+	}
+
+	var out []string
+	seen := map[string]bool{}
+
+	s := []byte(sql)
+	n := len(s)
+	i := 0
+
+	for i < n {
+		if skipped := scanSkippable(s, i, d); skipped > i {
+			i = skipped
+			continue
+		}
+		if s[i] == ':' && i+1 < n && s[i+1] == ':' {
+			i += 2
+			continue
+		}
+		if s[i] == ':' {
+			j := i + 1
+			for j < n && isNamedParamChar(s[j]) {
+				j++
+			}
+			if j > i+1 {
+				if name := string(s[i+1 : j]); !seen[name] {
+					seen[name] = true
+					out = append(out, name)
+				}
+				i = j
+				continue
+			}
+		}
+		i++
+	}
+
+	return out
+}
+
+// scanSkippable reports the index just past the comment, string literal or
+// quoted identifier starting at i, or i itself when nothing starts there.
+// Everything between is copied through verbatim and never scanned for
+// placeholders.
+func scanSkippable(s []byte, i int, d SQLDialect) int {
+	n := len(s)
+
+	// Line comments run to the newline, which is left for the caller so the
+	// statement keeps its shape.
+	lineComment := false
+	switch {
+	case s[i] == '-' && i+1 < n && s[i+1] == '-':
+		// MySQL wants whitespace after the dashes; the others do not.
+		lineComment = !d.DashDashNeedsSpace ||
+			i+2 >= n || s[i+2] == ' ' || s[i+2] == '\t' || s[i+2] == '\n' || s[i+2] == '\r'
+	case d.HashComments && s[i] == '#':
+		lineComment = true
+	}
+	if lineComment {
+		j := i
+		for j < n && s[j] != '\n' {
+			j++
+		}
+		return j
+	}
+
+	// Block comments. An unterminated one runs to the end of the statement,
+	// which is what the driver would do with it too.
+	if s[i] == '/' && i+1 < n && s[i+1] == '*' {
+		depth := 1
+		j := i + 2
+		for j < n {
+			if s[j] == '*' && j+1 < n && s[j+1] == '/' {
+				depth--
+				j += 2
+				if depth == 0 {
+					return j
+				}
+				continue
+			}
+			if d.NestedBlockComments && s[j] == '/' && j+1 < n && s[j+1] == '*' {
+				depth++
+				j += 2
+				continue
+			}
+			j++
+		}
+		return n
+	}
+
+	// String literals. A doubled quote is an escaped one and does not close
+	// the literal; so is a backslash-escaped quote where the dialect allows
+	// backslash escapes.
+	if s[i] == '\'' {
+		j := i + 1
+		for j < n {
+			if d.BackslashEscapes && s[j] == '\\' {
+				j += 2
+				continue
+			}
+			if s[j] == '\'' {
+				if j+1 < n && s[j+1] == '\'' {
+					j += 2
+					continue
+				}
+				return j + 1
+			}
+			j++
+		}
+		return n
+	}
+
+	// Quoted identifiers. A doubled closing character is an escaped one, the
+	// same as in a string; brackets have no escape and simply end at the
+	// first `]`.
+	if closer, ok := d.IdentifierQuotes[s[i]]; ok {
+		j := i + 1
+		for j < n {
+			if s[j] == closer {
+				if closer != ']' && j+1 < n && s[j+1] == closer {
+					j += 2
+					continue
+				}
+				return j + 1
+			}
+			j++
+		}
+		return n
+	}
+
+	return i
+}
+
+// isNamedParamChar reports whether a byte can appear in a :name placeholder.
+func isNamedParamChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_'
+}

--- a/internal/connector/named_params_test.go
+++ b/internal/connector/named_params_test.go
@@ -1,0 +1,290 @@
+package connector
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The reports that produced this scanner, first. An apostrophe in a comment
+// used to open a string literal that never closed, so every placeholder after
+// it reached the driver as literal text with nothing bound; and a colon inside
+// a comment used to be bound as if it were a placeholder, consuming one of the
+// statement's arguments.
+func TestBindNamedParams_CommentsAreNotCode(t *testing.T) {
+	params := map[string]interface{}{"sku": "X1", "orp": "X1-ORP"}
+
+	for _, tc := range []struct {
+		name    string
+		dialect SQLDialect
+		sql     string
+		want    string
+		wantN   int
+	}{
+		{
+			// "the item's parent" — the exact shape reported.
+			name:    "apostrophe in a line comment",
+			dialect: MySQLDialect,
+			sql:     "-- the item's parent\nSELECT id FROM t WHERE sku = :sku",
+			want:    "-- the item's parent\nSELECT id FROM t WHERE sku = ?",
+			wantN:   1,
+		},
+		{
+			name:    "apostrophe in a block comment",
+			dialect: MySQLDialect,
+			sql:     "/* doesn't matter */ SELECT id FROM t WHERE sku = :sku",
+			want:    "/* doesn't matter */ SELECT id FROM t WHERE sku = ?",
+			wantN:   1,
+		},
+		{
+			name:    "apostrophe in a comment between two placeholders",
+			dialect: MySQLDialect,
+			sql:     "SELECT 1 FROM t WHERE sku = :sku -- it's the parent\n  OR sku = :orp",
+			want:    "SELECT 1 FROM t WHERE sku = ? -- it's the parent\n  OR sku = ?",
+			wantN:   2,
+		},
+		{
+			// The other direction: a comment must not consume an argument.
+			name:    "a colon inside a comment is not a placeholder",
+			dialect: MySQLDialect,
+			sql:     "-- ratio:sku\nSELECT id FROM t WHERE sku = :sku",
+			want:    "-- ratio:sku\nSELECT id FROM t WHERE sku = ?",
+			wantN:   1,
+		},
+		{
+			name:    "hash comment (MySQL)",
+			dialect: MySQLDialect,
+			sql:     "# it's fine\nSELECT :sku",
+			want:    "# it's fine\nSELECT ?",
+			wantN:   1,
+		},
+		{
+			name:    "postgres numbers its placeholders across a comment",
+			dialect: PostgresDialect,
+			sql:     "-- the item's parent\nSELECT 1 WHERE sku = :sku OR sku = :orp",
+			want:    "-- the item's parent\nSELECT 1 WHERE sku = $1 OR sku = $2",
+			wantN:   2,
+		},
+		{
+			name:    "sqlite",
+			dialect: SQLiteDialect,
+			sql:     "/* the item's parent */ SELECT 1 WHERE sku = :sku",
+			want:    "/* the item's parent */ SELECT 1 WHERE sku = ?",
+			wantN:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, args := BindNamedParams(tc.sql, params, tc.dialect)
+			if got != tc.want {
+				t.Errorf("sql:\n  got  %q\n  want %q", got, tc.want)
+			}
+			if len(args) != tc.wantN {
+				t.Errorf("args = %d, want %d (%v)", len(args), tc.wantN, args)
+			}
+		})
+	}
+}
+
+// String literals and quoted identifiers keep their existing protection, and
+// gain the escapes each dialect actually uses.
+func TestBindNamedParams_LiteralsAndIdentifiers(t *testing.T) {
+	params := map[string]interface{}{"sku": "X1", "id": 7}
+
+	for _, tc := range []struct {
+		name    string
+		dialect SQLDialect
+		sql     string
+		want    string
+		wantN   int
+	}{
+		{
+			name:    "a colon inside a string is not a placeholder",
+			dialect: MySQLDialect,
+			sql:     "SELECT 'a:sku' WHERE sku = :sku",
+			want:    "SELECT 'a:sku' WHERE sku = ?",
+			wantN:   1,
+		},
+		{
+			name:    "doubled quote does not end the string",
+			dialect: SQLiteDialect,
+			sql:     "SELECT 'it''s' WHERE sku = :sku",
+			want:    "SELECT 'it''s' WHERE sku = ?",
+			wantN:   1,
+		},
+		{
+			// Without backslash escapes the literal ends at the middle quote
+			// and the rest of the statement is scanned as if inside a string.
+			name:    "backslash-escaped quote (MySQL)",
+			dialect: MySQLDialect,
+			sql:     `SELECT 'it\'s' WHERE sku = :sku`,
+			want:    `SELECT 'it\'s' WHERE sku = ?`,
+			wantN:   1,
+		},
+		{
+			name:    "backtick identifier holding a colon",
+			dialect: MySQLDialect,
+			sql:     "SELECT `a:b` FROM t WHERE sku = :sku",
+			want:    "SELECT `a:b` FROM t WHERE sku = ?",
+			wantN:   1,
+		},
+		{
+			name:    "double-quoted identifier holding an apostrophe",
+			dialect: PostgresDialect,
+			sql:     `SELECT "it's" FROM t WHERE sku = :sku`,
+			want:    `SELECT "it's" FROM t WHERE sku = $1`,
+			wantN:   1,
+		},
+		{
+			name:    "bracket identifier (SQLite)",
+			dialect: SQLiteDialect,
+			sql:     "SELECT [a:b] FROM t WHERE sku = :sku",
+			want:    "SELECT [a:b] FROM t WHERE sku = ?",
+			wantN:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, args := BindNamedParams(tc.sql, params, tc.dialect)
+			if got != tc.want {
+				t.Errorf("sql:\n  got  %q\n  want %q", got, tc.want)
+			}
+			if len(args) != tc.wantN {
+				t.Errorf("args = %d, want %d", len(args), tc.wantN)
+			}
+		})
+	}
+}
+
+// The behaviour every driver already had, unchanged.
+func TestBindNamedParams_UnchangedBehaviour(t *testing.T) {
+	params := map[string]interface{}{"sku": "X1", "n": 2}
+
+	t.Run("ordinary binding", func(t *testing.T) {
+		got, args := BindNamedParams("SELECT * FROM t WHERE sku = :sku AND n > :n", params, MySQLDialect)
+		if want := "SELECT * FROM t WHERE sku = ? AND n > ?"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if !reflect.DeepEqual(args, []interface{}{"X1", 2}) {
+			t.Errorf("args = %v, want [X1 2]", args)
+		}
+	})
+
+	t.Run("postgres numbers from one", func(t *testing.T) {
+		got, _ := BindNamedParams("SELECT :sku, :n, :sku", params, PostgresDialect)
+		if want := "SELECT $1, $2, $3"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a postgres cast is not a placeholder", func(t *testing.T) {
+		got, args := BindNamedParams("SELECT :sku::text", params, PostgresDialect)
+		if want := "SELECT $1::text"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if len(args) != 1 {
+			t.Errorf("args = %d, want 1", len(args))
+		}
+	})
+
+	t.Run("an unknown placeholder is left as written", func(t *testing.T) {
+		got, args := BindNamedParams("SELECT :nope", params, MySQLDialect)
+		if want := "SELECT :nope"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if len(args) != 0 {
+			t.Errorf("args = %d, want 0", len(args))
+		}
+	})
+
+	t.Run("no params is a passthrough", func(t *testing.T) {
+		sql := "SELECT 1 -- it's fine"
+		got, args := BindNamedParams(sql, nil, MySQLDialect)
+		if got != sql || args != nil {
+			t.Errorf("got %q / %v", got, args)
+		}
+	})
+}
+
+// MySQL needs whitespace after the dashes for a comment. Reading `a--b` as one
+// would swallow the rest of the statement, which is the failure this scanner
+// exists to prevent.
+func TestBindNamedParams_DashDashNeedsSpaceInMySQL(t *testing.T) {
+	params := map[string]interface{}{"sku": "X1"}
+
+	got, args := BindNamedParams("SELECT 1--2, :sku", params, MySQLDialect)
+	if want := "SELECT 1--2, ?"; got != want {
+		t.Errorf("MySQL: got %q, want %q", got, want)
+	}
+	if len(args) != 1 {
+		t.Errorf("MySQL: args = %d, want 1", len(args))
+	}
+
+	// Postgres and SQLite have no such rule.
+	got, args = BindNamedParams("SELECT 1--2, :sku", params, PostgresDialect)
+	if want := "SELECT 1--2, :sku"; got != want {
+		t.Errorf("Postgres: got %q, want %q", got, want)
+	}
+	if len(args) != 0 {
+		t.Errorf("Postgres: args = %d, want 0", len(args))
+	}
+}
+
+// Postgres block comments nest; the others end at the first close.
+func TestBindNamedParams_NestedBlockComments(t *testing.T) {
+	params := map[string]interface{}{"sku": "X1"}
+
+	got, _ := BindNamedParams("/* a /* b */ :sku */ SELECT :sku", params, PostgresDialect)
+	if want := "/* a /* b */ :sku */ SELECT $1"; got != want {
+		t.Errorf("Postgres: got %q, want %q", got, want)
+	}
+
+	got, _ = BindNamedParams("/* a /* b */ :sku */ SELECT :sku", params, MySQLDialect)
+	if want := "/* a /* b */ ? */ SELECT ?"; got != want {
+		t.Errorf("MySQL: got %q, want %q", got, want)
+	}
+}
+
+// An unterminated comment or literal runs to the end of the statement, which
+// is what the driver does with it too. The scanner must not loop or panic.
+func TestBindNamedParams_Unterminated(t *testing.T) {
+	params := map[string]interface{}{"sku": "X1"}
+	for _, sql := range []string{
+		"SELECT :sku /* unterminated",
+		"SELECT :sku 'unterminated",
+		"SELECT :sku `unterminated",
+		"-- only a comment",
+		"",
+		":",
+		"::",
+	} {
+		if _, _ = BindNamedParams(sql, params, MySQLDialect); false {
+			t.Fatal("unreachable")
+		}
+		_ = NamedParamsIn(sql, GenericSQLDialect)
+	}
+}
+
+// NamedParamsIn answers "which placeholders does this statement carry", and is
+// read to publish GraphQL arguments. A colon in a comment used to become an
+// argument nothing could ever fill.
+func TestNamedParamsIn(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{"plain", "SELECT * FROM t WHERE sku = :sku AND n > :n", []string{"sku", "n"}},
+		{"repeats collapse", "SELECT :sku, :sku", []string{"sku"}},
+		{"comment is not a source", "-- ratio:phantom\nSELECT :sku", []string{"sku"}},
+		{"apostrophe in a comment does not hide the rest", "-- item's\nSELECT :sku", []string{"sku"}},
+		{"string is not a source", "SELECT 'a:phantom' WHERE sku = :sku", []string{"sku"}},
+		{"cast is not a placeholder", "SELECT :sku::text", []string{"sku"}},
+		{"none", "SELECT 1", nil},
+		{"empty", "", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NamedParamsIn(tc.sql, GenericSQLDialect)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/coordinate_signal_quiet_test.go
+++ b/internal/runtime/coordinate_signal_quiet_test.go
@@ -1,0 +1,126 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/v3/internal/flow"
+)
+
+// capturedLogs swaps the process logger for one writing into a buffer, so a
+// test can assert on what an operator would actually read.
+func capturedLogs(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+// logged reports whether any line at the given level contains the message.
+func logged(t *testing.T, buf *bytes.Buffer, level, msg string) bool {
+	t.Helper()
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]interface{}
+		if json.Unmarshal([]byte(line), &rec) != nil {
+			continue
+		}
+		if rec["level"] == level && strings.Contains(rec["msg"].(string), msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// A flow behaving exactly as written must not log as though it were
+// misconfigured. Deciding not to signal — because the message was dropped, or
+// because signal.when said no — is reported once, at the level that suits it,
+// by the code that knows the reason. The emitter used to warn on top of that
+// about an "empty key", which reads as a fault in an expression that is doing
+// its job.
+func TestCoordinateSignal_DropDoesNotWarnAboutAnEmptyKey(t *testing.T) {
+	buf, restore := capturedLogs(t)
+	defer restore()
+
+	h, _, done := newSignallingHandler(t, true, false)
+	defer done()
+
+	ctx := context.Background()
+	first := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "1"}}
+	if _, err := h.HandleRequest(ctx, first); err != nil {
+		t.Fatalf("first HandleRequest: %v", err)
+	}
+
+	buf.Reset()
+
+	second := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "2"}}
+	result, err := h.HandleRequest(ctx, second)
+	if err != nil {
+		t.Fatalf("second HandleRequest: %v", err)
+	}
+	if drop, ok := result.(*flow.FilteredResultWithPolicy); !ok || !drop.Filtered {
+		t.Fatalf("expected a drop, got %T", result)
+	}
+
+	if logged(t, buf, "WARN", "empty key") {
+		t.Errorf("a dropped message warned about an empty signal key; it reads as a config error over correct behaviour:\n%s", buf.String())
+	}
+	if !logged(t, buf, "INFO", "coordinate signal skipped") {
+		t.Errorf("the reason for not signalling must still be reported:\n%s", buf.String())
+	}
+}
+
+// The same, for the other deliberate no-emit.
+func TestCoordinateSignal_WhenFalseDoesNotWarnAboutAnEmptyKey(t *testing.T) {
+	buf, restore := capturedLogs(t)
+	defer restore()
+
+	h, _, done := newSignallingHandler(t, false, false)
+	defer done()
+	h.Config.Coordinate.Signal.When = "false"
+
+	input := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "1"}}
+	if _, err := h.HandleRequest(context.Background(), input); err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	if logged(t, buf, "WARN", "empty key") {
+		t.Errorf("signal.when = false warned about an empty key:\n%s", buf.String())
+	}
+	if !logged(t, buf, "INFO", "coordinate signal skipped") {
+		t.Errorf("the reason must still be reported:\n%s", buf.String())
+	}
+}
+
+// The genuine fault still speaks. An emit expression that evaluates cleanly to
+// nothing is a misconfiguration, and quieting the two cases above must not
+// quiet this one — the warning moves to the code that knows which expression
+// it was, and now names it.
+func TestCoordinateSignal_EmptyKeyStillWarns(t *testing.T) {
+	buf, restore := capturedLogs(t)
+	defer restore()
+
+	h, _, done := newSignallingHandler(t, false, false)
+	defer done()
+	// Evaluates cleanly, to nothing.
+	h.Config.Coordinate.Signal.Emit = "'' + input.body.missing_prefix"
+
+	input := map[string]interface{}{"body": map[string]interface{}{"sku": "X1", "n": "1", "missing_prefix": ""}}
+	if _, err := h.HandleRequest(context.Background(), input); err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	if !logged(t, buf, "WARN", "empty key") {
+		t.Errorf("an emit expression evaluating to nothing must still warn:\n%s", buf.String())
+	}
+}
+
+var _ = io.Discard

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -1810,7 +1810,16 @@ func (h *FlowHandler) evaluateSignalKey(ctx context.Context, expr string, input,
 		return "", false
 	}
 	if s, ok := val.(string); ok {
-		return s, s != ""
+		// An expression that evaluated cleanly to nothing is a real problem
+		// and is reported here, by the code that knows which expression it
+		// was. The caller no longer warns on its behalf: it cannot tell this
+		// apart from a deliberate decision not to emit.
+		if s == "" {
+			slog.Warn("coordinate.signal.emit evaluated to an empty key, signal will not be emitted",
+				"expression", expr)
+			return "", false
+		}
+		return s, true
 	}
 	return fmt.Sprintf("%v", val), true
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"regexp"
 	goruntime "runtime"
 	"sort"
 	"strings"
@@ -2167,17 +2166,14 @@ func destinations(cfg *flow.Config) []*flow.ToConfig {
 }
 
 // namedParameters returns the :name placeholders a statement carries.
-var namedParameter = regexp.MustCompile(`:([a-zA-Z_][a-zA-Z0-9_]*)`)
-
+//
+// It reads the statement the way the driver's binder does rather than with a
+// regular expression, so a colon inside a comment or a string literal is not
+// mistaken for a placeholder — `-- ratio:sku` used to publish a GraphQL
+// argument named sku that nothing could ever fill. No driver is in hand here,
+// so the generic dialect applies.
 func namedParameters(query string) []string {
-	if query == "" {
-		return nil
-	}
-	var out []string
-	for _, match := range namedParameter.FindAllStringSubmatch(query, -1) {
-		out = append(out, match[1])
-	}
-	return out
+	return connector.NamedParamsIn(query, connector.GenericSQLDialect)
 }
 
 func extractInputArgs(value interface{}, args map[string]*ArgDef) {

--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -639,8 +639,21 @@ func (m *Manager) ExecuteWithCoordinate(ctx context.Context, cfg *FlowCoordinate
 			return result, err
 		}
 
+		// Two different things used to arrive here as one. A builder that
+		// returns ok=false has DECIDED not to emit — signal.when was false, or
+		// the message was dropped before it ever reached `to` — and has
+		// already logged why. Warning again on top of that reads as a
+		// configuration error over a flow behaving exactly as written, which
+		// is worse than saying nothing: it sends someone looking for a fault
+		// in an expression that is doing its job.
+		//
+		// An empty key WITH ok=true is the anomaly, and the one worth a
+		// warning: the builder believed it had a key and produced nothing.
 		signalKey, ok := signalKeyFn(result)
-		if !ok || signalKey == "" {
+		if !ok {
+			return result, nil
+		}
+		if signalKey == "" {
 			slog.Warn("coordinate.signal.emit evaluated to empty key, skipping emit",
 				"emit_expr", cfg.Signal.Emit)
 			return result, nil


### PR DESCRIPTION
Two reports from the Mercury consumers team running 3.2.0. Both reproduced; the first turned out to be wider than reported, and the second is a regression from #71.

## An apostrophe in a SQL comment unbound every parameter after it

The binder that rewrites `:name` placeholders into what a driver accepts knew about string literals and nothing else, so a comment was read as if it were code:

```sql
-- the item's parent
SELECT id FROM t WHERE sku = :sku
```

The apostrophe in `item's` opened a string literal that never closed, and every placeholder past it reached the driver as literal text with no argument bound. The statement failed with `missing named argument "sku"` — which names the parameter and never the comment — and `mycel validate` does not execute SQL, so it passed a query that could not run.

**It went wrong in the other direction too, which the report did not reach and is quieter.** `-- ratio:sku` had its colon bound as a placeholder and an argument appended, so a comment consumed one of the statement's arguments and everything after it shifted by one:

```
-- ratio:sku\nSELECT 1   →   "-- ratio?\nSELECT 1"   args=1
```

Verified end to end against a running service and a real SQLite database, not only in unit tests:

```
before:  {"error":"... query failed: missing named argument \"sku\""}
after:   {"found":"ABC-1","name":"Widget"}
```

### The fix

The scan now knows the lexical structure that can hide a colon or a quote — line comments, block comments, string literals, quoted identifiers. It is not a SQL parser and does not need to be: it only has to know which stretches of a statement to copy through untouched.

**One scanner instead of three.** Each driver carried its own copy of the same fifty lines, differing only in whether it wrote `?` or `$1`, and each copy had this hole. The differences that are real move into a dialect value:

- **MySQL** — `#` comments, backslash escapes inside literals, and `--` only when followed by whitespace. Reading `a--b` as a comment would swallow the rest of the statement, which is the failure this exists to prevent.
- **Postgres** — nested block comments, `$N` placeholders.
- **SQLite** — its three identifier quotings.

Postgres casts keep working (`:sku::text` binds once), and a placeholder with no matching value is still left as written, so the driver rejects the statement you wrote rather than one with an argument silently missing.

The runtime's own "which placeholders does this statement carry" — read to publish GraphQL arguments — used a regular expression and had **both** halves of the bug: a colon in a comment became an argument nothing could ever fill. It goes through the same scanner.

## A drop no longer warns about an empty signal key

Introduced by #71 and reported alongside the above. Two different things arrived at the emitter as one:

- A builder that returns no key has **decided** not to signal — `signal.when` was false, or the message was dropped before it reached `to` — and has already logged why.
- A key the builder believed in and could not produce is the genuine fault.

Warning on both, as `coordinate.signal.emit evaluated to empty key`, reads as a configuration error over a flow behaving exactly as written. Since #71 made a drop stop signalling, every drop produced the pair.

They are told apart now. The real fault still speaks, from the code that can name which expression produced nothing rather than from the caller that cannot tell the two apart — so quieting the noise does not quiet a misconfiguration.

## Verification

Every test was run against the unfixed code before being kept:

- The two driver tests fail on all three drivers (`args = 0, want 2` and `args = 2, want 1`).
- The two log tests fail pre-fix.
- Unit suite, `vet`, `gofmt` clean. Integration via `run.sh`: **216 passed, 0 failed**.
- The end-to-end A/B above, against a real service and database.

## Not included

`mycel validate` could catch a *typo'd* parameter in a `step`, where the declared `params` are fully known at parse time. It is left out on purpose: in `to { query }` the parameters come from the message at runtime, so the same check there would be false positives. Worth its own change if wanted.