### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.4.0] - 2026-08-28
 
 ### Fixed
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.3.0"
+	version = "3.4.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.4.0. Two files, two lines.

Contents, from #85. Both are fixes, but the version is a minor rather than a patch because two behaviours change for configurations that exist today:

- **A list bound into `IN (:name)` is expanded** (#83) instead of handed to the driver whole, which `database/sql` refused on every driver. An **empty** list and a list where a **scalar** belongs are now refused, naming the parameter — a flow relying on either was already failing, but it fails differently now, and earlier.
- **A `keys_from` / `patterns_from` that cannot be evaluated fails the request** (#84), where it used to invalidate nothing and answer 200. A cache that could not be reached stays non-fatal — the write is already committed — but is logged and counted as `mycel_cache_invalidate_errors_total`.

Both examples grew the thing that was missing in each: something that runs them. `examples/steps` shipped the `IN` flow with no `curl` reaching it; `examples/cache` gains an endpoint whose only job is invalidation.

Pre-tag checks:

- `go.mod` says `go 1.25.0` and both Dockerfiles pin `golang:1.25-alpine`.
- `go mod tidy` leaves `go.mod` and `go.sum` untouched.
- `mycel version` on a binary built from this commit reports 3.4.0.
- All 65 example directories validate; `go test ./...`, `vet` and `gofmt` clean.
- The release-notes step's script run against this CHANGELOG: no Breaking or Security section, so the notes carry the changelog link and the step does not fail.