### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.0] - 2026-09-07
 
 ### Added
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.6.2"
+	version = "3.7.0"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version constant and the CHANGELOG heading for 3.7.0.

The release itself is the annotated tag; this is what the tag needs to be sitting on. Contents in [CHANGELOG.md](https://github.com/matutetandil/mycel/blob/main/CHANGELOG.md): per-request `headers` on steps, destinations, enrichments and saga / state machine actions; `key_from` on a cache block; GraphQL answers fitted to the field's declared type; `#` comments dropped before the SDL lexer; the editor running `runtime.Checks`; and integers past 2^53 surviving the cache.

Issues #103 #104 #105 #106 #107 #108 #109 — closed by hand after the release is verified.