### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.1] - 2026-08-27
 
 ### Fixed
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.2.0"
+	version = "3.2.1"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.2.1. Two files, two lines: the `[Unreleased]` heading becomes `[3.2.1] - 2026-08-27`, and the version constant in `cmd/mycel/main.go` follows.

Contents, from #73 — both fixes, nothing added, so patch:

- **An apostrophe in a SQL comment no longer unbinds every parameter after it.** `-- the item's parent` opened a string literal that never closed, so every `:name` past it reached the driver as literal text with nothing bound; `-- ratio:sku` had its colon bound as a placeholder and consumed one of the statement's arguments. One dialect-aware scanner now replaces the three near-identical copies, one per driver.
- **A flow behaving as written no longer logs as though it were misconfigured.** Deciding not to emit a coordinate signal was reported once by the code that knows the reason and again by the emitter as an "empty key" warning. A genuine empty key still warns.

Pre-tag checks:

- `go.mod` says `go 1.25.0` and both Dockerfiles pin `golang:1.25-alpine`.
- `go mod tidy` leaves `go.mod` and `go.sum` untouched.
- `mycel version` on a binary built from this commit reports 3.2.1.
- All 65 example directories validate; `go test ./...`, `vet` and `gofmt` clean.
- The release-notes step's own script run against this CHANGELOG: 3.2.1 has neither a Breaking nor a Security section, so the notes carry the changelog link rather than a warning block, and the step does not fail.