### PR TITLE
Release 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.2] - 2026-08-27
 
 ### Fixed
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.2.1"
+	version = "3.2.2"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.2.2. Two files, two lines.

Contents, from #76 — all fixes, nothing added:

- **A write to an HTTP destination no longer puts the whole message on the request line.** `Write` appended its filters to the URL for every method, including the ones carrying a body, so for a flow writing to HTTP the message went out twice — once as the body that mattered, once as a query string nobody read. Invisible until the request line passed a proxy's limit and came back `414`. Reported in #75 by @federivo.
- **A structured value in a query string is JSON rather than Go syntax**, a `nil` is omitted rather than sent as `<nil>`, and parameters are sorted so the same filters always produce the same URL.
- **The integration stack no longer starts Mycel against a MySQL that is not listening.** The healthcheck pinged over the unix socket, which answers during initialization while nothing is on TCP — measured at 5.4s of false-healthy against a 5s probe interval. It took down the first CI run of #76 for a reason unrelated to that change.

Pre-tag checks:

- `go.mod` says `go 1.25.0` and both Dockerfiles pin `golang:1.25-alpine`.
- `go mod tidy` leaves `go.mod` and `go.sum` untouched.
- `mycel version` on a binary built from this commit reports 3.2.2.
- All 65 example directories validate; `go test ./...`, `vet` and `gofmt` clean.
- The release-notes step's script run against this CHANGELOG: no Breaking or Security section, so the notes carry the changelog link and the step does not fail.