### PR TITLE
Release 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.0] - 2026-08-31
 
 ### Security
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.4.0"
+	version = "3.5.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.5.0. Two files, two lines: the `[Unreleased]` heading becomes `[3.5.0] - 2026-08-31`, and the version constant in `cmd/mycel/main.go`.

## What is in the release

Two bugs reported as #87 and #88, fixed in #89 and #90. Both turned out to be wider than reported.

**Security** — the section the release notes will open with:

- A REST error's HTTP status was inferred from the error's **text**, so a response field named `invalidated` made internal failures a `400` and published their message in production. Renaming a field turned an opaque error into a disclosed one.
- Input and output validation shared one error type, so a flow that broke its **own** output contract answered `400` and named the fields of an internal record.
- Only the REST connector asked what environment it was running in — `graphql`, `soap`, `websocket` and `tcp` returned raw internal error text everywhere, production included.

**Fixed:**

- A TCP server registered no flows at all, and a flow reading from a remote GraphQL subscription received nothing — a handler parameter spelled as a named function type never satisfied the interface the runtime asserts to, silently.
- A hot reload added a second set of health checkers, so one reload marked a service unhealthy permanently while it served traffic normally.

## Why 3.5.0 and not 4.0.0

No breaking changes. Two things do change observable behaviour — a `500` where a `400` used to be returned, and less text in a production error — but in both cases the previous behaviour was the defect, and nobody had the old behaviour working on purpose. The `Security` section means the release notes lead with what to read before upgrading, which is the point.

## Verification

- `go.mod` still declares `go 1.25.0` and both Dockerfiles still pin `golang:1.25-alpine`; `go mod tidy` changes neither `go.mod` nor `go.sum`.
- The compiled binary reports `mycel 3.5.0` — the Dockerfile builds without `-X main.version`, so the image reports whatever this constant says.
- The release job's extraction was run against the edited `CHANGELOG.md`: it finds the `3.5.0` section and lifts `Security` with all three entries.
- Unit suite, `vet`, `gofmt` clean. 65 example directories validate. `main` was green on both merges, and #90's integration ran on the combined tree: **196 passed, 0 failed**.
