### PR TITLE
Bump grpc to 1.83.1 for CVE-2026-84304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **`google.golang.org/grpc` 1.82.1 → 1.83.1, for CVE-2026-84304 (HIGH).** Published after 3.6.0 shipped, so 3.5.0 and 3.6.0 both carry it — the image scanned clean at release and stopped being clean without anything changing on our side. Nothing else moved with it: `cel-go` stays at 0.29.0, so the CEL engine behind every transform, filter and fingerprint is byte-identical, and the `go` directive stays at 1.25.0, which is what a grpc bump has silently raised before now.
+
+  Verified against an image built with `--no-cache --pull`: `alpine` 0 and `gobinary` 0, all severities. (A cached build reports the system packages from whenever its `apk upgrade` layer was built, not from today — which is why a local scan can look worse than the published image.)
+
 ## [3.6.0] - 2026-09-02
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -54,14 +54,14 @@ require (
 	golang.org/x/mod v0.40.0
 	golang.org/x/net v0.58.0
 	golang.org/x/time v0.14.0
-	google.golang.org/grpc v1.82.1
+	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.42.2
 )
 
 require (
-	cel.dev/expr v0.25.1 // indirect
+	cel.dev/expr v0.25.2 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
-cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+cel.dev/expr v0.25.2 h1:K6j46C81hXtZQfuX60cVWQFBJahKSE2gfRbNuvr5bFs=
+cel.dev/expr v0.25.2/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
@@ -331,8 +331,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
`google.golang.org/grpc` 1.82.1 → 1.83.1, for **CVE-2026-84304** (HIGH).

## Where it came from

Artifact Hub marked 3.6.0 red. The finding is not new work of ours: the CVE was published **after** 3.6.0 shipped, and scanning both published images shows **3.5.0 carries it too**. Both scanned clean at release and stopped being clean with nothing changing on our side; Artifact Hub re-scans periodically, which is where it surfaced.

The rest of the report is unchanged: `alpine` clean, and the one `unknown` is the standing noise from `golang.org/x/crypto/openpgp` — no fix available and not reachable (`go mod why` confirms the main module does not need the package).

## What moved, and what deliberately did not

Only grpc and `cel.dev/expr`, a transitive dependency, which took a patch.

- **`cel-go` stays at 0.29.0.** It is the engine behind every transform, filter and dedupe fingerprint, and a bump there earns an A/B comparison of built binaries rather than trust in the unit suite. It did not move, so that is not owed here.
- **The `go` directive stays at 1.25.0.** A grpc bump is exactly what raised it silently once before, and the Dockerfiles pin `golang:1.25-alpine` — the combination is what broke the v2.10.0 release.

## Verification

Scanned an image built with `--no-cache --pull`:

```
alpine 3.24.1   0
app/mycel       0        ← was 1 HIGH
```

Clean at every severity, both targets.

Worth recording for the next time someone scans locally: a **cached** build reports the system packages from whenever its `apk upgrade` layer was built, not from today. The first local scan here showed 33 alpine findings that were entirely an artifact of layer caching — CI never sees them because the runner starts cold. Scan the published image, or build with `--no-cache --pull`.

Unit suite, `vet`, `gofmt` clean.
