### PR TITLE
Release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.6.0] - 2026-09-02
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.5.0"
+	version = "3.6.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.6.0. Two files, two lines: the `[Unreleased]` heading becomes `[3.6.0] - 2026-09-02`, and the version constant in `cmd/mycel/main.go`.

## What is in the release

From #92.

**Added — `facet` blocks in `dedupe`.** One message can be split into parts that are fingerprinted, gated and committed independently, so a change to a product's name no longer re-sends its images. A `to` naming a facet runs only when that facet changed; the message is dropped only when none did. Commit is per facet, which is the part that earns the machinery: when the data lands and the queue publish fails, the retry re-sends only what did not land.

**Fixed — dedupe was inert on any flow with more than one destination.** `handleMultiDestWrite` never called `dedupeAwareWrite`, so a `dedupe` block on such a flow was parsed, validated and never consulted: three identical messages wrote three rows to every destination. Flows with a single `to` were unaffected. This matters whether or not you use facets.

**Fixed — the example-coverage test walked only one level**, so a block declared two levels down could go unexampled without complaint. Walking the tree turned up that `coordinate > preflight` had never appeared in an example.

## Why 3.6.0

Additive. The new block is opt-in, a `dedupe` without facets takes the same code path with the same key and the same bytes, and a multi-destination flow without a `dedupe` block behaves exactly as before — both checked against a running service.

The fix does change behaviour for one shape: a flow with several destinations **and** a `dedupe` block now deduplicates, where before it did not. That is the block doing what it says, and there is nothing to read before upgrading, so the release notes will carry the generic line rather than a Breaking or Security section.

## Verification

- `go.mod` still declares `go 1.25.0` and both Dockerfiles still pin `golang:1.25-alpine`; `go mod tidy` changes neither `go.mod` nor `go.sum`.
- The compiled binary reports `mycel 3.6.0` — the Dockerfile builds without `-X main.version`, so the image reports whatever this constant says.
- The release job's extraction was run against the edited `CHANGELOG.md`: it finds the `3.6.0` section.
- Unit suite, `vet`, `gofmt` clean. 65 example directories validate. `main` was green on the merge, and #92's integration ran on the merge result: **196 passed, 0 failed** in CI, **216 passed, 0 failed** locally.
