### PR TITLE
Decide whose fault a failure was by type, and stop publishing the rest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ internal/plugin/validator.wasm
 # Claude Code instructions and local settings (not part of the codebase)
 CLAUDE.md
 CLAUDE.local.md
+CLAUDE.local.history.md
 .claude/
 
 # Benchmark / load testing — the suite is published, its state and output are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **A REST error's HTTP status was inferred from the error's text, so a response field named `invalidated` made internal failures a `400` and published their message in production.** The status was picked by searching the message for `validation`, `required` or `invalid`, and that message carries names chosen by whoever wrote the flow — a field called `invalidated` contains `invalid`, and `examples/cache` ships one. Every failure raised while evaluating that mapping was therefore reported as the caller's doing, whatever had actually gone wrong. The branch below the check then reasoned that a `400` was a validation error and its text was consequently safe to return, so **renaming a response field turned an opaque error into a disclosed one**: two flows differing only in that name answered `500 {"error":"Internal Server Error"}` and `400 {"error":"response transform error: … got 'types.String', expected iterable type"}` to the same request. The same applied to any internal failure whose text happened to contain the substrings — a driver reporting `invalid connection`, and database errors are the ones that carry fragments of a query. It also inverted the retryable class, since `4xx` tells a caller not to retry a failure that was never its to fix.
+
+  Whose fault a failure was is now decided by type — `pkg/errors.Validation`, which the runtime already implements and the aspect executor already consults, plus `sanitize.ErrRejected` — and anything unrecognised is the service's, which keeps the work retryable and the text unpublished. What a caller is told follows from the same answer rather than from the status, so a `4xx` chosen for any other reason can no longer publish internal text. Genuine validation still answers `400` with the message, which is the only way a caller can fix its request.
+
+- **Input and output validation shared one error type, so a flow that broke its own output contract blamed the caller.** `validate { output }` failing is the service failing, but it produced the same `ValidationError` as an input failure and so answered `400` with the field names of an internal record — telling a caller its request was at fault when no request could have satisfied it, and telling it not to retry something a retry might well have fixed. Output failures are now their own type and report `500`, undisclosed in production; they still name the field in logs and outside production.
+
+- **Only the REST connector asked what environment it was running in. `graphql`, `soap`, `websocket` and `tcp` returned raw internal error text to their callers everywhere, production included.** A flow failing on a database error sent the table name into a SOAP `faultstring`, a GraphQL `errors[].message`, and the `message`/`error` field of a WebSocket or TCP frame. All five servers now share one rule, each in its own protocol's shape. GraphQL keeps one deliberate exception: an error carrying no path failed before any flow ran — a malformed query, an unknown field, an argument of the wrong type — and that is the caller's own to fix and most of what a GraphQL endpoint is worth to whoever writes against it, so it is still explained in full. An `error_response` block is unaffected: its status, headers and body were written for the caller.
+
+### Fixed
+
+- **A TCP server registered no flows at all, and a flow reading from a remote GraphQL subscription received nothing.** Both spelled the handler parameter of `RegisterRoute` as their own `HandlerFunc`. The runtime finds a connector by asserting it to `runtime.RouteRegistrar`, an interface written with the unnamed function type, and Go requires an identical type rather than a compatible one — so the assertion failed, silently. Nothing failed to compile, the connector started and reported itself listening, the banner printed the flows, and every message a TCP server received was answered `unknown message type`, whatever the configuration said. Their own tests passed because they call `RegisterRoute` directly, which is the one caller that never had the problem. A parity test now reads every `RegisterRoute` declaration under `internal/connector` and requires the parameter to be written out in full, because the types are precisely what does not complain.
+
 ## [3.4.0] - 2026-08-28
 
 ### Fixed

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -152,6 +152,49 @@ The `body` block uses CEL expressions. Available variables:
 
 Custom error responses work with retry — the custom response is only sent after all retries are exhausted.
 
+## What a Caller Is Told
+
+When a flow fails and no `error_response` block chose the answer, two things are decided for you: the status the caller gets, and how much of the failure it is told about.
+
+### The status
+
+A failure is reported as `400` when it was the caller's own request that was at fault, and `500` otherwise:
+
+| Failure | Status | Why |
+|---------|--------|-----|
+| Input failed the `validate { input }` contract | `400` | The request can be fixed by changing it |
+| Input rejected by the sanitizer (oversized field, control characters) | `400` | Same |
+| The answer failed the `validate { output }` contract | `500` | No request could have satisfied it — the service broke its own contract |
+| A transform, step, destination or connector failed | `500` | Not the caller's to fix |
+| Anything else | `500` | The safe default |
+
+This matters beyond the number: `4xx` tells a client not to retry. A server-side failure reported as `400` makes a caller discard work that a retry would have completed.
+
+The decision is made from the *type* of the failure, never from its message. Error text contains names you chose — a response field, a connector, a table — and a field named `invalidated` must not make a failure look like a validation error.
+
+### How much is disclosed
+
+Outside production, the caller gets the full error text — that is the point of running outside production.
+
+In production, a caller is told the whole message only when its own request was at fault. Everything else collapses to a generic message, because internal error text is a map of the inside of a service: table names, hosts, driver output, fragments of a query.
+
+```
+# development
+POST /orders  →  500 {"error":"query failed: no such table: orders_v2"}
+
+# production
+POST /orders  →  500 {"error":"Internal Server Error"}
+POST /orders  →  400 {"error":"validation error on 'email': field is required"}
+```
+
+This applies to every server connector — `rest`, `graphql`, `soap`, `websocket` and `tcp` — each in its own protocol's shape: an HTTP body, a SOAP `faultstring`, the `message` field of a socket frame.
+
+GraphQL is the one exception worth knowing: a query that names a field that does not exist, or passes an argument of the wrong type, is still explained in full. That failure happened before any of your flows ran, the client wrote the query, and it is the only one who can fix it.
+
+An `error_response` block is not affected by any of this. The status, headers and body it names were written for the caller, so they are sent as written, in production too.
+
+Set the environment with `MYCEL_ENV=production` (`prod` is accepted as the same thing) or `--env production`.
+
 ## Step-Level Error Handling
 
 Each step in a multi-step flow can define its own error behavior with `on_error`. This is useful when some steps are critical and others are optional.

--- a/docs/guides/multi-step-flows.md
+++ b/docs/guides/multi-step-flows.md
@@ -85,7 +85,7 @@ step "items" {
 
     Note `?? []` in the condition: a step whose query matched no rows yields `null`, not an empty list.
 
-Full rules, including what happens when a list is written where a scalar belongs, in [binding a set](../reference/destination-properties.md#binding-a-set-in-name).
+Full rules, including what happens when a list is written where a scalar belongs, in [binding a set](../reference/destination-properties.md#binding-a-set--in-name).
 
 ## Conditional Steps
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -307,6 +307,18 @@ cp target/wasm32-unknown-unknown/release/strip_html.wasm plugins/
 
 ---
 
+## Error Message Disclosure
+
+An internal error message is a map of the inside of a service: table names, hosts, driver output, fragments of a query. In production, a caller is told the full text only when **its own request** was at fault — input that failed a `validate { input }` contract, or input the sanitizer turned away. Every other failure collapses to a generic message.
+
+This applies to all five server connectors — `rest`, `graphql`, `soap`, `websocket`, `tcp` — each in its own protocol's shape. Outside production the full text is returned, which is the point of running outside production.
+
+Whose fault a failure was is decided by the **type** of the error, never by matching its text. Error messages contain names chosen in your configuration, so a substring match lets a response field named `invalidated` reclassify unrelated internal failures as the caller's — and with it, publish them.
+
+See [Error Handling → What a Caller Is Told](error-handling.md#what-a-caller-is-told) for the status codes and the one deliberate exception (a malformed GraphQL query is still explained in full, since it failed before any flow ran and the caller is the only one who can fix it).
+
+---
+
 ## Vulnerability Mitigations Summary
 
 | Vulnerability | Mitigation | Layer |
@@ -322,6 +334,7 @@ cp target/wasm32-unknown-unknown/release/strip_html.wasm plugins/
 | Oversized payloads (DoS) | Input and field size limits enforced before any processing | Core sanitization |
 | Deeply nested input (DoS) | Field depth limit enforced before any processing | Core sanitization |
 | Invalid UTF-8 | Invalid sequences stripped before processing | Core sanitization |
+| Information disclosure via errors | In production only a caller's own request is quoted back; all other failures are generic. Classified by error type, not by matching message text | Connector (all servers) |
 
 ---
 

--- a/internal/connector/error_classification.go
+++ b/internal/connector/error_classification.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"github.com/matutetandil/mycel/v3/internal/sanitize"
+	myerrors "github.com/matutetandil/mycel/v3/pkg/errors"
 )
 
 // PermanentError is implemented by error types that the runtime should not
@@ -58,4 +61,70 @@ func IsTimeoutError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "timeout")
+}
+
+// ClientFault reports whether err says the caller's own request was at fault.
+//
+// Two things a caller depends on follow from the answer: the status it is
+// given — 4xx tells it not to retry, 5xx that the failure was ours and the
+// work may still be worth repeating — and, in production, whether the error
+// text is quoted back to it or withheld.
+//
+// It is answered by type. It used to be answered, in the REST connector, by
+// searching the error's message for "validation", "required" or "invalid",
+// and that message carries names the author of the flow chose. A response
+// field called `invalidated` contains `invalid`, so every failure raised while
+// evaluating that mapping was reported as the caller's doing, whatever had
+// actually gone wrong — and its text, believed safe because it had been
+// labelled 400, was disclosed in production. Renaming a field was enough to
+// turn an opaque error into a published one.
+//
+// Anything unrecognised is not the caller's fault. That is the safe default in
+// both directions: the work stays retryable, and nothing internal is quoted.
+func ClientFault(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Input that failed the type or validator contract the flow declares.
+	// The interface lives in pkg/errors because the runtime produces these
+	// and cannot be imported from here.
+	var invalid myerrors.Validation
+	if errors.As(err, &invalid) {
+		return true
+	}
+
+	// Input the sanitizer turned away is the sender's to fix. Reported as a
+	// 500 it read as Mycel breaking, and 5xx is the retryable class — so a
+	// client posting an oversized field retried it forever.
+	return errors.Is(err, sanitize.ErrRejected)
+}
+
+// FailureMessage returns the text a caller is told about err.
+//
+// Outside production it is the error itself, which is the point of
+// development. In production it is the error only when the caller's own
+// request is what failed — otherwise the caller learns the kind of failure and
+// nothing else, because an internal error message is a map of the inside of a
+// service: table names, hosts, driver output, fragments of a query.
+//
+// The generic text is supplied by the caller of this function because each
+// protocol words it differently — an HTTP status text, a SOAP faultstring, the
+// error field of a socket frame.
+func FailureMessage(err error, environment, generic string) string {
+	if err == nil {
+		return generic
+	}
+	if !IsProduction(environment) || ClientFault(err) {
+		return err.Error()
+	}
+	return generic
+}
+
+// IsProduction reports whether environment names a production deployment.
+//
+// It is the one place the spelling is decided. The REST connector accepted
+// both "production" and "prod" and was the only connector to ask at all.
+func IsProduction(environment string) bool {
+	return environment == "production" || environment == "prod"
 }

--- a/internal/connector/error_classification_client_fault_test.go
+++ b/internal/connector/error_classification_client_fault_test.go
@@ -1,0 +1,101 @@
+package connector
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/matutetandil/mycel/v3/internal/sanitize"
+)
+
+// invalidInput stands in for the runtime's validation error: the flow declared
+// a contract for its input and the request did not meet it.
+type invalidInput struct{ fields []string }
+
+func (e *invalidInput) Error() string              { return "validation error on 'email': field is required" }
+func (e *invalidInput) ValidationFields() []string { return e.fields }
+
+func TestWhoseFaultAFailureWasIsNotReadOffTheMessage(t *testing.T) {
+	// The name of a response field ends up in the message of any error raised
+	// while evaluating it. `invalidated` contains `invalid`, and that was
+	// enough to have every such failure reported as the caller's doing — a
+	// 400, and with it the licence to quote the text back in production.
+	//
+	// The name is not contrived: examples/cache ships a flow whose response
+	// is `invalidated = "size(step.affected ?? [])"`.
+	named := fmt.Errorf("response transform error: failed to evaluate expression for " +
+		"'invalidated': got 'types.String', expected iterable type")
+	if ClientFault(named) {
+		t.Error("a failure was blamed on the caller because a field the flow author named contained 'invalid'")
+	}
+
+	// The same failure with the field called something else. The two must
+	// agree: nothing about which of them happened is the caller's doing.
+	other := fmt.Errorf("response transform error: failed to evaluate expression for " +
+		"'count': got 'types.String', expected iterable type")
+	if ClientFault(named) != ClientFault(other) {
+		t.Error("two identical failures were classified differently because of a field name")
+	}
+
+	// Driver text is the other half of the same problem: a connection error
+	// reading `invalid connection` would have been handed to the caller, and
+	// database errors are the ones that carry fragments of a query.
+	if ClientFault(errors.New("pq: invalid connection to host db-primary.internal")) {
+		t.Error("a driver error was blamed on the caller")
+	}
+}
+
+func TestWhatIsRecognisedAsTheCallersOwnDoing(t *testing.T) {
+	// Input that failed the contract the flow declares, recognised through
+	// the interface in pkg/errors rather than through its text.
+	if !ClientFault(&invalidInput{fields: []string{"email"}}) {
+		t.Error("a validation failure was not recognised as the caller's")
+	}
+
+	// Still recognised through a wrap, because that is how it reaches the
+	// connector.
+	if !ClientFault(fmt.Errorf("flow \"create\": %w", &invalidInput{})) {
+		t.Error("a wrapped validation failure was not recognised")
+	}
+
+	// Input the sanitizer turned away. Reported as a 500 it read as Mycel
+	// breaking, and 5xx is the retryable class — so a client posting an
+	// oversized field retried it forever.
+	if !ClientFault(fmt.Errorf("field too large: %w", sanitize.ErrRejected)) {
+		t.Error("a sanitizer rejection was not recognised as the caller's")
+	}
+
+	// Anything unrecognised is ours. That keeps the work retryable and keeps
+	// the text unpublished.
+	if ClientFault(errors.New("dial tcp 10.0.0.5:5432: connect: connection refused")) {
+		t.Error("an unrecognised failure was blamed on the caller")
+	}
+	if ClientFault(nil) {
+		t.Error("no error at all was blamed on the caller")
+	}
+}
+
+func TestHowMuchOfAFailureIsQuotedBack(t *testing.T) {
+	internal := errors.New("dial tcp 10.0.0.5:5432: connect: connection refused")
+
+	// In production the caller learns the kind of failure and nothing else.
+	if got := FailureMessage(internal, "production", "Internal Server Error"); got != "Internal Server Error" {
+		t.Errorf("an internal failure was described to a production caller: %q", got)
+	}
+	// "prod" is the same deployment by a shorter name.
+	if got := FailureMessage(internal, "prod", "Internal Server Error"); got != "Internal Server Error" {
+		t.Errorf("the short spelling of production was not recognised: %q", got)
+	}
+
+	// Its own request is a different matter: it cannot be fixed without
+	// being told what was wrong with it.
+	if got := FailureMessage(&invalidInput{}, "production", "Internal Server Error"); got == "Internal Server Error" {
+		t.Error("a caller was not told what was wrong with its own request")
+	}
+
+	// Outside production everything is shown, which is the point of
+	// development.
+	if got := FailureMessage(internal, "development", "Internal Server Error"); got != internal.Error() {
+		t.Errorf("a developer was not told what actually failed: %q", got)
+	}
+}

--- a/internal/connector/graphql/client.go
+++ b/internal/connector/graphql/client.go
@@ -415,7 +415,12 @@ func isClientError(err error) bool {
 
 // RegisterRoute registers a handler for a subscription operation.
 // Operations should be in the form "Subscription.fieldName".
-func (c *ClientConnector) RegisterRoute(operation string, handler HandlerFunc) {
+// The parameter is the bare function type rather than HandlerFunc for the
+// reason given on the TCP server's method: the runtime's RouteRegistrar is
+// written with the unnamed type, and a defined type is not identical to it, so
+// spelled with HandlerFunc this never satisfied the interface. A flow reading
+// from a remote GraphQL subscription registered nothing and received nothing.
+func (c *ClientConnector) RegisterRoute(operation string, handler func(ctx context.Context, input map[string]interface{}) (interface{}, error)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if existing, ok := c.handlers[operation]; ok {

--- a/internal/connector/graphql/factory.go
+++ b/internal/connector/graphql/factory.go
@@ -118,7 +118,9 @@ func (f *Factory) createServer(cfg *connector.Config) (*ServerConnector, error) 
 		}
 	}
 
-	return NewServer(cfg.Name, config, f.logger), nil
+	server := NewServer(cfg.Name, config, f.logger)
+	server.environment = cfg.Environment
+	return server, nil
 }
 
 // createClient creates a GraphQL client connector.

--- a/internal/connector/graphql/failure.go
+++ b/internal/connector/graphql/failure.go
@@ -1,0 +1,60 @@
+package graphql
+
+import (
+	"errors"
+
+	"github.com/graphql-go/graphql/gqlerrors"
+
+	"github.com/matutetandil/mycel/v3/internal/connector"
+)
+
+// withheldFailures rewrites the errors of a GraphQL response so that a
+// production caller is not handed the inside of the service.
+//
+// The REST connector was the only server that asked what environment it was
+// running in; this one encoded whatever graphql-go put in the response, so a
+// flow that failed while shaping its answer published the reason — the
+// expression that broke, the key that was missing, and, for a failure further
+// down, the driver text underneath it.
+//
+// Not every error here is ours. A query that names a field that does not exist
+// or passes an argument of the wrong type failed before any resolver ran, and
+// that message is the whole value of a GraphQL endpoint to the client writing
+// against it: it must survive. The two are told apart by where they happened —
+// an error raised resolving a field carries the path to that field, and one
+// raised while parsing or validating the document carries none.
+func withheldFailures(errs []gqlerrors.FormattedError, environment string) []gqlerrors.FormattedError {
+	if len(errs) == 0 || !connector.IsProduction(environment) {
+		return errs
+	}
+
+	withheld := make([]gqlerrors.FormattedError, len(errs))
+	for i, formatted := range errs {
+		withheld[i] = formatted
+		if len(formatted.Path) == 0 {
+			// The document itself was refused. The caller wrote it and is
+			// the only one who can fix it.
+			continue
+		}
+		withheld[i].Message = connector.FailureMessage(
+			resolverError(formatted), environment, "internal error")
+	}
+	return withheld
+}
+
+// resolverError digs out the error a resolver actually returned, which
+// graphql-go wraps twice before it reaches the response. Classification is by
+// type, so a validation failure raised inside a flow is still quoted back to
+// the caller who caused it.
+func resolverError(formatted gqlerrors.FormattedError) error {
+	original := formatted.OriginalError()
+	if original == nil {
+		return errors.New(formatted.Message)
+	}
+
+	var wrapped *gqlerrors.Error
+	if errors.As(original, &wrapped) && wrapped.OriginalError != nil {
+		return wrapped.OriginalError
+	}
+	return original
+}

--- a/internal/connector/graphql/failure_test.go
+++ b/internal/connector/graphql/failure_test.go
@@ -1,0 +1,79 @@
+package graphql
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/graphql-go/graphql/gqlerrors"
+)
+
+func TestAProductionResolverFailureIsNotDescribed(t *testing.T) {
+	// A resolver error carries the path to the field it happened on. That is
+	// a failure inside the service, and its text is the inside of the service.
+	errs := []gqlerrors.FormattedError{{
+		Message: "response transform error: failed to evaluate expression for 'count': " +
+			"no such table: internal_billing_table",
+		Path: []interface{}{"orders"},
+	}}
+
+	withheld := withheldFailures(errs, "production")
+
+	if strings.Contains(withheld[0].Message, "internal_billing_table") {
+		t.Errorf("the name of an internal table was published: %q", withheld[0].Message)
+	}
+	// The shape of the response is not touched: a client reads the path to
+	// know which field it lost.
+	if len(withheld[0].Path) != 1 || withheld[0].Path[0] != "orders" {
+		t.Errorf("the path of the error was lost: %v", withheld[0].Path)
+	}
+}
+
+func TestAMalformedQueryIsStillExplainedInProduction(t *testing.T) {
+	// A query naming a field that does not exist failed before any resolver
+	// ran. The client wrote it, the client is the only one who can fix it, and
+	// that message is most of what a GraphQL endpoint is worth to whoever is
+	// writing against it. Errors from parsing and validation carry no path,
+	// which is how they are told apart.
+	errs := []gqlerrors.FormattedError{{
+		Message: `Cannot query field "nosuchfield" on type "Query".`,
+	}}
+
+	withheld := withheldFailures(errs, "production")
+
+	if withheld[0].Message != errs[0].Message {
+		t.Errorf("a caller was not told its query was malformed: %q", withheld[0].Message)
+	}
+}
+
+func TestOutsideProductionTheResponseIsUntouched(t *testing.T) {
+	errs := []gqlerrors.FormattedError{{
+		Message: "no such table: internal_billing_table",
+		Path:    []interface{}{"orders"},
+	}}
+
+	if got := withheldFailures(errs, "development"); got[0].Message != errs[0].Message {
+		t.Errorf("a developer was not told what actually failed: %q", got[0].Message)
+	}
+}
+
+func TestAValidationFailureInsideAFlowIsStillQuoted(t *testing.T) {
+	// Classification is by type all the way down, so a request that failed the
+	// contract a flow declares is quoted back to the caller who caused it,
+	// even though it surfaced as a resolver error with a path.
+	wrapped := gqlerrors.NewFormattedError("ignored")
+	if resolverError(wrapped) == nil {
+		t.Fatal("the original error could not be recovered from a formatted one")
+	}
+
+	// And an error graphql-go wrapped twice is still reached.
+	inner := errors.New("validation error on 'email': field is required")
+	formatted := gqlerrors.FormatError(&gqlerrors.Error{
+		Message:       inner.Error(),
+		OriginalError: inner,
+		Path:          []interface{}{"createUser"},
+	})
+	if got := resolverError(formatted); got != inner {
+		t.Errorf("the error a resolver returned was not recovered: %v", got)
+	}
+}

--- a/internal/connector/graphql/server.go
+++ b/internal/connector/graphql/server.go
@@ -33,6 +33,12 @@ type ServerConnector struct {
 	started             bool
 	schemaBuilt         bool
 	subscriptionManager *SubscriptionManager
+
+	// environment decides how much a caller is told about a failure. Only
+	// the REST connector used to ask: every other server, this one
+	// included, encoded the raw error text into its response in production
+	// as anywhere else.
+	environment string
 }
 
 // NewServer creates a new GraphQL server connector.
@@ -398,6 +404,11 @@ func (c *ServerConnector) handleGraphQL(w http.ResponseWriter, r *http.Request) 
 		OperationName:  request.OperationName,
 		Context:        ctx,
 	})
+
+	// In production a failure inside a flow is not described to the caller.
+	// See withheldFailures: a malformed query still is, because that is the
+	// caller's own to fix.
+	result.Errors = withheldFailures(result.Errors, c.environment)
 
 	// Write response
 	if err := json.NewEncoder(w).Encode(result); err != nil {

--- a/internal/connector/rest/connector.go
+++ b/internal/connector/rest/connector.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matutetandil/mycel/v3/internal/health"
 	"github.com/matutetandil/mycel/v3/internal/metrics"
 	"github.com/matutetandil/mycel/v3/internal/ratelimit"
-	"github.com/matutetandil/mycel/v3/internal/sanitize"
 )
 
 // HandlerFunc is a function that handles a flow request.
@@ -725,36 +724,21 @@ func (c *Connector) writeError(w http.ResponseWriter, err error) int {
 		return flowErr.Status
 	}
 
+	// Whose fault the failure was is decided by type, not by reading the
+	// message. See connector.ClientFault: the message contains names the
+	// author of the flow chose, so a response field called `invalidated`
+	// used to make every failure in that mapping a 400 — and a 400 was
+	// taken as licence to quote the error back in production.
 	status := http.StatusInternalServerError
-
-	// Check for specific error types
-	errStr := err.Error()
-	if strings.Contains(errStr, "validation") ||
-		strings.Contains(errStr, "required") ||
-		strings.Contains(errStr, "invalid") {
-		status = http.StatusBadRequest
-	}
-	// Input the sanitizer turned away is the sender's to fix. Reported as a
-	// 500 it read as Mycel breaking, and 5xx is the retryable class — so a
-	// client posting an oversized field retried it forever.
-	if errors.Is(err, sanitize.ErrRejected) {
+	if connector.ClientFault(err) {
 		status = http.StatusBadRequest
 	}
 
-	// In production, return minimal error info (no internal details)
-	if c.environment == "production" || c.environment == "prod" {
-		msg := http.StatusText(status)
-		if status == http.StatusBadRequest {
-			msg = errStr // validation errors are safe to expose
-		}
-		c.writeJSON(w, status, map[string]string{
-			"error": msg,
-		})
-		return status
-	}
-
+	// What the caller is told follows from the same answer rather than from
+	// the status, so a 4xx chosen for any other reason cannot publish
+	// internal text.
 	c.writeJSON(w, status, map[string]string{
-		"error": errStr,
+		"error": connector.FailureMessage(err, c.environment, http.StatusText(status)),
 	})
 	return status
 }

--- a/internal/connector/rest/exposure_test.go
+++ b/internal/connector/rest/exposure_test.go
@@ -157,9 +157,11 @@ func TestHowMuchACallerIsToldAboutAFailure(t *testing.T) {
 	}
 
 	// A validation failure is the caller's own doing, so it is told what was
-	// wrong — otherwise it cannot fix the request.
+	// wrong — otherwise it cannot fix the request. It is recognised by type:
+	// this used to be an untyped error whose text happened to contain
+	// "validation", which is the whole of what the check looked at.
 	w = httptest.NewRecorder()
-	status = production.writeError(w, errors.New("validation failed: email is required"))
+	status = production.writeError(w, &rejectedInput{})
 	if status != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", status)
 	}
@@ -289,4 +291,74 @@ func TestTheConnectorSaysWhatItIs(t *testing.T) {
 	if err := c.Health(t.Context()); err != nil {
 		fmt.Println("health before start:", err)
 	}
+}
+
+// rejectedInput stands in for the runtime's validation error, which the REST
+// connector cannot import.
+type rejectedInput struct{}
+
+func (e *rejectedInput) Error() string              { return "validation error on 'email': field is required" }
+func (e *rejectedInput) ValidationFields() []string { return []string{"email"} }
+
+func TestAFieldNameDoesNotDecideWhoIsAtFault(t *testing.T) {
+	// The reported bug. The status was picked by searching the error's message
+	// for "validation", "required" or "invalid", and that message carries the
+	// names the author of the flow chose. A response field called
+	// `invalidated` contains `invalid` — examples/cache ships one — so every
+	// failure raised while evaluating it was reported as a 400. The branch
+	// below the check then reasoned that a 400 was a validation error and its
+	// text was therefore safe to return, so renaming a field turned an opaque
+	// failure into a published one.
+	production := New("api", 0, nil, nil)
+	production.environment = "production"
+
+	const template = "response transform error: failed to evaluate expression for %q: " +
+		"got 'types.String', expected iterable type"
+
+	answers := map[string]*httptest.ResponseRecorder{}
+	statuses := map[string]int{}
+	for _, field := range []string{"invalidated", "count"} {
+		w := httptest.NewRecorder()
+		statuses[field] = production.writeError(w, fmt.Errorf(template, field))
+		answers[field] = w
+	}
+
+	if statuses["invalidated"] != statuses["count"] {
+		t.Errorf("the same failure got status %d or %d depending on what the response field was called",
+			statuses["invalidated"], statuses["count"])
+	}
+	if statuses["invalidated"] != http.StatusInternalServerError {
+		t.Errorf("a failure inside the service was reported as the caller's: %d", statuses["invalidated"])
+	}
+	if body := answers["invalidated"].Body.String(); strings.Contains(body, "types.String") {
+		t.Errorf("the inside of a failure was published to a production caller: %s", body)
+	}
+}
+
+func TestAnAnswerThatBrokeItsOwnContractIsNotTheCallersFault(t *testing.T) {
+	// Input and output validation used to share one error type, so a flow
+	// whose own answer failed the contract it declares answered 400 — telling
+	// a caller its request was at fault when no request could have satisfied
+	// it, and telling it not to retry something a retry might well have fixed.
+	// The message named the fields of an internal record.
+	production := New("api", 0, nil, nil)
+	production.environment = "production"
+
+	w := httptest.NewRecorder()
+	status := production.writeError(w, &brokenAnswer{})
+
+	if status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500: the service, not the caller, broke the contract", status)
+	}
+	if strings.Contains(w.Body.String(), "ssn") {
+		t.Errorf("a field of an internal record was named to the caller: %s", w.Body.String())
+	}
+}
+
+// brokenAnswer stands in for the runtime's output validation error, which
+// deliberately does not report validation fields: it is not the caller's.
+type brokenAnswer struct{}
+
+func (e *brokenAnswer) Error() string {
+	return "output validation error on 'ssn': field is required"
 }

--- a/internal/connector/soap/factory.go
+++ b/internal/connector/soap/factory.go
@@ -90,5 +90,7 @@ func (f *Factory) createClient(cfg *connector.Config, endpoint, soapVersion, nam
 }
 
 func (f *Factory) createServer(cfg *connector.Config, port int, soapVersion, namespace string) (*Server, error) {
-	return NewServer(cfg.Name, port, soapVersion, namespace, f.logger), nil
+	server := NewServer(cfg.Name, port, soapVersion, namespace, f.logger)
+	server.environment = cfg.Environment
+	return server, nil
 }

--- a/internal/connector/soap/failure_disclosure_test.go
+++ b/internal/connector/soap/failure_disclosure_test.go
@@ -1,0 +1,47 @@
+package soap
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestWhatAProductionFaultSays(t *testing.T) {
+	// The REST connector was the only server that asked what environment it
+	// was running in. This one put the raw error text in the faultstring
+	// wherever it ran, so a driver message — table names, hosts, fragments of
+	// a query — reached whoever called the endpoint.
+	s := serverFor(t, "1.1")
+	s.environment = "production"
+	s.RegisterRoute("CreateOrder", func(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+		return nil, errors.New("query failed: no such table: internal_billing_table")
+	})
+
+	body := call(t, s, envelopeFor("CreateOrder", `<CustomerId>customer-1</CustomerId>`)).Body.String()
+
+	if strings.Contains(body, "internal_billing_table") {
+		t.Errorf("the name of an internal table was sent to the caller:\n%s", body)
+	}
+	// It is still a fault, and still the server's: a SOAP client gets nothing
+	// out of a response it cannot parse, and Server is what tells it the
+	// failure is worth retrying.
+	if !strings.Contains(body, "Fault") || !strings.Contains(body, "Server") {
+		t.Errorf("a failure stopped coming back as a server fault:\n%s", body)
+	}
+}
+
+func TestWhatADevelopmentFaultSays(t *testing.T) {
+	// Withholding it from a developer helps nobody: the whole point of running
+	// outside production is being told what actually broke.
+	s := serverFor(t, "1.1")
+	s.RegisterRoute("CreateOrder", func(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+		return nil, errors.New("query failed: no such table: internal_billing_table")
+	})
+
+	body := call(t, s, envelopeFor("CreateOrder", `<CustomerId>customer-1</CustomerId>`)).Body.String()
+
+	if !strings.Contains(body, "internal_billing_table") {
+		t.Errorf("a developer was not told what actually failed:\n%s", body)
+	}
+}

--- a/internal/connector/soap/server.go
+++ b/internal/connector/soap/server.go
@@ -27,6 +27,12 @@ type Server struct {
 	logger      *slog.Logger
 	server      *http.Server
 
+	// environment decides how much a caller is told about a failure. Only
+	// the REST connector used to ask: every other server, this one
+	// included, returned the raw error text to whoever called it, in
+	// production as anywhere else.
+	environment string
+
 	mu       sync.Mutex
 	handlers map[string]HandlerFunc
 	started  bool
@@ -170,7 +176,7 @@ func (s *Server) handleSOAPRequest(w http.ResponseWriter, r *http.Request) {
 			slog.String("operation", operation),
 			slog.Any("error", err),
 		)
-		s.writeFault(w, "Server", err.Error(), "")
+		s.writeFault(w, "Server", connector.FailureMessage(err, s.environment, "Internal Server Error"), "")
 		return
 	}
 

--- a/internal/connector/tcp/factory.go
+++ b/internal/connector/tcp/factory.go
@@ -61,6 +61,7 @@ func (f *Factory) createServer(cfg *connector.Config) (*ServerConnector, error) 
 
 	opts := []ServerOption{
 		WithServerLogger(f.logger),
+		WithServerEnvironment(cfg.Environment),
 		WithMaxConnections(maxConns),
 		WithServerTimeouts(readTimeout, writeTimeout),
 	}

--- a/internal/connector/tcp/failure_disclosure_test.go
+++ b/internal/connector/tcp/failure_disclosure_test.go
@@ -1,0 +1,75 @@
+package tcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/v3/internal/connector"
+)
+
+func TestWhatAProductionClientIsToldAboutAFailure(t *testing.T) {
+	// The REST connector was the only server that asked what environment it
+	// was running in. This one framed the raw error text into its reply
+	// wherever it ran, and a database error is exactly the kind that carries
+	// the name of a table.
+	server, client := serverAndClient(t, "json")
+	server.environment = "production"
+
+	server.RegisterRoute("get_user", func(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+		return nil, errors.New("query failed: no such table: internal_billing_table")
+	})
+
+	_, err := client.Write(context.Background(), &connector.Data{
+		Target:  "get_user",
+		Payload: map[string]interface{}{"id": "u-1"},
+	})
+	if err == nil {
+		t.Fatal("a failed flow came back as a success")
+	}
+	if strings.Contains(err.Error(), "internal_billing_table") {
+		t.Errorf("the name of an internal table was sent to the caller: %v", err)
+	}
+}
+
+func TestWhatADevelopmentClientIsToldAboutAFailure(t *testing.T) {
+	server, client := serverAndClient(t, "json")
+
+	server.RegisterRoute("get_user", func(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+		return nil, errors.New("query failed: no such table: internal_billing_table")
+	})
+
+	_, err := client.Write(context.Background(), &connector.Data{
+		Target:  "get_user",
+		Payload: map[string]interface{}{"id": "u-1"},
+	})
+	if err == nil {
+		t.Fatal("a failed flow came back as a success")
+	}
+	if !strings.Contains(err.Error(), "internal_billing_table") {
+		t.Errorf("a developer was not told what actually failed: %v", err)
+	}
+}
+
+// TestAServerCanBeFoundAsARouteRegistrar guards the reason none of the above
+// could happen through a running Mycel until now.
+//
+// RegisterRoute took a HandlerFunc, and the runtime looks a connector up as a
+// runtime.RouteRegistrar, an interface written with the unnamed function type.
+// A defined type is not identical to it, so the assertion failed, silently, and
+// no flow was ever registered on a TCP server: every message it received was
+// answered "unknown message type", whatever the configuration said.
+//
+// The interface is restated here rather than imported because internal/runtime
+// imports this package.
+func TestAServerCanBeFoundAsARouteRegistrar(t *testing.T) {
+	type routeRegistrar interface {
+		RegisterRoute(operation string, handler func(ctx context.Context, input map[string]interface{}) (interface{}, error))
+	}
+
+	var server interface{} = &ServerConnector{}
+	if _, ok := server.(routeRegistrar); !ok {
+		t.Error("a TCP server cannot be found as a RouteRegistrar, so the runtime will register no flow on it")
+	}
+}

--- a/internal/connector/tcp/server.go
+++ b/internal/connector/tcp/server.go
@@ -49,10 +49,24 @@ type ServerConnector struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	// environment decides how much a caller is told about a failure. Only
+	// the REST connector used to ask: every other server, this one
+	// included, framed the raw error text into its reply in production as
+	// anywhere else.
+	environment string
 }
 
 // ServerOption configures a ServerConnector.
 type ServerOption func(*ServerConnector)
+
+// WithServerEnvironment sets the deployment environment, which decides how
+// much a caller is told about a failure.
+func WithServerEnvironment(environment string) ServerOption {
+	return func(s *ServerConnector) {
+		s.environment = environment
+	}
+}
 
 // WithServerLogger sets the logger for the server.
 func WithServerLogger(logger *slog.Logger) ServerOption {
@@ -386,7 +400,7 @@ func (s *ServerConnector) processNestJSMessage(framer *NestJSFramer, msg *NestJS
 	// Fire deferred on_drop closure (no-op on success).
 	flow.FireDropAspect(ctx, result)
 	if err != nil {
-		s.sendNestJSErrorResponse(framer, msg.ID, err.Error())
+		s.sendNestJSErrorResponse(framer, msg.ID, connector.FailureMessage(err, s.environment, "internal error"))
 		return
 	}
 
@@ -444,7 +458,7 @@ func (s *ServerConnector) processMessage(framer *Framer, msg *Message) {
 	// Fire deferred on_drop closure (no-op on success).
 	flow.FireDropAspect(ctx, result)
 	if err != nil {
-		s.sendErrorResponse(framer, msg.ID, err.Error())
+		s.sendErrorResponse(framer, msg.ID, connector.FailureMessage(err, s.environment, "internal error"))
 		return
 	}
 
@@ -490,7 +504,15 @@ func (s *ServerConnector) sendResponse(framer *Framer, msg *Message) {
 // This implements the RouteRegistrar interface used by the runtime.
 // Multiple flows can register for the same operation (fan-out): the first handler
 // returns the TCP response, additional handlers run concurrently as fire-and-forget.
-func (s *ServerConnector) RegisterRoute(operation string, handler HandlerFunc) {
+// The parameter is the bare function type rather than HandlerFunc on purpose.
+// The runtime looks a connector up as a RouteRegistrar, an interface written
+// with the unnamed type, and a defined type is not identical to it — so this
+// method, spelled with HandlerFunc, did not satisfy the interface. The lookup
+// failed silently and no flow was ever registered: every message a TCP server
+// received was answered "unknown message type", whatever the configuration
+// said. Nothing failed to compile and nothing was logged, because the runtime
+// simply found no registrar and moved on.
+func (s *ServerConnector) RegisterRoute(operation string, handler func(ctx context.Context, input map[string]interface{}) (interface{}, error)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if existing, ok := s.handlers[operation]; ok {

--- a/internal/connector/websocket/connector.go
+++ b/internal/connector/websocket/connector.go
@@ -58,6 +58,12 @@ type Connector struct {
 
 	// Debug throttling: single-message processing when debugger is connected
 	debugGate connector.DebugGate
+
+	// environment decides how much a caller is told about a failure. Only
+	// the REST connector used to ask: every other server, this one
+	// included, sent the raw error text down the socket in production as
+	// anywhere else.
+	environment string
 }
 
 // New creates a new WebSocket connector.
@@ -418,7 +424,7 @@ func (c *Connector) handleClientMessage(client *Client, msg *Message) {
 		// Fire deferred on_drop closure (no-op on success).
 		flow.FireDropAspect(context.Background(), result)
 		if err != nil {
-			c.sendError(client, err.Error())
+			c.sendError(client, connector.FailureMessage(err, c.environment, "internal error"))
 			return
 		}
 

--- a/internal/connector/websocket/factory.go
+++ b/internal/connector/websocket/factory.go
@@ -55,7 +55,9 @@ func (f *Factory) Create(ctx context.Context, cfg *connector.Config) (connector.
 		config.Path = "/ws"
 	}
 
-	return New(cfg.Name, config, f.logger), nil
+	conn := New(cfg.Name, config, f.logger)
+	conn.environment = cfg.Environment
+	return conn, nil
 }
 
 // parseDuration extracts a duration from properties.

--- a/internal/connector/websocket/failure_disclosure_test.go
+++ b/internal/connector/websocket/failure_disclosure_test.go
@@ -1,0 +1,56 @@
+package websocket
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestWhatAProductionSocketIsToldAboutAFailure(t *testing.T) {
+	// The REST connector was the only server that asked what environment it
+	// was running in. This one sent the raw error text down the socket
+	// wherever it ran, and a database error is exactly the kind that carries
+	// the name of a table.
+	c, address := serverOn(t)
+	c.environment = "production"
+
+	c.RegisterRoute("message", func(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+		return nil, errors.New("query failed: no such table: internal_billing_table")
+	})
+
+	client := dial(t, address, "")
+	waitForClients(t, c, 1)
+	send(t, client, Message{Type: "message", Data: map[string]interface{}{"order_id": "order-1"}})
+
+	message, ok := nextMessage(t, client)
+	if !ok {
+		t.Fatal("the client was told nothing at all")
+	}
+	if message["type"] != "error" {
+		t.Errorf("a failure came back as %v", message["type"])
+	}
+	if text, _ := message["message"].(string); strings.Contains(text, "internal_billing_table") {
+		t.Errorf("the name of an internal table was sent to the caller: %q", text)
+	}
+}
+
+func TestWhatADevelopmentSocketIsToldAboutAFailure(t *testing.T) {
+	c, address := serverOn(t)
+
+	c.RegisterRoute("message", func(ctx context.Context, input map[string]interface{}) (interface{}, error) {
+		return nil, errors.New("query failed: no such table: internal_billing_table")
+	})
+
+	client := dial(t, address, "")
+	waitForClients(t, c, 1)
+	send(t, client, Message{Type: "message", Data: map[string]interface{}{"order_id": "order-1"}})
+
+	message, ok := nextMessage(t, client)
+	if !ok {
+		t.Fatal("the client was told nothing at all")
+	}
+	if text, _ := message["message"].(string); !strings.Contains(text, "internal_billing_table") {
+		t.Errorf("a developer was not told what actually failed: %q", text)
+	}
+}

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -4268,12 +4268,36 @@ func (h *FlowHandler) validateOutput(ctx context.Context, output map[string]inte
 	result := h.Validator.Validate(ctx, output, schema)
 	if !result.Valid {
 		if len(result.Errors) > 0 {
-			return &ValidationError{Errors: result.Errors}
+			return &OutputValidationError{Errors: result.Errors}
 		}
 		return fmt.Errorf("output validation failed")
 	}
 
 	return nil
+}
+
+// OutputValidationError reports that the service's own answer failed the
+// contract its `validate` block names for the output.
+//
+// It is deliberately not a ValidationError. The two read alike — the same
+// checker, the same field messages — but they say opposite things about who
+// erred, and the whole of what a caller is told follows from that: an input
+// failure is the caller's to fix and is quoted back to it, while an answer
+// that broke its own contract is ours, and its text names the fields of an
+// internal record.
+//
+// Sharing one type meant a flow whose output was wrong answered 400 — telling
+// a caller its request was at fault when no request could have satisfied it,
+// and telling it not to retry something a retry might well have fixed.
+type OutputValidationError struct {
+	Errors []validate.Error
+}
+
+func (e *OutputValidationError) Error() string {
+	if len(e.Errors) == 0 {
+		return "output validation failed"
+	}
+	return "output " + e.Errors[0].Error()
 }
 
 // ValidationError represents validation failures.

--- a/internal/runtime/output_validation_fault_test.go
+++ b/internal/runtime/output_validation_fault_test.go
@@ -1,0 +1,55 @@
+package runtime
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/matutetandil/mycel/v3/internal/validate"
+	myerrors "github.com/matutetandil/mycel/v3/pkg/errors"
+)
+
+// Input and output validation used to share one error type. They read alike —
+// the same checker, the same field messages — but they say opposite things
+// about who erred, and everything a caller is told follows from that.
+//
+// Sharing the type meant a flow whose own answer broke the contract it
+// declares answered 400: the caller was told its request was at fault when no
+// request could have satisfied it, told not to retry something a retry might
+// well have fixed, and handed the names of the fields of an internal record,
+// because a 400 was taken as licence to quote the text.
+func TestAnAnswerThatBrokeItsContractIsNotBlamedOnTheCaller(t *testing.T) {
+	failed := []validate.Error{{Field: "ssn", Message: "field is required", Code: "required"}}
+
+	// Input: the caller's, and recognised as such through the interface the
+	// connectors consult.
+	var caller myerrors.Validation
+	if !errors.As(error(&ValidationError{Errors: failed}), &caller) {
+		t.Error("a failed request was not recognised as the caller's doing")
+	}
+
+	// Output: ours, and deliberately not recognised as the caller's.
+	var ours myerrors.Validation
+	if errors.As(error(&OutputValidationError{Errors: failed}), &ours) {
+		t.Error("the service breaking its own output contract was blamed on the caller")
+	}
+}
+
+func TestAnOutputFailureStillSaysWhatBroke(t *testing.T) {
+	// Not being the caller's fault is not a reason to be silent: a developer
+	// and a log still need the field.
+	err := &OutputValidationError{Errors: []validate.Error{
+		{Field: "ssn", Message: "field is required", Code: "required"},
+	}}
+
+	if got := err.Error(); got == "" {
+		t.Error("an output failure said nothing at all")
+	} else if !strings.Contains(got, "ssn") || !strings.Contains(got, "output") {
+		t.Errorf("an output failure does not name the field or say which side it was on: %q", got)
+	}
+
+	// And one with nothing in it still reads as an output failure.
+	if got := (&OutputValidationError{}).Error(); !strings.Contains(got, "output") {
+		t.Errorf("an empty output failure = %q", got)
+	}
+}

--- a/internal/runtime/route_registrar_parity_test.go
+++ b/internal/runtime/route_registrar_parity_test.go
@@ -1,0 +1,122 @@
+package runtime
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A connector registers its flows by being found as a RouteRegistrar. The
+// interface is written with an unnamed function type, and Go asks for an
+// identical type, not a compatible one — so a connector that spells the same
+// parameter as its own `HandlerFunc` does not implement the interface.
+//
+// Nothing catches that. It compiles, the method looks right beside its
+// neighbours, the connector starts and reports itself listening, and the
+// banner prints the flows. The runtime asks whether it is a RouteRegistrar,
+// is told no, and moves on without a word. Two connectors were in that state:
+// a TCP server answered "unknown message type" to every message it was sent,
+// and a flow reading from a remote GraphQL subscription received nothing.
+//
+// The check is on the source rather than on the types because the types are
+// exactly what does not complain. It reads every RegisterRoute declaration
+// under internal/connector and requires the handler parameter to be written
+// out in full.
+func TestEveryRegisterRouteCanActuallyBeFound(t *testing.T) {
+	const want = "func(ctx context.Context, input map[string]interface{}) (interface{}, error)"
+
+	declarations := registerRouteDeclarations(t)
+	if len(declarations) < 10 {
+		t.Fatalf("found %d RegisterRoute declarations, too few to be the whole set", len(declarations))
+	}
+
+	for _, found := range declarations {
+		if found.handlerType != want {
+			t.Errorf("%s: %s takes a handler of type %s, so it does not satisfy runtime.RouteRegistrar "+
+				"and the runtime will never register a flow on it. Write the parameter as %s.",
+				found.position, found.receiver, found.handlerType, want)
+		}
+	}
+}
+
+type registerRoute struct {
+	position    string
+	receiver    string
+	handlerType string
+}
+
+// registerRouteDeclarations returns every RegisterRoute method declared under
+// internal/connector, with the source text of its handler parameter.
+func registerRouteDeclarations(t *testing.T) []registerRoute {
+	t.Helper()
+
+	root, err := filepath.Abs(filepath.Join("..", "connector"))
+	if err != nil {
+		t.Fatalf("locating the connector packages: %v", err)
+	}
+
+	var found []registerRoute
+	fset := token.NewFileSet()
+
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "RegisterRoute" || fn.Recv == nil {
+				continue
+			}
+			// The handler is the second parameter; the first is the operation.
+			params := fn.Type.Params.List
+			if len(params) < 2 {
+				continue
+			}
+			var handler bytes.Buffer
+			if err := printer.Fprint(&handler, fset, params[len(params)-1].Type); err != nil {
+				return err
+			}
+			found = append(found, registerRoute{
+				position:    fset.Position(fn.Pos()).String(),
+				receiver:    receiverName(fn),
+				handlerType: handler.String(),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the connector packages: %v", err)
+	}
+
+	return found
+}
+
+func receiverName(fn *ast.FuncDecl) string {
+	if len(fn.Recv.List) == 0 {
+		return "RegisterRoute"
+	}
+	switch receiver := fn.Recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if ident, ok := receiver.X.(*ast.Ident); ok {
+			return "*" + ident.Name + ".RegisterRoute"
+		}
+	case *ast.Ident:
+		return receiver.Name + ".RegisterRoute"
+	}
+	return "RegisterRoute"
+}


### PR DESCRIPTION
Refs #87.

## The reported bug

The REST error status was picked by searching the error's **message** for `validation`, `required` or `invalid`. That message carries names chosen by whoever wrote the flow: a response field called `invalidated` contains `invalid`, and `examples/cache` ships one.

So every failure raised while evaluating that mapping was reported as the caller's doing, whatever had actually gone wrong. The branch below then reasoned that a `400` was a validation error and its text was therefore safe to return — so **renaming a response field turned an opaque error into a published one**. Reproduced against a built binary, two flows differing only in that name, same request, `MYCEL_ENV=production`:

```
POST /named-invalidated -> 400 {"error":"response transform error: failed to evaluate
                                expression for 'invalidated': got 'types.String', ..."}
POST /named-count       -> 500 {"error":"Internal Server Error"}
```

Whose fault a failure was is now decided by **type** — `pkg/errors.Validation`, which the runtime already implements and the aspect executor already consults, plus `sanitize.ErrRejected`. Anything unrecognised is the service's, which is the safe default in both directions: the work stays retryable and nothing internal is quoted. What a caller is told follows from the same answer rather than from the status, so a `4xx` chosen for any other reason can no longer publish internal text.

Genuine validation still answers `400` with its message — verified, including a custom `validator` whose message contains none of the three words.

## Three more places the same defect lived

Found by verifying rather than by reading.

**Input and output validation shared one error type.** A flow whose own answer failed `validate { output }` answered `400` with the field names of an internal record — telling a caller its request was at fault when no request could have satisfied it, and telling it not to retry something a retry might well have fixed. Output failures are now their own type and report `500`.

**Only REST asked what environment it was running in.** `graphql`, `soap`, `websocket` and `tcp` returned raw internal error text everywhere, production included. Verified on all four with real clients — a database error carried the table name into a SOAP `faultstring`, a GraphQL `errors[].message` and the frame of a socket. All five now share one rule, each in its own protocol's shape.

GraphQL keeps one deliberate exception: an error carrying **no path** failed before any flow ran — a malformed query, an unknown field, an argument of the wrong type — and that is the caller's own to fix and most of what a GraphQL endpoint is worth to whoever writes against it, so it is still explained in full. An `error_response` block is unaffected: its status, headers and body were written for the caller.

**A TCP server registered no flows at all**, and a flow reading from a remote GraphQL subscription received nothing. Both spelled the handler parameter of `RegisterRoute` as their own `HandlerFunc`; the runtime finds a connector by asserting it to `runtime.RouteRegistrar`, an interface written with the unnamed function type, and Go requires an identical type rather than a compatible one. The assertion failed **silently** — it compiles, the connector starts and reports itself listening, the banner prints the flows, and every message a TCP server received was answered `unknown message type`. Their own tests passed because they call `RegisterRoute` directly, which is the one caller that never had the problem.

A parity test now reads every `RegisterRoute` declaration under `internal/connector` and requires the parameter to be written out in full, because the types are precisely what does not complain.

## Documentation

Neither the status nor the disclosure was written down anywhere. `guides/error-handling.md` gains **What a Caller Is Told** (which failures are `400`, which are `500`, what production withholds, and the GraphQL exception), and `guides/security.md` gains the class and a row in the mitigations table — that is where someone auditing looks.

Also fixes a broken anchor from 3.4.0: `#binding-a-set-in-name` was written for the slug mkdocs produced before the slugify configuration stopped collapsing double dashes, so it pointed at nothing on the published site.

## Verification

- Both new REST tests, and the parity test, run against the unfixed code before being kept.
- Every case reproduced and re-checked against a built binary, in production and development: the reported bug, output validation, and all four other servers.
- Every claim in the new documentation run against the binary, including `--env production` and an `error_response` block being sent as written in production.
- Unit suite, `vet`, `gofmt` clean; `-race` clean on the packages touched. `mkdocs build --strict` with no warnings. 65 example directories validate. Integration via `run.sh`: **216 passed, 0 failed**.
