### PR TITLE
Release 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.6.2] - 2026-09-04
 
 ### Fixed
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.6.1"
+	version = "3.6.2"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version bump to 3.6.2. Four fixes from #101, all in the CHANGELOG under `[3.6.2]`: a `use`-only transform honoured in flows with steps (#97), the REST connector decoding a `DELETE` body (#98), `??` no longer swallowing a map-literal key (#99), and the caching guide's cache keys corrected plus a validate check that refuses a key written as CEL (#100).

No `Breaking` or `Security` section, so the release notes carry the generic line. `go` directive 1.25.0 matches `golang:1.25-alpine` in both Dockerfiles.