### PR TITLE
Release 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.6.1] - 2026-09-02
 
 ### Security
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.6.0"
+	version = "3.6.1"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump for 3.6.1. Two files, two lines.

## What is in the release

A security patch and a documentation clarification.

**Security (#94)** — `google.golang.org/grpc` 1.82.1 → 1.83.1 for **CVE-2026-84304** (HIGH). The CVE was published after 3.6.0 shipped, so **3.5.0 and 3.6.0 both carry it**: both scanned clean at release and stopped being clean with nothing changing here. Anyone running either should take this one.

Nothing else moved. `cel-go` stays at 0.29.0, so the engine behind every transform, filter and fingerprint is untouched; the `go` directive stays at 1.25.0, which is what a grpc bump has silently raised before against pinned Dockerfiles.

**Docs (#95)** — how `parallel` orders destinations against each other. The default was documented; the ordering was not, and it is the half that surprises: parallel destinations all run before any sequential one, so declaration order does not decide execution order unless every destination agrees on the attribute.

## Verification

- An image built with `--no-cache --pull` scans clean at every severity: `alpine` 0, `gobinary` 0 — the finding was 1 HIGH before.
- `go mod tidy` changes neither `go.mod` nor `go.sum`; the `go` directive still matches `golang:1.25-alpine` in both Dockerfiles.
- The compiled binary reports `mycel 3.6.1`.
- The release job's extraction was run against the edited `CHANGELOG.md`: it finds the `3.6.1` section and lifts `Security`, so the notes open with the CVE rather than the generic line.
- Unit suite, `vet`, `gofmt` clean. Both merged PRs were green on all four checks, #95 re-verified after being brought up to date with the security fix.
