### PR TITLE
Release 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.1] - 2026-09-08
 
 ### Security
 

--- a/cmd/mycel/main.go
+++ b/cmd/mycel/main.go
@@ -36,7 +36,7 @@ var (
 	// buildInfo() overrides both of these when the binary carries real build
 	// metadata, which it does for `go install` (module version) and for any
 	// build from a git checkout (VCS revision).
-	version = "3.7.0"
+	version = "3.7.1"
 	commit  = "dev"
 )
 


### PR DESCRIPTION
Version constant and the CHANGELOG heading for 3.7.1.

A security release: `amqp091-go` for CVE-2026-79921, the patch-level dependency updates around it, dependency scanning on every pull request, the versioning and testing pages, and the step-skipping fix for a list-typed GraphQL field.

It is a patch by the policy this release publishes: nothing changes what a configuration that works today means. The two behaviour changes — steps that used to be skipped now run, and a header that used to be dropped is now sent — are fixes for things that were silently wrong, which [Versioning and Support](docs/versioning.md) puts in a patch by name.

Issue #112 — closed by hand after the release is verified.