### PR TITLE
Say how parallel and sequential destinations order against each other

### DIFF
--- a/docs/core-concepts/flows.md
+++ b/docs/core-concepts/flows.md
@@ -427,6 +427,27 @@ flow "create_order" {
 
 By default, multiple `to` blocks execute in parallel. Set `parallel = false` on a `to` block to force sequential execution.
 
+**Order, when the two are mixed.** The destinations are split into two groups, and the groups do not interleave: **every parallel destination runs first**, concurrently, and all of them finish before the first sequential one starts. The sequential ones then run one at a time, in the order they are declared.
+
+The consequence is worth stating plainly, because it is not what the file looks like: **declaration order does not decide execution order unless every destination agrees on `parallel`.** A destination written first with `parallel = false` runs *after* one written below it that left the attribute out.
+
+```hcl
+to {                          # declared first, but sequential
+  connector = "audit"
+  parallel  = false
+}
+
+to {                          # declared second, parallel by default
+  connector = "warehouse"
+}
+
+# Runs: warehouse, then audit.
+```
+
+If one destination has to observe what another wrote, mark **both** `parallel = false` and declare them in the order you need. Marking only the later one is the mistake this ordering invites: it still runs last, but only by accident of there being nothing else in its group.
+
+Parallel destinations have no order among themselves. Each is reported separately, so one failing does not hide another's result, and a flow fails only if every destination failed.
+
 ### Source Fan-Out (Multiple Flows from Same Source)
 
 Multiple flows can share the same `from` connector and operation. When a request or message arrives, **all registered flows execute concurrently**:

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -415,14 +415,12 @@ to {
   facet     = "data"                # skipped when the data facet is unchanged
   connector = "catalog"
   target    = "catalog_items"
-  parallel  = true
 }
 
 to {
   facet     = "assets"              # skipped when the assets facet is unchanged
   connector = "asset_jobs"          # a queue a second consumer reads
   target    = "item.assets.q"
-  parallel  = true
 }
 ```
 

--- a/examples/dedupe/item_update_split_by_facet.mycel
+++ b/examples/dedupe/item_update_split_by_facet.mycel
@@ -66,7 +66,6 @@ flow "item_update_split" {
     facet     = "data"
     connector = "catalog"
     target    = "catalog_items"
-    parallel  = true
   }
 
   // Runs only when the assets facet changed. What is committed here is the
@@ -84,6 +83,5 @@ flow "item_update_split" {
     facet     = "assets"
     connector = "asset_jobs"
     target    = "item.assets.q"
-    parallel  = true
   }
 }


### PR DESCRIPTION
Answers a question that came out of reading the new facet documentation: `parallel` appears in the examples and nothing says how it orders destinations against each other.

The default (`true`) was already documented in `flows.md` and the configuration reference. What was not documented is the half that surprises.

## What the ordering actually is

Verified against a running service rather than read off the code:

```hcl
to {                          # declared first, but sequential
  connector = "audit"
  parallel  = false
}

to {                          # declared second, parallel by default
  connector = "warehouse"
}
```

Runs **warehouse, then audit**.

The destinations are split into two groups that do not interleave: every parallel destination runs first, concurrently, and all of them finish before the first sequential one starts. The sequential ones then run one at a time in declaration order.

So **declaration order does not decide execution order unless every destination agrees on `parallel`** — and marking only the later of two destinations `parallel = false` still leaves it last by accident of there being nothing else in its group, which is the mistake this invites.

## Also

Drops `parallel = true` from the facet example and its documentation. It is the default, so writing it suggested it was part of declaring a facet — which is what prompted the question in the first place.

Doc-only; no runtime change.
