### PR TITLE
Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.3.0] - 2026-08-28
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.2.2"
+	version = "3.3.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.3.0. Two files, two lines.

Contents, from #81 — minor because `encoding`, `keys_from` and `patterns_from` are new attributes; everything else is a fix and nothing is breaking.

**Added**

- **`encoding` on a flow's `cache {}` block** (#78) — the wire format for entries, so a namespace can be shared with a service that is not Mycel. Getting it wrong was not incompatibility but mutual destruction: the entry could not be decoded, that read as a miss, the flow did the work and wrote its own format over the key. Absent is `["json"]`, byte for byte what every cache did before.
- **`keys_from` / `patterns_from` on `after { invalidate }`** (#80) — a CEL expression yielding a list, for a key set whose size only the data knows.

**Fixed**

- **A cache entry that cannot be decoded is no longer counted as a hit** (#79), and no longer passes in silence: `mycel_cache_decode_errors_total` plus a warn line naming the key. It is what made #78 invisible while it was happening.
- **An update no longer takes the record's id away from everything downstream** — found by running the example rather than reading the code. The `${input.id}` in an `after { invalidate }`, which is the pattern the caching guide shows for that verb, was resolving to the empty string and leaving the stale entry alive.
- **A cache key template resolving to a list says so**, instead of rendering Go syntax into the key.
- **`invalidate_on` on a named `cache` block is declared in the schema.**

Pre-tag checks:

- `go.mod` says `go 1.25.0` and both Dockerfiles pin `golang:1.25-alpine`.
- `go mod tidy` leaves `go.mod` and `go.sum` untouched.
- `mycel version` on a binary built from this commit reports 3.3.0.
- All 65 example directories validate; `go test ./...`, `vet` and `gofmt` clean.
- The release-notes step's script run against this CHANGELOG: no Breaking or Security section, so the notes carry the changelog link and the step does not fail.