### PR TITLE
Track parts of a message independently, and run dedupe when a flow has several destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`facet` blocks in `dedupe`, so one message can be split into parts that are tracked, gated and committed independently.** A fingerprint answers one question — did anything change — and its only verb is to drop the message. That is the right shape while every part of a message costs about the same to apply, and the wrong one when it does not: a product message carries its data and its images together, the images are URLs the downstream goes and fetches, and with one fingerprint a message whose *name* changed re-sends the images too — so anything waiting on that product waits minutes for work nobody asked for. Each facet declares its own projection and is stored under its own key; a `to` naming a facet runs only when that facet changed, and the message is dropped only when none did.
+
+  One attribute does the gating and the accounting both, which is why it is `facet` on the destination rather than a `when` plus some bookkeeping: the same name decides whether the write happens and whether its facet is committed. **Commit is per facet** — a facet is committed only once every destination naming it has succeeded, so when the catalogue write lands and the queue publish fails, the retry finds the data unchanged, does not write it a second time, and publishes only the assets. Committing them together would lose the images for the life of the entry, which is the failure the two-phase commit exists to prevent, one level down.
+
+  What a facet's success means is its `to` succeeding and nothing more: for a queue that is the broker accepting the message, not the other consumer finishing the work. `compare_when` stays a single flow-level gate — when it is false nothing is compared and every facet runs, which is what a missing downstream record needs. A bare `fingerprint {}` and `facet` blocks together are refused rather than resolved, and `mycel validate` refuses a `to` naming a facet nobody declared as well as a facet no destination names: the first would be skipped on every message, the second could never be committed and would therefore read as changed for ever, quietly disabling deduplication for the whole flow. Adding a facet to a live flow re-runs its destinations once per key, since a facet never seen reads as changed — a backfill, not a bug. Mycel does not check that facets are independent; two whose destinations write the same record will race and nothing will report it.
+
+### Fixed
+
+- **A `dedupe` block on a flow with more than one destination was parsed, validated and never consulted.** `handleMultiDestWrite` did not call `dedupeAwareWrite` at all, so a flow declaring several destinations had no deduplication whatsoever: three identical messages wrote three rows to every destination while the configuration said they would be dropped. Verified against the released 3.5.0 binary before the fix. Flows with a single `to` — and every test that called the primitive directly — were unaffected throughout, which is why it went unnoticed.
+
+- **The example-coverage test walked only the direct children of a flow.** A block declared two levels down was invisible to it, so the whole of a block's contents could go unexampled without anything noticing; `coordinate > preflight` had in fact never appeared in an example. It now walks the tree, and its label pattern accepts the bare middle label of `each "item" in "..."` rather than reporting it missing from the examples that use it — a false alarm being how a coverage test stops being read.
+
 ## [3.5.0] - 2026-08-31
 
 ### Security

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -327,7 +327,8 @@ flow "process_payment" {
 |-----------|------|----------|---------|-------------|
 | `cache` | string | yes | — | Name of a `connector { type = "cache" }`. The connector pool is initialized once at startup; the hot path does not pay a registry lookup per message |
 | `key` | string | yes | — | CEL expression for the per-resource fingerprint key (evaluated against `input.*`) |
-| `fingerprint {}` | block | yes | — | Named CEL expressions whose values form the projection. Both `input.*` and `output.*` (transform result) are in scope. Must list every persisted field — omitting one would silently drop real changes |
+| `fingerprint {}` | block | yes* | — | Named CEL expressions whose values form the projection. Both `input.*` and `output.*` (transform result) are in scope. Must list every persisted field — omitting one would silently drop real changes. *Required unless the block declares `facet` blocks instead |
+| `facet "<name>" {}` | block | no | — | An independently-tracked part of the projection, holding its own `fingerprint {}`. Each is stored and committed on its own; a `to` naming it runs only when it changed, and the message is dropped only when no facet did. Cannot be combined with a bare `fingerprint {}`. See [Splitting a message into parts](#splitting-a-message-into-parts) |
 | `ttl` | string | no | — | How long to keep stored fingerprints. Supports `"30d"` and `"2w"` plus stdlib units (`s`/`m`/`h`); malformed values fail the parse |
 | `on_duplicate` | string | no | `"ack"` | Behavior on fingerprint match: `"ack"`, `"reject"`, `"requeue"`. Matches the `sequence_guard` vocabulary so MQ consumers handle it uniformly |
 | `compare_when` | string | no | — | CEL predicate gating Phase A **only**. False: the stored fingerprint is not consulted, so the message cannot be dropped; Phase B still commits after a successful write. `input.*` and `output.*` in scope. See [When the record can vanish](#when-the-record-can-vanish) |
@@ -377,6 +378,77 @@ dedupe {
     | record deleted externally, re-send | 0 | 0 | match → **dropped**, which is the case it was added for |
 
     It breaks suppression exactly where suppression worked, and stays inert exactly where invalidation was needed.
+
+### Splitting a message into parts
+
+A fingerprint answers one question — did anything change — and its only verb is to drop the message. That is right while every part of a message costs about the same to apply. It stops being right when it does not.
+
+A product message carries its data and its images together. The data is a handful of columns; the images are URLs the downstream goes and fetches, which is minutes of work. With one fingerprint, a message whose *name* changed re-sends the images too, and anything waiting on that product waits for them to finish.
+
+`facet` blocks split the projection into parts that are fingerprinted, stored and committed independently. A `to` naming a facet runs only when that facet changed; the message is dropped only when **none** did.
+
+```hcl
+dedupe {
+  cache        = "fp_cache"
+  key          = "'item_fp:' + input.body.sku"
+  ttl          = "30d"
+  on_duplicate = "ack"              # applies when no facet changed
+
+  facet "data" {
+    fingerprint {
+      sku   = "output.sku"
+      name  = "output.name"
+      price = "output.price"
+    }
+  }
+
+  facet "assets" {
+    fingerprint {
+      sku        = "output.sku"
+      main_image = "output.main_image"
+      gallery    = "output.gallery"
+    }
+  }
+}
+
+to {
+  facet     = "data"                # skipped when the data facet is unchanged
+  connector = "catalog"
+  target    = "catalog_items"
+  parallel  = true
+}
+
+to {
+  facet     = "assets"              # skipped when the assets facet is unchanged
+  connector = "asset_jobs"          # a queue a second consumer reads
+  target    = "item.assets.q"
+  parallel  = true
+}
+```
+
+What each kind of message now does:
+
+| The message changes | data destination | assets destination |
+|---------------------|------------------|--------------------|
+| Nothing | — | — (message dropped) |
+| The name only | writes | — |
+| An image only | — | publishes |
+| Both | writes | publishes |
+
+**Commit is per facet, and that is the point.** A facet is committed only once every destination naming it has succeeded. If the catalogue write lands and the queue publish fails, the data facet is committed and the assets facet is not: the retry finds the data unchanged, does not write it a second time, and publishes the assets. Committing them together would have lost the images for the life of the entry — the same failure the two-phase commit exists to prevent, one level down.
+
+**What a facet's success means.** It means its `to` succeeded, and nothing more. For a queue that is "the broker accepted the message", not "the other consumer finished the work" — there is no callback, and Mycel does not ask. The assets facet records that this set of images was *handed over* once. Past the handoff it is the second consumer's problem: its retries, its dead-letter queue, its own dedupe. Design the split so that is a reasonable place for the responsibility to change hands.
+
+A few rules worth knowing before reaching for them:
+
+- A `to` **without** `facet` runs whenever the message is not dropped — which is what every flow without facets does, so nothing changes for them.
+- Each facet is stored under its own key, so a facet that has never been seen reads as changed. Adding a facet to a live flow therefore re-runs its destinations once per key: a backfill, not a bug, and worth planning the rollout around.
+- `compare_when` stays a single flow-level gate. When it is false nothing is compared and **every** facet runs — which is what a missing downstream record needs, since an assets-only message against a record that no longer exists would otherwise never re-create it.
+- A bare `fingerprint {}` and `facet` blocks in the same `dedupe` are refused: honouring both would mean deciding which one drops the message.
+- `mycel validate` refuses a `to` naming a facet nobody declared, and a facet no destination names. Both would otherwise be silent — the first skipped on every message, the second never committed and therefore permanently "changed", which quietly disables deduplication for the whole flow.
+
+!!! warning "Mycel does not check that facets are independent"
+    Facets are a statement by the author that these parts of the message can be applied separately. Two facets whose destinations write the same record will race, and nothing here will report it. Split by what the destinations actually touch — a domain, a table, a subsystem — not by what is convenient to name.
 
 ### Pipeline order
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -983,6 +983,56 @@ dedupe {
 }
 ```
 
+**`facet` — tracking parts of a message independently.**
+
+A bare `fingerprint {}` answers one question — did anything change — and its only verb is to drop the message. That is the wrong shape when one message carries work of different weights: a product's data and its images arrive together, the images take minutes because the far side downloads them, and re-sending both because a name changed makes the cheap half wait for the expensive one.
+
+Facets split the projection into independently-tracked parts. Each is fingerprinted, stored and committed on its own; a `to` naming a facet runs only when that facet changed, and the message is dropped only when **no** facet did.
+
+```hcl
+dedupe {
+  cache        = "redis_cache"
+  key          = "'sku_fp:' + input.body.payload.sku"
+  ttl          = "30d"
+  on_duplicate = "ack"                       # applies when no facet changed
+
+  facet "data" {
+    fingerprint {
+      name   = "output.name"
+      prices = "output.prices"
+    }
+  }
+
+  facet "assets" {
+    fingerprint {
+      main_image = "output.main_image"
+      gallery    = "output.gallery"
+    }
+  }
+}
+
+to {
+  facet     = "data"                         # skipped when the data facet did not change
+  connector = "magento"
+  target    = "/rest/V1/products"
+}
+
+to {
+  facet     = "assets"                       # skipped when the assets facet did not change
+  connector = "rabbit"
+  target    = "assets.q"
+}
+```
+
+- A `to` **without** `facet` runs whenever the message is not dropped — which is what every flow without facets does.
+- Each facet is stored under its own key (`dedupe:<flow>:<key>:<facet>`), so a facet that has never been seen reads as changed. Introducing a facet therefore re-runs its destinations once per key, which is a backfill, not a bug.
+- **Commit is per facet.** A facet is committed only once every destination naming it has succeeded. When the data lands and the asset enqueue fails, the data facet is committed and the assets facet is not, so the retry re-sends only what did not land — committing them together would lose the assets for as long as the entry lives.
+- `compare_when` stays a single flow-level gate. When it is false nothing is compared, so **every** facet runs — which is what a missing downstream record requires: an assets-only message against a record that no longer exists would otherwise never re-create it.
+- A bare `fingerprint {}` and `facet` blocks in the same `dedupe` are refused. Honouring both would mean deciding which one drops the message.
+
+!!! warning "Mycel does not check that facets are independent"
+    Facets are a statement by the author that these parts of the message can be applied separately. Two facets whose destinations write the same thing will race, and nothing here will report it. Split by what the destinations actually touch — a domain, a table, a subsystem — not by what is convenient to name.
+
 **Pipeline order:** `dedupe` runs **after** `transform` because the fingerprint expressions reference `output.*`. Earlier versions (≤ 2.0.0) ran a key-based dedupe before transform; see CHANGELOG v2.1.0 for migration.
 
 **`compare_when` — when "already seen" and "already applied" diverge.** A stored fingerprint says this content was written once, not that it is still written. If the downstream record can disappear by a path the flow never observes — a manual delete, a restore, a data fix — nothing clears the fingerprint, and the re-send that was meant to repair the damage is dropped as a duplicate instead. `compare_when` is how a flow says the stored fingerprint is no longer trustworthy:

--- a/examples/dedupe/connectors.mycel
+++ b/examples/dedupe/connectors.mycel
@@ -53,3 +53,15 @@ connector "catalog" {
   driver   = "sqlite"
   database = env("CATALOG_DB", "./data/catalog.db")
 }
+
+// Where the slow half goes. A second consumer reads this queue and applies
+// the images at its own pace, so this flow's own work finishes as soon as the
+// broker has accepted the message.
+//
+// It is deliberately a different connector from `rabbit` above: that one is a
+// source with a queue{} to consume, this one is only ever written to.
+connector "asset_jobs" {
+  type   = "mq"
+  driver = "rabbitmq"
+  url    = env("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+}

--- a/examples/dedupe/item_update_split_by_facet.mycel
+++ b/examples/dedupe/item_update_split_by_facet.mycel
@@ -1,0 +1,89 @@
+// Splitting one message into parts that are tracked separately.
+//
+// The two flows beside this one treat a message as one thing: either
+// something changed and the whole message is written, or nothing did and it
+// is dropped. That is the right shape while every part of the message costs
+// about the same to apply.
+//
+// It stops being right when it does not. A product message carries its data
+// and its images together. The data is a handful of columns; the images are
+// URLs the downstream goes and downloads, which is minutes of work. With one
+// fingerprint, a message whose name changed re-sends the images too — and
+// anything waiting on this product waits for those images to finish.
+//
+// Facets split the projection into parts that are fingerprinted, stored and
+// committed on their own. Here the data goes straight to the catalogue and
+// the images are handed to a queue for a second consumer to apply in the
+// background, so the fast half never waits for the slow one.
+flow "item_update_split" {
+  from {
+    connector = "rabbit"
+    operation = "item.update.split"
+  }
+
+  transform {
+    sku   = "input.body.sku"
+    name  = "input.body.name"
+    price = "input.body.price"
+
+    // The assets: URLs the downstream fetches, which is why they are slow.
+    main_image = "input.body.main_image ?? ''"
+    gallery    = "input.body.gallery ?? []"
+  }
+
+  dedupe {
+    cache = "fp_cache"
+    key   = "'item_fp:' + input.body.sku"
+    ttl   = "30d"
+
+    // Applies when NO facet changed — the message says nothing new about any
+    // part of the product, so there is nothing to do with it.
+    on_duplicate = "ack"
+
+    // What the catalogue stores directly. Cheap to apply, so it is worth
+    // applying on its own as soon as it changes.
+    facet "data" {
+      fingerprint {
+        sku   = "output.sku"
+        name  = "output.name"
+        price = "output.price"
+      }
+    }
+
+    // What somebody else has to fetch. A change here is expensive, and a
+    // change to the name above must not drag it along.
+    facet "assets" {
+      fingerprint {
+        sku        = "output.sku"
+        main_image = "output.main_image"
+        gallery    = "output.gallery"
+      }
+    }
+  }
+
+  // Runs only when the data facet changed, and commits it only if it lands.
+  to {
+    facet     = "data"
+    connector = "catalog"
+    target    = "catalog_items"
+    parallel  = true
+  }
+
+  // Runs only when the assets facet changed. What is committed here is the
+  // handoff, not the work: the facet records that this set of images was
+  // published to the queue once, not that the downstream finished applying
+  // them. Where that guarantee ends is the queue — from there it is the
+  // second consumer's retries, its dead-letter queue and its own dedupe.
+  //
+  // The pair-off that makes this worth the machinery: if the catalogue write
+  // succeeds and this publish fails, only the data facet is committed. The
+  // retry finds the data unchanged, does not write it a second time, and
+  // publishes the assets. Committing both together would have lost the images
+  // for the life of the entry.
+  to {
+    facet     = "assets"
+    connector = "asset_jobs"
+    target    = "item.assets.q"
+    parallel  = true
+  }
+}

--- a/examples/sync/flows/process_entity.mycel
+++ b/examples/sync/flows/process_entity.mycel
@@ -22,6 +22,17 @@ flow "process_entity" {
     max_retries          = 3
     max_concurrent_waits = 10
 
+    # Before waiting at all, ask whether the thing being waited for is
+    # already there. A signal has a TTL, so a child arriving late finds
+    # nothing to wait for even though its parent was processed hours ago —
+    # and would wait out the whole timeout for a message that will never
+    # come. The check answers from the record itself, which does not expire.
+    preflight {
+      connector = "postgres"
+      query     = "SELECT 1 FROM entities WHERE id = :parent_id AND status = 'ready'"
+      if_exists = "pass"
+    }
+
     # Child entities wait for their parent to be processed
     wait {
       when = "input.headers.type == 'child'"

--- a/internal/examples/coverage_test.go
+++ b/internal/examples/coverage_test.go
@@ -95,17 +95,22 @@ var flowBlocksWithoutAnExample = map[string]string{}
 func TestEveryFlowBlockHasAnExample(t *testing.T) {
 	config := everyExampleConfig(t)
 
+	// Nested, not just the direct children. A block declared two levels down
+	// is as real as one declared at the top — `dedupe > facet` is a feature in
+	// its own right — and walking one level meant the whole of a block's
+	// contents could go unexampled without this noticing.
 	var missing []string
-	for _, child := range schema.FlowSchema().Children {
-		if _, allowed := flowBlocksWithoutAnExample[child.Type]; allowed {
-			continue
-		}
-		// `block {` or `block "label" {`, at the start of a line.
-		used := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(child.Type) + `\s*("[^"]*"\s*)?\{`).MatchString(config)
-		if !used {
-			missing = append(missing, child.Type)
+	var walk func(parent schema.Block, path string)
+	walk = func(parent schema.Block, path string) {
+		for _, child := range parent.Children {
+			where := path + " > " + child.Type
+			if _, allowed := flowBlocksWithoutAnExample[child.Type]; !allowed && !blockAppearsIn(config, child) {
+				missing = append(missing, where)
+			}
+			walk(child, where)
 		}
 	}
+	walk(schema.FlowSchema(), "flow")
 
 	sort.Strings(missing)
 	if len(missing) > 0 {
@@ -328,4 +333,17 @@ func TestEveryAuthBlockHasAnExample(t *testing.T) {
 	if len(missing) > 0 {
 		t.Errorf("no example writes these auth blocks: %s", strings.Join(missing, ", "))
 	}
+}
+
+// blockAppearsIn reports whether an example declares this block.
+//
+// The label pattern repeats rather than allowing one: `each` takes three
+// labels, and a pattern written for a single one reported it missing from
+// examples that use it — a false alarm is how a coverage test stops being
+// read.
+func blockAppearsIn(config string, blk schema.Block) bool {
+	// A label is quoted or bare: `each "item" in "output.items"` writes its
+	// middle label as the keyword `in`, with no quotes.
+	pattern := `(?m)^\s*` + regexp.QuoteMeta(blk.Type) + `\s*(("[^"]*"|[A-Za-z_][A-Za-z0-9_]*)\s*)*\{`
+	return regexp.MustCompile(pattern).MatchString(config)
 }

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -509,6 +509,16 @@ type ToConfig struct {
 	// TransformConfig.Order.
 	TransformOrder []string
 
+	// Facet names the dedupe facet this destination satisfies.
+	//
+	// It does two things at once, which is why it is one attribute rather
+	// than a `when` plus some bookkeeping: the destination is skipped when
+	// its facet did not change, and the facet is committed only once every
+	// destination naming it has succeeded. A destination with no facet runs
+	// whenever the message is not dropped, which is what every existing flow
+	// does.
+	Facet string
+
 	// Parallel indicates if this destination should be written in parallel with others.
 	// Default is true. Set to false for sequential writes.
 	Parallel bool
@@ -829,6 +839,25 @@ type DedupeConfig struct {
 	// with sorted keys for canonicalization.
 	Fingerprint map[string]string
 
+	// Facets splits the projection into independently-tracked parts.
+	//
+	// A plain Fingerprint answers one question — did anything change — and
+	// its only verb is to drop the message. That is the wrong shape when one
+	// message carries work of different weights: a product's data and its
+	// images travel together, the images take minutes because the far side
+	// downloads them, and re-sending both because a name changed is what
+	// makes the cheap half wait for the expensive one.
+	//
+	// Each facet is fingerprinted, stored and committed on its own, and a
+	// `to` naming a facet runs only when that facet changed. The message is
+	// dropped only when no facet did. Empty means the block behaves exactly
+	// as it always has.
+	//
+	// Whether the facets are genuinely independent is the author's to decide.
+	// Two facets whose destinations write the same thing will race, and
+	// nothing here will say so.
+	Facets []DedupeFacet
+
 	// TTL is how long to keep the stored fingerprint after the last update
 	// (e.g., "30d"). Empty means no expiry. Long-tail keys can leak, so a
 	// 30-day TTL is the recommended baseline.
@@ -861,6 +890,24 @@ type DedupeConfig struct {
 	// to catch still matches and still gets dropped. Both directions land
 	// backwards.
 	CompareWhen string
+}
+
+// DedupeFacet is one independently-tracked projection inside a dedupe block.
+//
+// Its fingerprint is stored under its own key, so committing one facet says
+// nothing about the others: when a flow writes its data and fails to enqueue
+// its images, the data facet is committed and the images facet is not, and
+// the retry re-sends only what did not land. Committing them together would
+// lose the images for as long as the entry lives, which is the failure the
+// biphasic commit exists to prevent.
+type DedupeFacet struct {
+	// Name identifies the facet and is what a `to` block refers to. It is
+	// also part of the storage key, so renaming a facet resets it.
+	Name string
+
+	// Fingerprint is the facet's projection, in the same form and scope as
+	// DedupeConfig.Fingerprint.
+	Fingerprint map[string]string
 }
 
 // AsyncConfig defines async execution for a flow.

--- a/internal/parser/flow.go
+++ b/internal/parser/flow.go
@@ -571,6 +571,7 @@ func parseToBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ToConfig, error
 			{Name: "when"},
 			{Name: "parallel"},
 			{Name: "envelope"},
+			{Name: "facet"},
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "transform"},
@@ -612,6 +613,20 @@ func parseToBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.ToConfig, error
 		}
 		if val.Type() == cty.Bool {
 			to.Parallel = boolOrFalse(val)
+		}
+	}
+
+	// facet ties this destination to a dedupe facet: it is skipped when that
+	// facet did not change, and the facet is committed only once every
+	// destination naming it has succeeded.
+	if attr, ok := content.Attributes["facet"]; ok {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("to facet error: %s", diags.Error())
+		}
+		to.Facet = stringOrEmpty(val)
+		if to.Facet == "" {
+			return nil, fmt.Errorf("to facet must name a dedupe facet — omit the attribute for a destination that always runs")
 		}
 	}
 
@@ -1584,6 +1599,7 @@ func parseDedupeBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow
 		},
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "fingerprint"},
+			{Type: "facet", LabelNames: []string{"name"}},
 		},
 	}
 
@@ -1692,6 +1708,37 @@ func parseDedupeBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow
 		}
 	}
 
+	// Parse facet blocks. Each carries its own fingerprint and is tracked,
+	// stored and committed independently of the others.
+	seen := make(map[string]bool)
+	for _, b := range content.Blocks {
+		if b.Type != "facet" {
+			continue
+		}
+		name := b.Labels[0]
+		if name == "" {
+			return nil, fmt.Errorf("dedupe facet requires a name")
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("dedupe declares facet %q twice", name)
+		}
+		seen[name] = true
+
+		fingerprint, err := parseFacetFingerprint(b, ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		dedupe.Facets = append(dedupe.Facets, flow.DedupeFacet{Name: name, Fingerprint: fingerprint})
+	}
+
+	// A bare fingerprint and facets answer the same question at different
+	// granularities, and honouring both would mean deciding which one drops
+	// the message. Refused rather than resolved.
+	if len(dedupe.Fingerprint) > 0 && len(dedupe.Facets) > 0 {
+		return nil, fmt.Errorf("dedupe has both a fingerprint block and facet blocks — use one or the other: " +
+			"a bare fingerprint tracks the message as a whole, facets track parts of it independently")
+	}
+
 	if strict {
 		if dedupe.Use != "" {
 			return nil, fmt.Errorf("top-level dedupe %q cannot use `use` — that's for inline references", block.Labels[0])
@@ -1702,8 +1749,8 @@ func parseDedupeBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow
 		if dedupe.Key == "" {
 			return nil, fmt.Errorf("dedupe block must specify a key expression")
 		}
-		if fingerprintBlock == nil {
-			return nil, fmt.Errorf("dedupe block must contain a fingerprint block")
+		if fingerprintBlock == nil && len(dedupe.Facets) == 0 {
+			return nil, fmt.Errorf("dedupe block must contain a fingerprint block or at least one facet")
 		}
 	} else if dedupe.Use == "" {
 		// Inline dedupe without `use` must be self-contained (current behavior).
@@ -1713,8 +1760,8 @@ func parseDedupeBody(block *hcl.Block, ctx *hcl.EvalContext, strict bool) (*flow
 		if dedupe.Key == "" {
 			return nil, fmt.Errorf("dedupe block must specify a key expression (or `use` a named one)")
 		}
-		if fingerprintBlock == nil {
-			return nil, fmt.Errorf("dedupe block must contain a fingerprint block (or `use` a named one)")
+		if fingerprintBlock == nil && len(dedupe.Facets) == 0 {
+			return nil, fmt.Errorf("dedupe block must contain a fingerprint block or at least one facet (or `use` a named one)")
 		}
 	}
 
@@ -3396,4 +3443,50 @@ func parseStateTransitionBlock(block *hcl.Block, ctx *hcl.EvalContext) (*flow.St
 	}
 
 	return st, nil
+}
+
+// parseFacetFingerprint reads the fingerprint block of one dedupe facet.
+// A facet without one tracks nothing and would silently never change, so it
+// is refused rather than accepted as an empty projection.
+func parseFacetFingerprint(block *hcl.Block, ctx *hcl.EvalContext, facet string) (map[string]string, error) {
+	schema := &hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{{Type: "fingerprint"}},
+	}
+	content, diags := block.Body.Content(schema)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("dedupe facet %q: %s", facet, diags.Error())
+	}
+
+	var fingerprintBlock *hcl.Block
+	for _, b := range content.Blocks {
+		if b.Type != "fingerprint" {
+			continue
+		}
+		if fingerprintBlock != nil {
+			return nil, fmt.Errorf("dedupe facet %q must contain exactly one fingerprint block", facet)
+		}
+		fingerprintBlock = b
+	}
+	if fingerprintBlock == nil {
+		return nil, fmt.Errorf("dedupe facet %q must contain a fingerprint block", facet)
+	}
+
+	attrs, diags := fingerprintBlock.Body.JustAttributes()
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("dedupe facet %q fingerprint block error: %s", facet, diags.Error())
+	}
+	if len(attrs) == 0 {
+		return nil, fmt.Errorf("dedupe facet %q fingerprint block must define at least one named expression", facet)
+	}
+
+	fingerprint := make(map[string]string, len(attrs))
+	for name, attr := range attrs {
+		val, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			fingerprint[name] = extractExpressionText(attr.Expr)
+			continue
+		}
+		fingerprint[name] = stringOrEmpty(val)
+	}
+	return fingerprint, nil
 }

--- a/internal/parser/schema_parity_test.go
+++ b/internal/parser/schema_parity_test.go
@@ -44,17 +44,23 @@ func assertSchemaParses(t *testing.T, blk schema.Block, name string) {
 	for i := range labels {
 		labels[i] = name
 	}
-	doc := renderBlockFromSchema(blk, labels, 0, true)
 
-	// Not mustParse: the failure is the point, and it should name the block
-	// and show what was rendered.
-	cfg, err := tryParse(t, doc)
-	if err != nil {
-		t.Fatalf("the %s schema describes something the parser rejects: %v\n\n%s",
-			blk.Type, err, doc)
-	}
-	if cfg == nil {
-		t.Fatalf("%s parsed to nothing", blk.Type)
+	// Two children that cannot appear together are rendered one per pass, so
+	// both are still covered. Without this the second one is never parsed and
+	// the schema can start describing something the parser refuses.
+	for branch := 0; branch < parityBranches(blk); branch++ {
+		doc := renderBlockFromSchema(blk, labels, 0, true, branch)
+
+		// Not mustParse: the failure is the point, and it should name the block
+		// and show what was rendered.
+		cfg, err := tryParse(t, doc)
+		if err != nil {
+			t.Fatalf("the %s schema describes something the parser rejects: %v\n\n%s",
+				blk.Type, err, doc)
+		}
+		if cfg == nil {
+			t.Fatalf("%s parsed to nothing", blk.Type)
+		}
 	}
 }
 
@@ -64,7 +70,7 @@ func assertSchemaParses(t *testing.T, blk schema.Block, name string) {
 // nested one level deep. Depth is capped because schemas are recursive — a
 // transform can hold a transform — and the goal is coverage of each declared
 // name, not of every path through them.
-func renderBlockFromSchema(blk schema.Block, labels []string, depth int, withChildren bool) string {
+func renderBlockFromSchema(blk schema.Block, labels []string, depth int, withChildren bool, branch int) string {
 	var b strings.Builder
 
 	b.WriteString(blockHeader(blk, labels) + " {\n")
@@ -96,11 +102,14 @@ func renderBlockFromSchema(blk schema.Block, labels []string, depth int, withChi
 
 	if withChildren && depth < 5 {
 		for _, child := range blk.Children {
+			if excludedBySibling(blk, child.Type, branch) {
+				continue
+			}
 			childLabels := make([]string, child.Labels)
 			for i := range childLabels {
 				childLabels[i] = fmt.Sprintf("%s_%d", child.Type, i)
 			}
-			nested := renderBlockFromSchema(child, childLabels, depth+1, true)
+			nested := renderBlockFromSchema(child, childLabels, depth+1, true, branch)
 			for _, line := range strings.Split(strings.TrimRight(nested, "\n"), "\n") {
 				b.WriteString(indent + line + "\n")
 			}
@@ -112,7 +121,7 @@ func renderBlockFromSchema(blk schema.Block, labels []string, depth int, withChi
 			// rather than a trick: one writes via a transaction, the other
 			// via query.
 			if childExcludesAttrs(child) {
-				alt := renderBlockFromSchema(child, childLabels, depth+1, false)
+				alt := renderBlockFromSchema(child, childLabels, depth+1, false, branch)
 				for _, line := range strings.Split(strings.TrimRight(alt, "\n"), "\n") {
 					b.WriteString(indent + line + "\n")
 				}
@@ -257,4 +266,44 @@ func tryParseFiles(t *testing.T, files map[string]string) (*Configuration, error
 		}
 	}
 	return NewHCLParser().Parse(context.Background(), dir)
+}
+
+// exclusiveChildren lists children that cannot appear in the same block. The
+// exclusions are the language's, and each is stated in the child's own
+// documentation. Rendering both would produce a document the parser refuses
+// for a reason that has nothing to do with drift.
+var exclusiveChildren = map[string][]string{
+	// A bare fingerprint tracks the message as a whole and a facet tracks a
+	// part of it. Honouring both would mean deciding which one drops the
+	// message, so the parser refuses the pair.
+	"dedupe": {"fingerprint", "facet"},
+}
+
+// parityBranches is how many passes a block needs for every child to be
+// rendered at least once.
+func parityBranches(blk schema.Block) int {
+	if n := len(exclusiveChildren[blk.Type]); n > 1 {
+		return n
+	}
+	for _, child := range blk.Children {
+		if n := parityBranches(child); n > 1 {
+			return n
+		}
+	}
+	return 1
+}
+
+// excludedBySibling reports whether this child is the one being left out on
+// this pass.
+func excludedBySibling(parent schema.Block, child string, branch int) bool {
+	group, ok := exclusiveChildren[parent.Type]
+	if !ok {
+		return false
+	}
+	for i, name := range group {
+		if name == child {
+			return i != branch%len(group)
+		}
+	}
+	return false
 }

--- a/internal/runtime/dedupe.go
+++ b/internal/runtime/dedupe.go
@@ -65,11 +65,11 @@ func (h *FlowHandler) dedupeAwareWrite(
 	ctx context.Context,
 	input map[string]interface{},
 	payload map[string]interface{},
-	write func() (interface{}, error),
+	write func(context.Context) (interface{}, error),
 ) (interface{}, error) {
 	cfg := h.Config.Dedupe
 	if cfg == nil {
-		return write()
+		return write(ctx)
 	}
 	if h.DedupeCache == nil {
 		// Misconfiguration caught at registration time normally; defend
@@ -89,7 +89,14 @@ func (h *FlowHandler) dedupeAwareWrite(
 		return nil, err
 	}
 
-	fp, err := h.computeDedupeFingerprint(ctx, input, payload)
+	// A flow declares one or the other; the parser refuses both.
+	var fp []byte
+	var facetFingerprints map[string][]byte
+	if len(cfg.Facets) > 0 {
+		facetFingerprints, err = h.computeDedupeFacetFingerprints(ctx, input, payload)
+	} else {
+		fp, err = h.computeDedupeFingerprint(ctx, input, payload)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +133,9 @@ func (h *FlowHandler) dedupeAwareWrite(
 	// comparison and its verdict, and a breakpoint on dedupe stops before the
 	// fingerprint is looked up rather than never.
 	return trace.RecordStage(ctx, trace.StageDedupe, key, input, func() (interface{}, error) {
+		if len(cfg.Facets) > 0 {
+			return h.dedupeDecideFacets(ctx, lockCfg, storageKey, key, facetFingerprints, ttl, cfg, compare, write)
+		}
 		return h.dedupeDecide(ctx, lockCfg, lockKey, storageKey, key, fp, ttl, cfg, compare, write)
 	})
 }
@@ -181,7 +191,7 @@ func (h *FlowHandler) dedupeDecide(
 	ttl time.Duration,
 	cfg *flow.DedupeConfig,
 	compare bool,
-	write func() (interface{}, error),
+	write func(context.Context) (interface{}, error),
 ) (interface{}, error) {
 	return h.SyncManager.ExecuteWithLock(ctx, lockCfg, lockKey, func() (interface{}, error) {
 		// Phase A: GET stored, compare — unless the flow gated it.
@@ -209,7 +219,7 @@ func (h *FlowHandler) dedupeDecide(
 		}
 
 		// Not a duplicate — run the actual write.
-		result, writeErr := write()
+		result, writeErr := write(ctx)
 		if writeErr != nil {
 			// Phase B runs after a failed write ONLY when the flow's
 			// error_handling will ack this failure (e.g. on_timeout

--- a/internal/runtime/dedupe_ack_commit_test.go
+++ b/internal/runtime/dedupe_ack_commit_test.go
@@ -30,7 +30,7 @@ func TestDedupe_AckOnTimeoutCommitsFingerprint(t *testing.T) {
 	input := map[string]interface{}{"sku": "X1"}
 
 	var calls int
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		calls++
 		return nil, context.DeadlineExceeded // simulate the backend timeout
 	}
@@ -70,7 +70,7 @@ func TestDedupe_RequeueOnErrorSkipsCommit(t *testing.T) {
 
 	boom := errors.New("downstream blew up")
 	var calls int
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		calls++
 		if calls == 1 {
 			return nil, boom
@@ -105,7 +105,7 @@ func TestDedupe_NoHandlerSkipsCommit(t *testing.T) {
 	input := map[string]interface{}{"sku": "X1"}
 
 	var calls int
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		calls++
 		if calls == 1 {
 			return nil, context.DeadlineExceeded
@@ -142,7 +142,7 @@ func TestDedupe_SuccessStillCommits(t *testing.T) {
 	input := map[string]interface{}{"sku": "X1"}
 
 	var calls int
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		calls++
 		return &connector.Result{Affected: 1}, nil
 	}

--- a/internal/runtime/dedupe_compare_when_test.go
+++ b/internal/runtime/dedupe_compare_when_test.go
@@ -66,9 +66,9 @@ func newCompareWhenHandler(t *testing.T, compareWhen string) (*FlowHandler, *byt
 }
 
 // countingWrite returns a write closure plus a live counter of its calls.
-func countingWrite() (func() (interface{}, error), *int32) {
+func countingWrite() (func(context.Context) (interface{}, error), *int32) {
 	var calls int32
-	return func() (interface{}, error) {
+	return func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		return &connector.Result{Affected: 1}, nil
 	}, &calls

--- a/internal/runtime/dedupe_facets.go
+++ b/internal/runtime/dedupe_facets.go
@@ -1,0 +1,264 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/matutetandil/mycel/v3/internal/flow"
+	msync "github.com/matutetandil/mycel/v3/internal/sync"
+)
+
+// Facets are the same primitive at a finer grain.
+//
+// A plain fingerprint answers one question — did anything change — and its
+// only verb is to drop the message. That is the wrong shape when one message
+// carries work of different weights: a product's data and its images arrive
+// together, the images take minutes because the far side downloads them, and
+// re-sending both because a name changed makes the cheap half wait for the
+// expensive one.
+//
+// Each facet is fingerprinted, stored and committed on its own. A destination
+// naming a facet runs only when that facet changed, and the message is dropped
+// only when none did. What makes it worth the machinery is the commit: when
+// the data lands and the asset enqueue fails, the data facet is committed and
+// the assets facet is not, so the retry re-sends only what did not land.
+// Committing them together would lose the assets for as long as the entry
+// lives — the same failure the biphasic commit exists to prevent, one level
+// down.
+
+// changedFacetsKey carries the set of facets a message changed from the
+// dedupe decision to the destinations, which cannot be told any other way:
+// the write closure is opaque to dedupe and the destinations run inside it.
+type changedFacetsKey struct{}
+
+// withChangedFacets returns a context carrying the facets this message
+// changed. A nil set means the flow has no facets, which is every flow that
+// existed before them.
+func withChangedFacets(ctx context.Context, changed map[string]bool) context.Context {
+	return context.WithValue(ctx, changedFacetsKey{}, changed)
+}
+
+// facetChanged reports whether a destination naming this facet should run.
+//
+// A destination with no facet always runs, and so does every destination on a
+// flow with no facets — that is what keeps this invisible to flows that do not
+// use it.
+func facetChanged(ctx context.Context, facet string) bool {
+	if facet == "" {
+		return true
+	}
+	changed, ok := ctx.Value(changedFacetsKey{}).(map[string]bool)
+	if !ok || changed == nil {
+		return true
+	}
+	return changed[facet]
+}
+
+// dedupeFacetStorageKey namespaces a facet's fingerprint under the message's
+// key. A facet has its own entry rather than sharing one map, so introducing
+// facets leaves every fingerprint already stored untouched and readable.
+func dedupeFacetStorageKey(flowName, key, facet string) string {
+	return dedupeStorageKey(flowName, key) + ":" + facet
+}
+
+// computeDedupeFacetFingerprints evaluates each facet's projection.
+func (h *FlowHandler) computeDedupeFacetFingerprints(
+	ctx context.Context,
+	input map[string]interface{},
+	payload map[string]interface{},
+) (map[string][]byte, error) {
+	cfg := h.Config.Dedupe
+	fingerprints := make(map[string][]byte, len(cfg.Facets))
+
+	for _, facet := range cfg.Facets {
+		projection := make(map[string]interface{}, len(facet.Fingerprint))
+		for name, expr := range facet.Fingerprint {
+			v, err := h.Transformer.EvaluateExpressionWithOutput(ctx, input, payload, expr)
+			if err != nil {
+				return nil, fmt.Errorf("dedupe facet %q fingerprint[%q] evaluation: %w", facet.Name, name, err)
+			}
+			projection[name] = v
+		}
+		fp, err := Fingerprint(projection)
+		if err != nil {
+			return nil, fmt.Errorf("dedupe facet %q: %w", facet.Name, err)
+		}
+		fingerprints[facet.Name] = fp
+	}
+	return fingerprints, nil
+}
+
+// dedupeDecideFacets is Phase A and Phase B for a flow with facets.
+//
+// Phase A reads each facet's stored fingerprint and builds the set that
+// changed; when none did, the message is dropped exactly as a whole-message
+// match would drop it. Phase B commits each changed facet whose destinations
+// all succeeded.
+func (h *FlowHandler) dedupeDecideFacets(
+	ctx context.Context,
+	lockCfg *msync.FlowLockConfig,
+	storageKey string,
+	key string,
+	fingerprints map[string][]byte,
+	ttl time.Duration,
+	cfg *flow.DedupeConfig,
+	compare bool,
+	write func(context.Context) (interface{}, error),
+) (interface{}, error) {
+	return h.SyncManager.ExecuteWithLock(ctx, lockCfg, lockCfg.Key, func() (interface{}, error) {
+		changed := make(map[string]bool, len(cfg.Facets))
+
+		for _, facet := range cfg.Facets {
+			// compare_when stays a single flow-level gate. When it is false
+			// nothing is consulted, so every facet runs — which is what a
+			// missing downstream record requires: an assets-only message
+			// against a record that no longer exists would otherwise never
+			// re-create it, because the facet describing the record still
+			// matches.
+			if !compare {
+				changed[facet.Name] = true
+				continue
+			}
+
+			stored, found, err := h.DedupeCache.Get(ctx, dedupeFacetStorageKey(h.Config.Name, key, facet.Name))
+			if err != nil {
+				// Fail open, as the whole-message path does: one extra
+				// downstream call is recoverable, a swallowed message is not.
+				slog.Warn("dedupe facet Get failed; treating the facet as changed",
+					"flow", h.Config.Name,
+					"key", key,
+					"facet", facet.Name,
+					"error", err)
+				changed[facet.Name] = true
+				continue
+			}
+			changed[facet.Name] = !found || !bytes.Equal(stored, fingerprints[facet.Name])
+		}
+
+		if !anyChanged(changed) {
+			slog.Info("dedupe match on every facet; dropping duplicate",
+				"flow", h.Config.Name,
+				"key", key,
+				"policy", cfg.OnDuplicate)
+			return &flow.FilteredResultWithPolicy{
+				Filtered: true,
+				Policy:   cfg.OnDuplicate,
+				Reason:   "dedupe_match",
+				Detail:   fmt.Sprintf("key %q already seen within the dedupe window, on every facet", key),
+			}, nil
+		}
+
+		result, writeErr := write(withChangedFacets(ctx, changed))
+
+		// Phase B. A facet is committed only when every destination naming it
+		// succeeded, so a partial failure leaves the part that did not land
+		// looking changed and the retry re-sends only that part.
+		landed := facetsThatLanded(h.Config, changed, result, writeErr)
+		for name := range landed {
+			if setErr := h.DedupeCache.Set(ctx, dedupeFacetStorageKey(h.Config.Name, key, name), fingerprints[name], ttl); setErr != nil {
+				slog.Warn("dedupe facet commit failed; next identical message will not be filtered on this facet",
+					"flow", h.Config.Name,
+					"key", key,
+					"facet", name,
+					"error", setErr)
+			}
+		}
+
+		if writeErr != nil {
+			return nil, writeErr
+		}
+		return result, nil
+	})
+}
+
+func anyChanged(changed map[string]bool) bool {
+	for _, c := range changed {
+		if c {
+			return true
+		}
+	}
+	return false
+}
+
+// facetsThatLanded returns the facets whose every destination succeeded.
+//
+// Only facets that ran are considered: one that did not change was not
+// written and its stored fingerprint is already the right one.
+func facetsThatLanded(
+	cfg *flow.Config,
+	changed map[string]bool,
+	result interface{},
+	writeErr error,
+) map[string]bool {
+	landed := make(map[string]bool, len(changed))
+
+	// A single destination: the flow's own error is the whole verdict.
+	if len(cfg.MultiTo) == 0 {
+		if writeErr != nil {
+			return landed
+		}
+		for name, didChange := range changed {
+			if !didChange {
+				continue
+			}
+			// With one destination there is nothing to attribute: either it
+			// named this facet, or the facet has no destination at all and
+			// validation refused the flow before it ran.
+			if cfg.To == nil || cfg.To.Facet == "" || cfg.To.Facet == name {
+				landed[name] = true
+			}
+		}
+		return landed
+	}
+
+	// Several destinations: the per-destination report says which of them
+	// failed, so a facet is judged on its own destinations rather than on
+	// whether the message as a whole succeeded.
+	failed := failedDestinations(result, cfg)
+
+	for name, didChange := range changed {
+		if !didChange {
+			continue
+		}
+		ran := false
+		ok := true
+		for _, dest := range cfg.MultiTo {
+			if dest.Facet != name {
+				continue
+			}
+			ran = true
+			if failed[dest] {
+				ok = false
+			}
+		}
+		if ran && ok {
+			landed[name] = true
+		}
+	}
+	return landed
+}
+
+// failedDestinations maps each destination to whether it reported an error.
+// When the write produced no per-destination report at all — it failed before
+// reaching them — every destination counts as failed, so nothing is committed.
+func failedDestinations(result interface{}, cfg *flow.Config) map[*flow.ToConfig]bool {
+	failed := make(map[*flow.ToConfig]bool, len(cfg.MultiTo))
+
+	multi, ok := result.(*MultiDestResult)
+	if !ok || multi == nil {
+		for _, dest := range cfg.MultiTo {
+			failed[dest] = true
+		}
+		return failed
+	}
+
+	labels := destinationLabels(cfg.MultiTo)
+	for _, dest := range cfg.MultiTo {
+		_, hasError := multi.Errors[labels[dest]]
+		failed[dest] = hasError
+	}
+	return failed
+}

--- a/internal/runtime/dedupe_facets_test.go
+++ b/internal/runtime/dedupe_facets_test.go
@@ -1,0 +1,317 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/matutetandil/mycel/v3/internal/connector"
+	"github.com/matutetandil/mycel/v3/internal/connector/cache/memory"
+	"github.com/matutetandil/mycel/v3/internal/connector/cache/types"
+	"github.com/matutetandil/mycel/v3/internal/flow"
+	msync "github.com/matutetandil/mycel/v3/internal/sync"
+	"github.com/matutetandil/mycel/v3/internal/transform"
+)
+
+// A message can carry work of different weights. A product's data and its
+// images arrive together, the images take minutes because the far side
+// downloads them, and a whole-message fingerprint re-sends both because a name
+// changed — which is what makes the cheap half wait for the expensive one.
+//
+// Facets track the parts separately. What has to hold: only the parts that
+// changed are written, nothing is written when none did, and a facet is
+// committed only when its own destinations succeeded — so a partial failure
+// re-sends the part that did not land and only that part.
+
+func facetHandler(t *testing.T, destinations []*flow.ToConfig) (*FlowHandler, func()) {
+	t.Helper()
+
+	memCache := memory.New("fp_cache", &types.Config{Driver: "memory"})
+	if err := memCache.Connect(context.Background()); err != nil {
+		t.Fatalf("cache connect: %v", err)
+	}
+	mgr := msync.NewManager()
+	tr, err := transform.NewCELTransformer()
+	if err != nil {
+		t.Fatalf("transformer: %v", err)
+	}
+
+	h := &FlowHandler{
+		Config: &flow.Config{
+			Name:    "split",
+			From:    &flow.FromConfig{Connector: "rabbit"},
+			MultiTo: destinations,
+			Dedupe: &flow.DedupeConfig{
+				Cache:       "fp_cache",
+				Key:         "'sku:' + input.sku",
+				OnDuplicate: "ack",
+				TTL:         "1h",
+				Facets: []flow.DedupeFacet{
+					{Name: "data", Fingerprint: map[string]string{"name": "output.name"}},
+					{Name: "assets", Fingerprint: map[string]string{"image": "output.image"}},
+				},
+			},
+		},
+		DedupeCache: memCache,
+		SyncManager: mgr,
+		Transformer: tr,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return h, func() {
+		_ = memCache.Close(context.Background())
+		_ = mgr.Close()
+	}
+}
+
+func twoDestinations() (*flow.ToConfig, *flow.ToConfig) {
+	return &flow.ToConfig{Connector: "magento", Facet: "data"},
+		&flow.ToConfig{Connector: "rabbit", Facet: "assets"}
+}
+
+// runFacets drives one message through dedupe, reporting which destinations
+// the decision let through and which facets it asked to fail.
+func runFacets(t *testing.T, h *FlowHandler, name, image string, failing map[string]bool) (ran map[string]bool, dropped bool) {
+	t.Helper()
+
+	input := map[string]interface{}{"sku": "S1", "name": name, "image": image}
+	payload := map[string]interface{}{"name": name, "image": image}
+	ran = map[string]bool{}
+
+	result, err := h.dedupeAwareWrite(context.Background(), input, payload,
+		func(ctx context.Context) (interface{}, error) {
+			report := &MultiDestResult{
+				Results: map[string]interface{}{},
+				Errors:  map[string]string{},
+				Success: true,
+			}
+			labels := destinationLabels(h.Config.MultiTo)
+			for _, dest := range h.Config.MultiTo {
+				if !facetChanged(ctx, dest.Facet) {
+					continue
+				}
+				ran[dest.Facet] = true
+				if failing[dest.Facet] {
+					report.Errors[labels[dest]] = "destination refused"
+					report.Success = false
+					continue
+				}
+				report.Results[labels[dest]] = "ok"
+			}
+			if len(report.Errors) > 0 && len(report.Results) == 0 {
+				return report, errors.New("all destination writes failed")
+			}
+			return report, nil
+		})
+
+	if _, isDrop := result.(*flow.FilteredResultWithPolicy); isDrop {
+		return ran, true
+	}
+	if err != nil && len(ran) == 0 {
+		t.Fatalf("dedupe failed before reaching any destination: %v", err)
+	}
+	return ran, false
+}
+
+func TestOnlyTheFacetsThatChangedAreWritten(t *testing.T) {
+	data, assets := twoDestinations()
+	h, cleanup := facetHandler(t, []*flow.ToConfig{data, assets})
+	defer cleanup()
+
+	// First message: nothing has been seen, so both parts are new.
+	ran, dropped := runFacets(t, h, "Widget", "img1.jpg", nil)
+	if dropped || !ran["data"] || !ran["assets"] {
+		t.Fatalf("first message: ran=%v dropped=%v, want both", ran, dropped)
+	}
+
+	// The same message again changes nothing, so it is dropped whole — the
+	// behaviour a bare fingerprint has always had.
+	ran, dropped = runFacets(t, h, "Widget", "img1.jpg", nil)
+	if !dropped || len(ran) != 0 {
+		t.Errorf("an unchanged message was not dropped: ran=%v dropped=%v", ran, dropped)
+	}
+
+	// Only the image changed: the expensive half runs and Magento is left
+	// alone. This is the whole point of the primitive.
+	ran, dropped = runFacets(t, h, "Widget", "img2.jpg", nil)
+	if dropped || ran["data"] || !ran["assets"] {
+		t.Errorf("image-only change: ran=%v dropped=%v, want assets only", ran, dropped)
+	}
+
+	// Only the name changed: no image work is queued at all.
+	ran, dropped = runFacets(t, h, "Gadget", "img2.jpg", nil)
+	if dropped || !ran["data"] || ran["assets"] {
+		t.Errorf("data-only change: ran=%v dropped=%v, want data only", ran, dropped)
+	}
+
+	// Both changed.
+	ran, dropped = runFacets(t, h, "Gizmo", "img3.jpg", nil)
+	if dropped || !ran["data"] || !ran["assets"] {
+		t.Errorf("both changed: ran=%v dropped=%v, want both", ran, dropped)
+	}
+}
+
+func TestAFacetIsCommittedOnlyWhenItsOwnDestinationsSucceeded(t *testing.T) {
+	data, assets := twoDestinations()
+	h, cleanup := facetHandler(t, []*flow.ToConfig{data, assets})
+	defer cleanup()
+
+	// The data lands and the asset enqueue fails — the broker is down, the
+	// queue is missing. Committing both here would lose the assets for as
+	// long as the entry lives, because the next identical message would find
+	// them unchanged and never send them again.
+	ran, _ := runFacets(t, h, "Widget", "img1.jpg", map[string]bool{"assets": true})
+	if !ran["data"] || !ran["assets"] {
+		t.Fatalf("both destinations should have been attempted: %v", ran)
+	}
+
+	// The retry: the same message, with the broker back. Data is not written
+	// a second time, and the assets are.
+	ran, dropped := runFacets(t, h, "Widget", "img1.jpg", nil)
+	if dropped {
+		t.Fatal("the retry was dropped as a duplicate, losing the assets for good")
+	}
+	if ran["data"] {
+		t.Error("the data was written a second time even though it had landed")
+	}
+	if !ran["assets"] {
+		t.Error("the assets were not re-sent, so the failed half was lost")
+	}
+
+	// And now that both have landed, an identical message is dropped.
+	_, dropped = runFacets(t, h, "Widget", "img1.jpg", nil)
+	if !dropped {
+		t.Error("a message identical to one fully applied was not dropped")
+	}
+}
+
+func TestCompareWhenRunsEveryFacet(t *testing.T) {
+	// compare_when says the stored fingerprints describe something that is no
+	// longer there. Comparing any facet against them could drop a message the
+	// downstream needs — an assets-only message against a record that no
+	// longer exists would never re-create it — so nothing is compared and
+	// every facet runs.
+	data, assets := twoDestinations()
+	h, cleanup := facetHandler(t, []*flow.ToConfig{data, assets})
+	defer cleanup()
+
+	if _, dropped := runFacets(t, h, "Widget", "img1.jpg", nil); dropped {
+		t.Fatal("the first message was dropped")
+	}
+
+	h.Config.Dedupe.CompareWhen = "false"
+	ran, dropped := runFacets(t, h, "Widget", "img1.jpg", nil)
+	if dropped {
+		t.Fatal("a message was dropped while compare_when said not to compare")
+	}
+	if !ran["data"] || !ran["assets"] {
+		t.Errorf("compare_when false must run every facet: %v", ran)
+	}
+}
+
+func TestADestinationWithNoFacetAlwaysRuns(t *testing.T) {
+	// Every flow written before facets is this flow: destinations that are not
+	// tied to any facet must keep running whenever the message is not dropped.
+	data, assets := twoDestinations()
+	audit := &flow.ToConfig{Connector: "audit"}
+	h, cleanup := facetHandler(t, []*flow.ToConfig{data, assets, audit})
+	defer cleanup()
+
+	if _, dropped := runFacets(t, h, "Widget", "img1.jpg", nil); dropped {
+		t.Fatal("the first message was dropped")
+	}
+
+	ran, dropped := runFacets(t, h, "Gadget", "img1.jpg", nil)
+	if dropped {
+		t.Fatal("a changed message was dropped")
+	}
+	if !ran[""] {
+		t.Error("a destination with no facet was skipped")
+	}
+	if ran["assets"] {
+		t.Error("an unchanged facet's destination ran")
+	}
+}
+
+// tallyWriter is a destination that records what it was asked to write.
+type tallyWriter struct {
+	name   string
+	writes int
+}
+
+func (c *tallyWriter) Name() string                  { return c.name }
+func (c *tallyWriter) Type() string                  { return "test" }
+func (c *tallyWriter) Connect(context.Context) error { return nil }
+func (c *tallyWriter) Close(context.Context) error   { return nil }
+func (c *tallyWriter) Health(context.Context) error  { return nil }
+func (c *tallyWriter) Write(_ context.Context, _ *connector.Data) (*connector.Result, error) {
+	c.writes++
+	return &connector.Result{Affected: 1}, nil
+}
+
+// A dedupe block on a flow with more than one destination was parsed,
+// validated and never consulted: handleMultiDestWrite did not call
+// dedupeAwareWrite at all. Three identical messages wrote three rows to every
+// destination while the configuration said they would be deduplicated.
+//
+// The test goes through handleMultiDestWrite rather than calling
+// dedupeAwareWrite directly, because the defect was the wiring between them —
+// every test that called the primitive itself passed throughout.
+func TestDedupeRunsOnAFlowWithSeveralDestinations(t *testing.T) {
+	memCache := memory.New("fp_cache", &types.Config{Driver: "memory"})
+	if err := memCache.Connect(context.Background()); err != nil {
+		t.Fatalf("cache connect: %v", err)
+	}
+	defer memCache.Close(context.Background())
+
+	mgr := msync.NewManager()
+	defer mgr.Close()
+
+	tr, err := transform.NewCELTransformer()
+	if err != nil {
+		t.Fatalf("transformer: %v", err)
+	}
+
+	first := &tallyWriter{name: "first"}
+	second := &tallyWriter{name: "second"}
+	registry := connector.NewRegistry()
+	registry.Replace("first", first)
+	registry.Replace("second", second)
+
+	h := &FlowHandler{
+		Config: &flow.Config{
+			Name: "two_destinations",
+			From: &flow.FromConfig{Connector: "rabbit"},
+			MultiTo: []*flow.ToConfig{
+				{Connector: "first"},
+				{Connector: "second"},
+			},
+			Transform: &flow.TransformConfig{Mappings: map[string]string{"name": "input.name"}},
+			Dedupe: &flow.DedupeConfig{
+				Cache:       "fp_cache",
+				Key:         "'sku:' + input.sku",
+				OnDuplicate: "ack",
+				TTL:         "1h",
+				Fingerprint: map[string]string{"name": "output.name"},
+			},
+		},
+		Connectors:  registry,
+		DedupeCache: memCache,
+		SyncManager: mgr,
+		Transformer: tr,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	input := map[string]interface{}{"sku": "S1", "name": "Widget"}
+	for i := 0; i < 3; i++ {
+		if _, err := h.handleMultiDestWrite(context.Background(), input, Operation{}); err != nil {
+			t.Fatalf("message %d: %v", i+1, err)
+		}
+	}
+
+	if first.writes != 1 || second.writes != 1 {
+		t.Errorf("three identical messages wrote %d and %d times; dedupe never ran",
+			first.writes, second.writes)
+	}
+}

--- a/internal/runtime/dedupe_integration_test.go
+++ b/internal/runtime/dedupe_integration_test.go
@@ -77,7 +77,7 @@ func TestDedupe_SameMessageTwiceIsDropped(t *testing.T) {
 	}
 
 	var calls int32
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		return &connector.Result{Affected: 1}, nil
 	}
@@ -135,7 +135,7 @@ func TestDedupe_DifferentContentBothPass(t *testing.T) {
 	}
 
 	var calls int32
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		return &connector.Result{Affected: 1}, nil
 	}
@@ -172,7 +172,7 @@ func TestDedupe_KeyOrderInsensitive(t *testing.T) {
 	}
 
 	var calls int32
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		return &connector.Result{Affected: 1}, nil
 	}
@@ -208,7 +208,7 @@ func TestDedupe_WriteFailureSkipsCommit(t *testing.T) {
 
 	var calls int32
 	failOnce := errors.New("simulated downstream error")
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		// Fail the first call, succeed on the retry.
 		if atomic.LoadInt32(&calls) == 1 {
@@ -269,7 +269,7 @@ func TestDedupe_ConcurrentSameFingerprint(t *testing.T) {
 	}
 
 	var calls int32
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		return &connector.Result{Affected: 1}, nil
 	}
@@ -316,7 +316,7 @@ func TestDedupe_ConcurrentDifferentKeysParallel(t *testing.T) {
 	}
 
 	var calls int32
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		return &connector.Result{Affected: 1}, nil
 	}
@@ -362,7 +362,7 @@ func TestDedupe_NoConfigZeroOverhead(t *testing.T) {
 	}
 
 	var calls int32
-	write := func() (interface{}, error) {
+	write := func(context.Context) (interface{}, error) {
 		atomic.AddInt32(&calls, 1)
 		return &connector.Result{Affected: 1}, nil
 	}
@@ -394,7 +394,7 @@ func TestDedupe_OnDuplicatePolicyPropagates(t *testing.T) {
 				"price":    1,
 				"websites": map[string]interface{}{"us": true},
 			}
-			write := func() (interface{}, error) {
+			write := func(context.Context) (interface{}, error) {
 				return &connector.Result{Affected: 1}, nil
 			}
 

--- a/internal/runtime/flow_registry.go
+++ b/internal/runtime/flow_registry.go
@@ -2711,7 +2711,7 @@ func (h *FlowHandler) handleCreate(ctx context.Context, input map[string]interfa
 		}, nil
 	}
 
-	writeResult, writeErr := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
+	writeResult, writeErr := h.dedupeAwareWrite(ctx, input, payload, func(ctx context.Context) (interface{}, error) {
 		return trace.RecordStage(ctx, trace.StageWrite, data.Target, trace.Snapshot(data.Payload), func() (interface{}, error) {
 			return meteredWrite(ctx, dest, data)
 		})
@@ -2871,7 +2871,7 @@ func (h *FlowHandler) handleUpdate(ctx context.Context, input map[string]interfa
 		}, nil
 	}
 
-	writeResult, err := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
+	writeResult, err := h.dedupeAwareWrite(ctx, input, payload, func(ctx context.Context) (interface{}, error) {
 		return meteredWrite(ctx, dest, data)
 	})
 	if err != nil {
@@ -3025,6 +3025,21 @@ func (h *FlowHandler) handleMultiDestWrite(ctx context.Context, input map[string
 	// Remove meta fields that should not be written to destination
 	delete(basePayload, "headers")
 
+	// Dedupe wraps the destinations here for the same reason it wraps a
+	// single one: it decides before the write and commits after it. Without
+	// this the block was parsed, validated and never consulted, so a flow
+	// with more than one destination had no deduplication at all — three
+	// identical messages wrote three rows to every destination while the
+	// configuration said otherwise.
+	return h.dedupeAwareWrite(ctx, input, basePayload, func(ctx context.Context) (interface{}, error) {
+		return h.writeToAllDestinations(ctx, input, basePayload, operation)
+	})
+}
+
+// writeToAllDestinations performs the writes themselves, reporting each
+// destination separately. It is what dedupe wraps, so the context it receives
+// is the one carrying the facets this message changed.
+func (h *FlowHandler) writeToAllDestinations(ctx context.Context, input, basePayload map[string]interface{}, operation Operation) (interface{}, error) {
 	// Determine which destinations should be written in parallel
 	var parallelDests []*flow.ToConfig
 	var sequentialDests []*flow.ToConfig
@@ -3125,6 +3140,18 @@ func destinationLabels(destinations []*flow.ToConfig) map[*flow.ToConfig]string 
 
 // writeToDestination writes data to a single destination.
 func (h *FlowHandler) writeToDestination(ctx context.Context, input, basePayload map[string]interface{}, destConfig *flow.ToConfig, operation Operation) (interface{}, error) {
+	// A destination tied to a dedupe facet runs only when that facet changed.
+	// One attribute does the gating and the commit accounting both, so the
+	// two cannot disagree: the same name decides whether this write happens
+	// and whether its facet is committed afterwards.
+	if !facetChanged(ctx, destConfig.Facet) {
+		return map[string]interface{}{
+			"skipped": true,
+			"reason":  "dedupe facet unchanged",
+			"facet":   destConfig.Facet,
+		}, nil
+	}
+
 	// Check when condition if specified
 	if destConfig.When != "" {
 		// `input` is the message as it arrived and `output` is what the

--- a/internal/runtime/transaction.go
+++ b/internal/runtime/transaction.go
@@ -65,7 +65,7 @@ func (h *FlowHandler) handleTransaction(ctx context.Context, input map[string]in
 	captured := map[string]interface{}{}
 	var affected int64
 
-	writeResult, writeErr := h.dedupeAwareWrite(ctx, input, payload, func() (interface{}, error) {
+	writeResult, writeErr := h.dedupeAwareWrite(ctx, input, payload, func(ctx context.Context) (interface{}, error) {
 		return trace.RecordStage(ctx, trace.StageWrite, h.Config.To.Connector, trace.Snapshot(payload), func() (interface{}, error) {
 			runErr := runner.RunInTx(ctx, func(ops connector.TxOps) error {
 				txCtx, txSpan := tracing.StartSpan(ctx, "transaction")

--- a/internal/runtime/validate_all.go
+++ b/internal/runtime/validate_all.go
@@ -52,6 +52,10 @@ func Checks(config *parser.Configuration, reg *schema.Registry) []Check {
 		// A validator a type names but nothing declares is not a failure at
 		// run time: the rule is skipped, so the field goes unvalidated.
 		{"validator reference", ValidateValidatorReferences(config)},
+		// A destination naming a facet nobody declared is skipped on every
+		// message; a facet no destination names can never be committed, so it
+		// reads as changed for ever and no duplicate is ever dropped.
+		{"dedupe facet", ValidateDedupeFacets(config)},
 		// Names repeated inside a flow, where something is keyed by them: the
 		// second silently overwrites the first.
 		{"duplicate name", ValidateUniqueInnerNames(config)},

--- a/internal/runtime/validate_all_test.go
+++ b/internal/runtime/validate_all_test.go
@@ -36,8 +36,8 @@ func TestValidateAndStartRunTheSameChecks(t *testing.T) {
 
 	// The count is written down so that adding a check without a thought about
 	// this test is a failure rather than a silent pass.
-	if len(kinds) != 10 {
-		t.Errorf("%d checks, and this test knows about 10 — add the new one to "+
+	if len(kinds) != 11 {
+		t.Errorf("%d checks, and this test knows about 11 — add the new one to "+
 			"the list in validate_all.go and update this number", len(kinds))
 	}
 }

--- a/internal/runtime/validate_dedupe_facets.go
+++ b/internal/runtime/validate_dedupe_facets.go
@@ -1,0 +1,103 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/matutetandil/mycel/v3/internal/flow"
+	"github.com/matutetandil/mycel/v3/internal/parser"
+)
+
+// ValidateDedupeFacets checks that facets and the destinations naming them
+// agree.
+//
+// Both mistakes it catches are the same shape: something written in the
+// configuration that reads as if it were doing work and is not. A `to` naming
+// a facet nobody declared would never run, because the set of changed facets
+// can never contain a name that does not exist — the destination is skipped on
+// every message, silently, for as long as the flow is deployed. A facet no
+// destination names can never be committed, because commit is per facet and
+// there is nothing to attribute success to — so it reads as changed for ever
+// and the message is never dropped, which quietly disables deduplication.
+//
+// Neither fails at run time. Both would look like a flow that works.
+func ValidateDedupeFacets(config *parser.Configuration) []error {
+	if config == nil {
+		return nil
+	}
+
+	var errs []error
+	for _, f := range config.Flows {
+		if f == nil || f.Dedupe == nil || len(f.Dedupe.Facets) == 0 {
+			continue
+		}
+
+		declared := make(map[string]bool, len(f.Dedupe.Facets))
+		for _, facet := range f.Dedupe.Facets {
+			declared[facet.Name] = true
+		}
+
+		named := make(map[string]bool, len(declared))
+		for _, dest := range destinationsOf(f) {
+			if dest.Facet == "" {
+				continue
+			}
+			if !declared[dest.Facet] {
+				errs = append(errs, fmt.Errorf(
+					"flow %q: a destination names facet %q, which the dedupe block does not declare — "+
+						"it would be skipped on every message. Declared: %s",
+					f.Name, dest.Facet, listOf(declared)))
+				continue
+			}
+			named[dest.Facet] = true
+		}
+
+		for _, facet := range f.Dedupe.Facets {
+			if !named[facet.Name] {
+				errs = append(errs, fmt.Errorf(
+					"flow %q: dedupe declares facet %q and no destination names it — "+
+						"nothing could commit it, so it would read as changed for ever and the flow would never "+
+						"drop a duplicate. Add `facet = %q` to the destination it belongs to",
+					f.Name, facet.Name, facet.Name))
+			}
+		}
+	}
+	return errs
+}
+
+// destinationsOf returns a flow's destinations whichever way it declares them.
+func destinationsOf(f *flow.Config) []*flow.ToConfig {
+	if len(f.MultiTo) > 0 {
+		return f.MultiTo
+	}
+	if f.To != nil {
+		return []*flow.ToConfig{f.To}
+	}
+	return nil
+}
+
+func listOf(names map[string]bool) string {
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, fmt.Sprintf("%q", name))
+	}
+	sort.Strings(out)
+	if len(out) == 0 {
+		return "none"
+	}
+	return joinWithCommas(out)
+}
+
+func joinWithCommas(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += ", " + p
+	}
+	return out
+}

--- a/pkg/schema/builtins.go
+++ b/pkg/schema/builtins.go
@@ -105,6 +105,7 @@ func ToSchema() Block {
 			{Name: "when", Doc: "CEL condition for conditional write", Type: TypeString},
 			{Name: "parallel", Doc: "Write in parallel with other destinations", Type: TypeBool},
 			{Name: "envelope", Doc: "Wrap the outgoing payload under a single root key (Magento webapi / Spring @RequestBody / SOAP-style REST)", Type: TypeString},
+			{Name: "facet", Doc: "Dedupe facet this destination satisfies. Skipped when that facet did not change; the facet is committed only once every destination naming it succeeded. Omit for a destination that always runs", Type: TypeString},
 			{Name: "query", Doc: "SQL query for database writes", Type: TypeString},
 			{Name: "format", Doc: "Output format", Type: TypeString, Values: []string{"json", "xml", "csv", "tsv"}},
 			{Name: "filter", Doc: "Per-user filter (WebSocket, SSE, subscriptions)", Type: TypeString},
@@ -441,6 +442,20 @@ func DedupeSchema() Block {
 				Doc:   "Named CEL expressions whose values form the projection. Must list every field the flow persists downstream — omitting one would silently drop real changes. Both input.* and output.* (transform result) are in scope.",
 				Open:  true,
 				Attrs: []Attr{},
+			},
+			{
+				Type:   "facet",
+				Labels: 1,
+				Doc:    "An independently-tracked part of the projection, named by its label. Each facet is fingerprinted, stored and committed on its own; a `to` naming it runs only when it changed, and the message is dropped only when no facet did. Use instead of a bare fingerprint, not alongside it. Mycel does not check that facets are independent — two whose destinations write the same thing will race.",
+				Attrs:  []Attr{},
+				Children: []Block{
+					{
+						Type:  "fingerprint",
+						Doc:   "The facet's projection, in the same form and scope as the dedupe-level fingerprint block.",
+						Open:  true,
+						Attrs: []Attr{},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Two things, and the second matters whether or not you use the first.

## Added: `facet` blocks in `dedupe`

A fingerprint answers one question — did anything change — and its only verb is to drop the message. That is the right shape while every part of a message costs about the same to apply, and the wrong one when it does not.

A product message carries its data and its images together. The data is a handful of columns; the images are URLs the downstream goes and fetches, which is minutes of work. With one fingerprint, a message whose *name* changed re-sends the images too — and anything waiting on that product waits for them to finish.

```hcl
dedupe {
  cache        = "fp_cache"
  key          = "'item_fp:' + input.body.sku"
  on_duplicate = "ack"                # applies when no facet changed

  facet "data"   { fingerprint { name = "output.name"  price = "output.price" } }
  facet "assets" { fingerprint { main_image = "output.main_image" } }
}

to { facet = "data"    connector = "catalog"    target = "catalog_items" }
to { facet = "assets"  connector = "asset_jobs" target = "item.assets.q" }
```

| The message changes | data destination | assets destination |
|---------------------|------------------|--------------------|
| Nothing | — | — (dropped) |
| The name only | writes | — |
| An image only | — | publishes |
| Both | writes | publishes |

**One attribute does the gating and the accounting both**, which is why it is `facet` on the destination rather than a `when` plus some bookkeeping: the same name decides whether the write happens and whether its facet is committed.

**Commit is per facet, and that is the point.** A facet is committed only once every destination naming it has succeeded. If the catalogue write lands and the queue publish fails, only the data facet is committed: the retry finds the data unchanged, does not write it a second time, and publishes the assets. Committing them together would lose the images for the life of the entry — the failure the two-phase commit exists to prevent, one level down.

**What a facet's success means** is its `to` succeeding and nothing more. For a queue that is the broker accepting the message, not the other consumer finishing the work — there is no callback and Mycel does not ask. Past the handoff it is the second consumer's retries, its dead-letter queue and its own dedupe.

Details that took a decision rather than a default:

- A `to` **without** `facet` runs whenever the message is not dropped, so nothing changes for flows that do not use facets.
- Each facet is stored under its own key (`dedupe:<flow>:<key>:<facet>`), so fingerprints already in Redis are untouched and **there is no migration**. A facet never seen reads as changed, so adding one re-runs its destinations once per key — a backfill, worth planning the rollout around.
- `compare_when` stays a single flow-level gate. False means nothing is compared and **every** facet runs, which is what a missing downstream record needs: an assets-only message against a record that no longer exists would otherwise never re-create it.
- A bare `fingerprint {}` and `facet` blocks together are refused rather than resolved — honouring both would mean deciding which one drops the message.
- `mycel validate` refuses a `to` naming a facet nobody declared, and a facet no destination names. Both are silent otherwise: the first is skipped on every message, and the second can never be committed, so it reads as changed for ever and **deduplication stops working for the whole flow**.
- Mycel does not check that facets are independent. Two whose destinations write the same record will race and nothing will report it; the documentation says so where someone will read it.

## Fixed: dedupe was inert on any flow with more than one destination

`handleMultiDestWrite` never called `dedupeAwareWrite`, so a `dedupe` block on a flow with several destinations was parsed, validated and never consulted. Three identical messages wrote three rows to every destination while the configuration said they would be dropped.

Verified against the **released 3.5.0 binary** before the fix:

```
v3.5.0 published:  a=3, b=3     ← should be 1 and 1
with the fix:      a=1, b=1
```

Flows with a single `to` were unaffected throughout, and so was every test that called the primitive directly — which is why it went unnoticed. The new test goes through `handleMultiDestWrite` precisely because the defect was the wiring between the two.

This was also a blocker for facets, which live on having several destinations.

## Also fixed: the example-coverage test walked only one level

It checked the direct children of a flow, so a block declared two levels down was invisible to it and `dedupe > facet` would have gone unexampled without complaint. Walking the tree turned up that **`coordinate > preflight` had never appeared in an example either**; it now does, in the sync example, where it answers the question a signal's TTL cannot. The label pattern also had to accept the bare middle label of `each "item" in "..."`, which it was reporting missing from the examples that use it — a false alarm is how a coverage test stops being read.

## Verification

- Every test run against the code without the change before being kept. The per-facet commit test fails against a naive "commit every changed facet" with *"the retry was dropped as a duplicate, losing the assets for good"*, which is the exact failure it exists to prevent.
- The five facet cases exercised end to end against a running service, not only in unit tests.
- Backward compatibility checked on the two paths this touches: a multi-destination flow **without** dedupe behaves exactly as before, and a `dedupe` with no facets takes the same code path with the same key and the same bytes.
- Unit suite, `vet`, `gofmt` clean; `-race` clean on the packages touched. 65 example directories validate. `mkdocs build --strict` with no warnings. Integration via `run.sh`: **216 passed, 0 failed**.
